### PR TITLE
[Feat] 공통 응답 & 전역 예외 처리

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ out/
 !**/src/test/**/out/
 
 ### Eclipse ###
+*.env
 .apt_generated
 .classpath
 .factorypath

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
+  <component name="FrameworkDetectionExcludesConfiguration">
+    <file type="web" url="file://$PROJECT_DIR$" />
+  </component>
   <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,6 +21,9 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
     implementation("org.springframework.boot:spring-boot-starter-security")
 
+    // Validation
+    implementation("org.springframework.boot:spring-boot-starter-validation:3.5.4")
+
     compileOnly("org.projectlombok:lombok")
     annotationProcessor("org.projectlombok:lombok")
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,6 +24,14 @@ dependencies {
     // Validation
     implementation("org.springframework.boot:spring-boot-starter-validation:3.5.4")
 
+    // Data Jpa
+    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+
+    // MySQL
+    runtimeOnly("com.mysql:mysql-connector-j")
+
+
+
     compileOnly("org.projectlombok:lombok")
     annotationProcessor("org.projectlombok:lombok")
 

--- a/src/main/java/com/tavemakers/surf/SurfApplication.java
+++ b/src/main/java/com/tavemakers/surf/SurfApplication.java
@@ -2,7 +2,9 @@ package com.tavemakers.surf;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class SurfApplication {
     public static void main(String[] args) {

--- a/src/main/java/com/tavemakers/surf/global/common/advice/GlobalExceptionHandler.java
+++ b/src/main/java/com/tavemakers/surf/global/common/advice/GlobalExceptionHandler.java
@@ -75,7 +75,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
         ErrorCode errorCode = INTERNAL_SERVER_ERROR;
-        logWarning(e, errorCode.getStatus().value());
+        logError(e, errorCode.getStatus().value());
         return responseException(errorCode.getStatus(), e.getMessage(), null);
     }
 
@@ -90,6 +90,11 @@ public class GlobalExceptionHandler {
     private void logWarning(Exception e, int errorCode) {
         log.warn(e.getMessage(), e);
         log.warn(LOG_FORMAT, e.getClass().getSimpleName(), errorCode, e.getMessage());
+    }
+
+    private void logError(Exception e, int errorCode) {
+        log.error(e.getMessage(), e);
+        log.error(LOG_FORMAT, e.getClass().getSimpleName(), errorCode, e.getMessage());
     }
 
 }

--- a/src/main/java/com/tavemakers/surf/global/common/advice/GlobalExceptionHandler.java
+++ b/src/main/java/com/tavemakers/surf/global/common/advice/GlobalExceptionHandler.java
@@ -1,0 +1,95 @@
+package com.tavemakers.surf.global.common.advice;
+
+import com.tavemakers.surf.global.common.exception.BaseException;
+import com.tavemakers.surf.global.common.exception.ErrorCode;
+import com.tavemakers.surf.global.common.exception.ErrorDetail;
+import com.tavemakers.surf.global.common.response.ApiResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
+
+import java.util.List;
+
+import static com.tavemakers.surf.global.common.exception.ErrorCode.*;
+
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    private static final String LOG_FORMAT = "Class : {}, Code : {}, Message : {}";
+
+    @ExceptionHandler(BaseException.class)
+    public ResponseEntity<ApiResponse<Void>> handleBaseException(BaseException e) {
+        logWarning(e, e.getStatus().value());
+        return responseException(e.getStatus(), e.getMessage(), null);
+    }
+
+    // Request Parameter 누락
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<ApiResponse<Void>> handleMissingServletRequestParameterException(MissingServletRequestParameterException e) {
+        ErrorCode errorCode = PARAMETER_NOT_FOUND;
+        logWarning(e, HttpStatus.BAD_REQUEST.value());
+        return responseException(errorCode.getStatus(), errorCode.getMessage(), null);
+    }
+
+    // JSON 형식이 어긋난 경우 (유실, 형식X etc...)
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ApiResponse<Void>> handleHttpMessageNotReadableException(HttpMessageNotReadableException e) {
+        logWarning(e, HttpStatus.BAD_REQUEST.value());
+        return responseException(HttpStatus.BAD_REQUEST, e.getMessage(), null);
+    }
+
+    // @Valid 유효성 검증 예외
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse<List<ErrorDetail>>> handleMethodArgumentValidation(MethodArgumentNotValidException e) {
+        ErrorCode errorCode = METHOD_ARGUMENT_NOT_VALID;
+
+        List<ErrorDetail> errors = e.getBindingResult()
+                .getFieldErrors().stream()
+                .map(fe -> ErrorDetail.of(
+                        fe.getField(),
+                        fe.getDefaultMessage(),
+                        fe.getRejectedValue()
+                ))
+                .toList();
+
+        logWarning(e, errorCode.getStatus().value());
+        return responseException(errorCode.getStatus(), errorCode.getMessage(), errors);
+    }
+
+    // No Resource Error
+    @ExceptionHandler(NoResourceFoundException.class)
+    public ResponseEntity<ApiResponse<Void>> handleNoResourceFound(NoResourceFoundException e) {
+        ErrorCode errorCode = RESOURCE_NOT_FOUND;
+        logWarning(e, errorCode.getStatus().value());
+        return responseException(errorCode.getStatus(), errorCode.getMessage(), null);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
+        ErrorCode errorCode = INTERNAL_SERVER_ERROR;
+        logWarning(e, errorCode.getStatus().value());
+        return responseException(errorCode.getStatus(), e.getMessage(), null);
+    }
+
+    private <T> ResponseEntity<ApiResponse<T>> responseException(HttpStatus status, String message, T data ) {
+        ApiResponse<T> response = ApiResponse.response(status, message, data);
+
+        return ResponseEntity
+                .status(status)
+                .body(response);
+    }
+
+    private void logWarning(Exception e, int errorCode) {
+        log.warn(e.getMessage(), e);
+        log.warn(LOG_FORMAT, e.getClass().getSimpleName(), errorCode, e.getMessage());
+    }
+
+}

--- a/src/main/java/com/tavemakers/surf/global/common/entity/BaseEntity.java
+++ b/src/main/java/com/tavemakers/surf/global/common/entity/BaseEntity.java
@@ -1,0 +1,35 @@
+package com.tavemakers.surf.global.common.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+/*
+* NOTE
+* BaseEntity isDeleted 추가할 지?
+* */
+
+@Getter
+@SuperBuilder
+@MappedSuperclass
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class BaseEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+}

--- a/src/main/java/com/tavemakers/surf/global/common/exception/BaseException.java
+++ b/src/main/java/com/tavemakers/surf/global/common/exception/BaseException.java
@@ -1,0 +1,22 @@
+package com.tavemakers.surf.global.common.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+/*
+* NOTE
+* 커스텀 예외를 위한 추상 클래스 명을
+* BaseException, BusinessException, etc... 의논하면 좋을 듯.
+* */
+
+@Getter
+public abstract class BaseException extends RuntimeException {
+
+    private final HttpStatus status;
+
+    public BaseException(final HttpStatus status, final String message) {
+        super(message);
+        this.status = status;
+    }
+
+}

--- a/src/main/java/com/tavemakers/surf/global/common/exception/ErrorCode.java
+++ b/src/main/java/com/tavemakers/surf/global/common/exception/ErrorCode.java
@@ -1,0 +1,22 @@
+package com.tavemakers.surf.global.common.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+
+    // 4XX Errors
+    METHOD_ARGUMENT_NOT_VALID(HttpStatus.BAD_REQUEST, "잘못된 [인자]입니다."),
+    RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "요청한 [RESOURCE, URL]를 찾을 수 없습니다."),
+    PARAMETER_NOT_FOUND(HttpStatus.BAD_REQUEST, "요청에 [Parameter]가 존재하지 않습니다."),
+
+    // 5XX Errors
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "[Server] 내부 에러가 발생했습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+
+}

--- a/src/main/java/com/tavemakers/surf/global/common/exception/ErrorDetail.java
+++ b/src/main/java/com/tavemakers/surf/global/common/exception/ErrorDetail.java
@@ -1,0 +1,18 @@
+package com.tavemakers.surf.global.common.exception;
+
+import lombok.Builder;
+
+@Builder
+public record ErrorDetail(
+        String errorField,
+        String errorMessage,
+        Object inputValue
+) {
+    public static ErrorDetail of(String errorField, String errorMessage, Object inputValue) {
+        return ErrorDetail.builder()
+                .errorField(errorField)
+                .errorMessage(errorMessage)
+                .inputValue(inputValue)
+                .build();
+    }
+}

--- a/src/main/java/com/tavemakers/surf/global/common/response/ApiResponse.java
+++ b/src/main/java/com/tavemakers/surf/global/common/response/ApiResponse.java
@@ -1,0 +1,29 @@
+package com.tavemakers.surf.global.common.response;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import org.springframework.http.HttpStatus;
+
+@Builder(access = AccessLevel.PRIVATE)
+public record ApiResponse<T>(
+        int code,
+        String message,
+        T data
+) {
+
+    public static <T> ApiResponse<T> response(HttpStatus httpStatus, String message, T data) {
+        return ApiResponse.<T>builder()
+                .code(httpStatus.value())
+                .message(message)
+                .data(data)
+                .build();
+    }
+
+    public static <T> ApiResponse<T> response(HttpStatus httpStatus, String message) {
+        return ApiResponse.<T>builder()
+                .code(httpStatus.value())
+                .message(message)
+                .build();
+    }
+
+}

--- a/src/main/resources/application-example.properties
+++ b/src/main/resources/application-example.properties
@@ -1,8 +1,0 @@
-server.port=8080
-
-# Kakao OAuth (replace with your real keys)
-kakao.client-id=YOUR_CLIENT_ID
-kakao.client-secret=YOUR_CLIENT_SECRET
-kakao.redirect-uri=http://localhost:8080/login/oauth2/code/kakao
-kakao.token-uri=https://kauth.kakao.com/oauth/token
-kakao.userinfo-uri=https://kapi.kakao.com/v2/user/me

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,19 @@
+spring:
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: ${DB_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQLDialect
+
+kakao:
+  client-id: ${KAKAO_CLIENT_ID}
+  client-secret: ${KAKAO_CLIENT_SECRET}
+  redirect-uri: ${KAKAO_REDIRECT_URI}
+  token-uri: ${KAKAO_TOKEN_URI}
+  userinfo-uri: ${KAKAO_USER_INFO}


### PR DESCRIPTION
## 📄 작업 내용 요약

- [x] ApiResponse 공통 응답 객체 추가 
- [x] GlobalExceptionHandler 전역 예외 처리
- [x] BaseEntity 추가

## 📎 Issue 번호
closed #3 

## 설명

### ApiResponse

공통 응답을 사용하는 이유는 프론트엔드에게 일관된 형식으로 데이터를 응답하기 위함입니다.
API에 응답한다는 의미로 `ApiResponse`로 클래스명을 지었습니다.

```java
    @GetMapping("/test")
    public ApiResponse<SomethingDto> test() {
        
        SomethingDto data = service.doSomething();

        return ApiResponse.response(HttpStatus.OK, "Success Message", data);
    }
```

위와 같은 형식으로 사용하면 됩니다!
만약 data가 없는 API는 그냥 매개 인자를 두개만 사용하시면 됩니다. (오버로딩)

<hr>

### GlobalExceptionHandler

1. `@ExceptionHandler`는 @Controller가 적용된 Bean에서 발생하는 예외를 잡아 처리하는 기능
2. `@ControllerAdvice`는 @Controller 어노테이션이 적용된 모든 곳에서의 발생되는 예외를 잡아 처리
-> 그러므로 @ControllerAdvice가 적용된 클래스(GlobalExceptionHandler)에 정의되어있는 `@ExceptionHandler`는 모든 컨트롤러에서 발생하는 예외를 잡아 처리함.

<hr>

### BaseEntity 

실제 프로젝트 중에는 데이터가 언제 생성되고 언제 수정됐는 지 알아야할 때가 많습니다. (생성 & 수정 추적)
각각 객체마다 `createdAt`, `updatedAt` Field를 추가하면 비효율적입니다.
따라서 기본적으로 모든 Entity가 BaseEntity를 상속하고 JpaAuditing을 통해 생성과 수정 시간을 추적하도록 합니다.

- 프로젝트 기본 삭제 전략을 `Soft Delete`로 취한다면 `isDeleted`도 고려해봐야 할 것 같습니다.

<hr>

### ErrorDetail

@Valid를 통해 유효성 검증을 실시할 때 발생하는 예외 `MethodArgumentNotValidException`
이때, e.getBindingResult()를 통해 어떤 Field에서 예외가 발생했는 지 구체적으로 확인하고자 만들었습니다.

예시
```json
{
    "code": 400,
    "message": "잘못된 [인자]입니다.",
    "data": [
        {
            "errorField": "name",
            "errorMessage": "공백일 수 없습니다",
            "inputValue": ""
        }
    ]
}
```

## 참고자료

[@RestControllerAdvice를 이용한 예외 처리](https://thalals.tistory.com/272)

