### PR TITLE
[Feat] 활동점수 활동기록 엔티티 설계

### DIFF
--- a/src/main/java/com/tavemakers/surf/domain/activity/entity/ActivityRecord.java
+++ b/src/main/java/com/tavemakers/surf/domain/activity/entity/ActivityRecord.java
@@ -27,10 +27,13 @@ public class ActivityRecord extends BaseEntity {
     @JoinColumn(name = "member_id")
     private Member member;
 
+    @Enumerated(EnumType.STRING)
     private ActivityCategory category; // 대주제
 
+    @Enumerated(EnumType.STRING)
     private ActivityType activityType; // 소주제 (활동 기록 명)
 
+    @Enumerated(EnumType.STRING)
     private ScoreType scoreType; // 상점, 벌점 여부
 
     private LocalDate activityDate;

--- a/src/main/java/com/tavemakers/surf/domain/activity/entity/ActivityRecord.java
+++ b/src/main/java/com/tavemakers/surf/domain/activity/entity/ActivityRecord.java
@@ -1,0 +1,46 @@
+package com.tavemakers.surf.domain.activity.entity;
+
+import com.tavemakers.surf.domain.activity.entity.enums.ActivityCategory;
+import com.tavemakers.surf.domain.activity.entity.enums.ActivityType;
+import com.tavemakers.surf.domain.activity.entity.enums.ScoreType;
+import com.tavemakers.surf.domain.member.entity.Member;
+import com.tavemakers.surf.global.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ActivityRecord extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    private ActivityCategory category; // 대주제
+
+    private ActivityType activityType; // 소주제 (활동 기록 명)
+
+    private ScoreType scoreType; // 상점, 벌점 여부
+
+    private LocalDate activityDate;
+
+    private Long prefixSum; // 누적합
+
+    private Long appliedScore; // 적용 점수
+
+    private boolean isDeleted;
+
+    // TODO 정적 팩토리 메서드
+
+}

--- a/src/main/java/com/tavemakers/surf/domain/activity/entity/ActivityRecord.java
+++ b/src/main/java/com/tavemakers/surf/domain/activity/entity/ActivityRecord.java
@@ -42,7 +42,8 @@ public class ActivityRecord extends BaseEntity {
 
     private Long appliedScore; // 적용 점수
 
-    private boolean isDeleted;
+    @Column(nullable = false, columnDefinition = "TINYINT(1) default 0")
+    private boolean isDeleted = false;
 
     // TODO 정적 팩토리 메서드
 

--- a/src/main/java/com/tavemakers/surf/domain/activity/entity/enums/ActivityCategory.java
+++ b/src/main/java/com/tavemakers/surf/domain/activity/entity/enums/ActivityCategory.java
@@ -1,0 +1,10 @@
+package com.tavemakers.surf.domain.activity.entity.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ActivityCategory {
+    // 미정
+}

--- a/src/main/java/com/tavemakers/surf/domain/activity/entity/enums/ActivityType.java
+++ b/src/main/java/com/tavemakers/surf/domain/activity/entity/enums/ActivityType.java
@@ -22,6 +22,7 @@ public enum ActivityType {
     WRITE_WIL("WIL 작성", 3, REWARD),
     UPLOAD_INSTAGRAM_STORY("인스타그램 스토리 업로드", 3, REWARD),
     UPLOAD_TAVE_REVIEW("TAVE 활동 후기 업로드", 20, REWARD),
+    TEAM_LEADER("팀장 역할 수행", 10, REWARD),
 
     // PENALTY
     SESSION_ABSENCE("정규 세션 결석", -30,PENALTY),

--- a/src/main/java/com/tavemakers/surf/domain/activity/entity/enums/ActivityType.java
+++ b/src/main/java/com/tavemakers/surf/domain/activity/entity/enums/ActivityType.java
@@ -21,7 +21,28 @@ public enum ActivityType {
     ENGAGE_SOCIAL_CLUB("소모임 활동", 3, REWARD),
     WRITE_WIL("WIL 작성", 3, REWARD),
     UPLOAD_INSTAGRAM_STORY("인스타그램 스토리 업로드", 3, REWARD),
-    UPLOAD_TAVE_REVIEW("TAVE 활동 후기 업로드", 20, REWARD);
+    UPLOAD_TAVE_REVIEW("TAVE 활동 후기 업로드", 20, REWARD),
+
+    // PENALTY
+    SESSION_ABSENCE("정규 세션 결석", -30,PENALTY),
+    SESSION_TRUANCY("정규 세션 무단 결석", -100, PENALTY),
+    SESSION_LATE_1_TO_10("정규 세션 지각", -10, PENALTY),
+    SESSION_LATE_11_TO_20("정규 세션 지각", -20, PENALTY),
+    SESSION_LATE_21_TO_30("정규 세션 지각", -30, PENALTY),
+
+    STUDY_LATE_5_TO_9("스터디 지각", -5, PENALTY),
+    STUDY_LATE_10_TO_19("스터디 지각", -10, PENALTY),
+    STUDY_LATE_20_TO_29("스터디 지각", -15, PENALTY),
+    STUDY_ABSENCE("스터디 결석", -30, PENALTY),
+
+    PROJECT_LATE_5_TO_9("프로젝트 지각", -5, PENALTY),
+    PROJECT_LATE_10_TO_19("프로젝트 지각", -10, PENALTY),
+    PROJECT_LATE_20_TO_29("프로젝트 지각", -15, PENALTY),
+    PROJECT_ABSENCE("프로젝트 결석", -30, PENALTY),
+
+    NO_VOTE("투표 미참여", -15, PENALTY),
+    DELAY_DEPOSIT("보증금 입금 지연", -5, PENALTY),
+    NO_SHOW_AFTER_PARTY("뒷풀이 불참", -10, PENALTY);
 
     private String displayName;
     private Integer score;

--- a/src/main/java/com/tavemakers/surf/domain/activity/entity/enums/ActivityType.java
+++ b/src/main/java/com/tavemakers/surf/domain/activity/entity/enums/ActivityType.java
@@ -1,0 +1,30 @@
+package com.tavemakers.surf.domain.activity.entity.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import static com.tavemakers.surf.domain.activity.entity.enums.ScoreType.*;
+
+@Getter
+@AllArgsConstructor
+public enum ActivityType {
+
+    // REWARD 상점
+    EARLY_BIRD("행사 얼리버드", 5, REWARD),
+    ENGAGE_AFTER_PARTY("뒷풀이 참여", 5, REWARD),
+    CREATE_FLASH_MEETUP("번개모임 주최", 10, REWARD),
+    ENGAGE_FLASH_MEETUP("번개모임 참여", 5, REWARD),
+    SHARE_INFORMATION_AGIT("아지트 정보 공유", 3, REWARD),
+    ENGAGE_TECH_SEMINAR("기술 세미나 참여", 10, REWARD),
+    PRESENT_OUTLINE("기획안 발표", 10, REWARD),
+    CREATE_SOCIAL_CLUB("소모임 생성", 15, REWARD),
+    ENGAGE_SOCIAL_CLUB("소모임 활동", 3, REWARD),
+    WRITE_WIL("WIL 작성", 3, REWARD),
+    UPLOAD_INSTAGRAM_STORY("인스타그램 스토리 업로드", 3, REWARD),
+    UPLOAD_TAVE_REVIEW("TAVE 활동 후기 업로드", 20, REWARD);
+
+    private String displayName;
+    private Integer score;
+    private ScoreType scoreType;
+
+}

--- a/src/main/java/com/tavemakers/surf/domain/activity/entity/enums/ScoreType.java
+++ b/src/main/java/com/tavemakers/surf/domain/activity/entity/enums/ScoreType.java
@@ -1,0 +1,11 @@
+package com.tavemakers.surf.domain.activity.entity.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ScoreType {
+    REWARD,   // 상점 (가점)
+    PENALTY   // 벌점 (감점)
+}

--- a/src/main/java/com/tavemakers/surf/domain/member/entity/Member.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/entity/Member.java
@@ -51,4 +51,8 @@ public class Member extends BaseEntity {
 
     private boolean activityStatus; // 활동/비활동 여부
 
+    public boolean isYB() {
+        return memberType == MemberType.YB;
+    }
+
 }

--- a/src/main/java/com/tavemakers/surf/domain/score/entity/PersonalActivityScore.java
+++ b/src/main/java/com/tavemakers/surf/domain/score/entity/PersonalActivityScore.java
@@ -1,0 +1,45 @@
+package com.tavemakers.surf.domain.score.entity;
+
+import com.tavemakers.surf.domain.member.entity.Member;
+import com.tavemakers.surf.global.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Entity
+@Getter
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PersonalActivityScore extends BaseEntity implements ScoreComputable {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    private Integer score;
+
+    @Override
+    public Integer getScore() {
+        return this.score;
+    }
+
+    @Override
+    public Integer updateScore(Integer score) {
+        this.score += score;
+        return this.score;
+    }
+
+    public static PersonalActivityScore create(Member member) {
+        return PersonalActivityScore.builder()
+                .member(member)
+                .score(100) // 기본 점수 100
+                .build();
+    }
+
+}

--- a/src/main/java/com/tavemakers/surf/domain/score/entity/PersonalActivityScore.java
+++ b/src/main/java/com/tavemakers/surf/domain/score/entity/PersonalActivityScore.java
@@ -18,7 +18,7 @@ public class PersonalActivityScore extends BaseEntity implements ScoreComputable
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
 

--- a/src/main/java/com/tavemakers/surf/domain/score/entity/PersonalActivityScore.java
+++ b/src/main/java/com/tavemakers/surf/domain/score/entity/PersonalActivityScore.java
@@ -22,6 +22,7 @@ public class PersonalActivityScore extends BaseEntity implements ScoreComputable
     @JoinColumn(name = "member_id")
     private Member member;
 
+    @Column(nullable = false)
     private Integer score;
 
     @Override

--- a/src/main/java/com/tavemakers/surf/domain/score/entity/PersonalActivityScore.java
+++ b/src/main/java/com/tavemakers/surf/domain/score/entity/PersonalActivityScore.java
@@ -23,15 +23,15 @@ public class PersonalActivityScore extends BaseEntity implements ScoreComputable
     private Member member;
 
     @Column(nullable = false)
-    private Integer score;
+    private double score;
 
     @Override
-    public Integer getScore() {
+    public double getScore() {
         return this.score;
     }
 
     @Override
-    public Integer updateScore(Integer score) {
+    public double updateScore(double score) {
         this.score += score;
         return this.score;
     }
@@ -39,7 +39,7 @@ public class PersonalActivityScore extends BaseEntity implements ScoreComputable
     public static PersonalActivityScore create(Member member) {
         return PersonalActivityScore.builder()
                 .member(member)
-                .score(100) // 기본 점수 100
+                .score(member.isYB() ? 100 : 50) // 기본 점수 100
                 .build();
     }
 

--- a/src/main/java/com/tavemakers/surf/domain/score/entity/PersonalActivityScore.java
+++ b/src/main/java/com/tavemakers/surf/domain/score/entity/PersonalActivityScore.java
@@ -18,7 +18,7 @@ public class PersonalActivityScore extends BaseEntity implements ScoreComputable
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
 

--- a/src/main/java/com/tavemakers/surf/domain/score/entity/ScoreComputable.java
+++ b/src/main/java/com/tavemakers/surf/domain/score/entity/ScoreComputable.java
@@ -1,0 +1,9 @@
+package com.tavemakers.surf.domain.score.entity;
+
+public interface ScoreComputable {
+
+    Integer getScore();
+
+    Integer updateScore(Integer score);
+
+}

--- a/src/main/java/com/tavemakers/surf/domain/score/entity/ScoreComputable.java
+++ b/src/main/java/com/tavemakers/surf/domain/score/entity/ScoreComputable.java
@@ -2,8 +2,8 @@ package com.tavemakers.surf.domain.score.entity;
 
 public interface ScoreComputable {
 
-    Integer getScore();
+    double getScore();
 
-    Integer updateScore(Integer score);
+    double updateScore(double score);
 
 }

--- a/src/main/java/com/tavemakers/surf/global/common/entity/BaseEntity.java
+++ b/src/main/java/com/tavemakers/surf/global/common/entity/BaseEntity.java
@@ -23,7 +23,7 @@ import java.time.LocalDateTime;
 @MappedSuperclass
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @EntityListeners(AuditingEntityListener.class)
-public class BaseEntity {
+public abstract class BaseEntity {
 
     @CreatedDate
     @Column(updatable = false)


### PR DESCRIPTION
## 📄 작업 내용 요약

- [ ] 개인활동 점수 엔티티 설계 및 추가
- [ ] 활동기록 엔티티 설계 및 추가

## 작업 내용 설명

### PersonalActivityScore로 분리

제가 생각한 엔티티 설계는 다음과 같습니다.
Member안에 score를 두는 것 대신, `PersonalActivityScore`로 `분리`하는 것입니다.

다음과 같은 생각을 통해 이렇게 설계 했습니다.

### Q1 개인 활동 점수를 아는 것이 Member Entity의 책임인가?

-> 활동 점수를 + - 연산하는 책임을 Member가 가지는 게 맞는가??
-> 활동 점수와 Member 정보의 생명주기가 같은가??

첫째.
우선 활동 점수를 Member Entity 안에 두게되면 개인 활동 점수를 update하는 연산은 Member 객체 내에서 수행해야합니다.   
관리자가 점수를 부여하여 연산되는 데, 정작 Member 객체에서 활동 점수를 연산하는 책임을 두는 게 조금 어색하다고 생각했습니다.
Member 객체의 관심사에 활동 점수 연산이 포함되면 어색하다고 생각합니다아

둘째.
활동 점수와 Member 정보의 생명주기가 같지 않다는 점입니다.
개인 활동 점수만..! 필요한 페이지가 있습니다. 만약 Member Entity안에 두게되면, 활동 점수만을 얻을 수 없고 항상 Member 객체를 조회해서 사용해야합니다.

<img width="550" height="450" alt="활동 점수 확장성 고려" src="https://github.com/user-attachments/assets/9a4474ee-1438-4165-a224-1c9cee59d7d8" />


### Q2. 확장성 있는 설계인가??

현재 MVP1에서는 개인활동점수만 관리합니다.
만약 스터디 팀 점수, 프로젝트 팀 점수까지 추가된다면...? 
다음과 같이 PersonalActivity, StudyActivityScore, ProjectActivityScore 처럼 확장성 있게 설계할 수 있다고 생각했습니다...!
또한, 활동점수가 하나로 쭉 관리되는 게 아니라, 기수별로 활동점수가 관리되고 과거 활동점수가 궁금하다는 사용자들의 피드백이 있다면...? Score를 분리하는 게 조금 더 좋지 않을까 생각했습니다.

조금 더 객체지향적인 설계가 아닐 까 생각했습니다....!

<img width="1059" height="423" alt="interface" src="https://github.com/user-attachments/assets/882fcfae-ab5f-4e8b-9e9f-46620bd220de" />

### 성능 괜찮을까??

<img width="1108" height="445" alt="성능 괜찮을까" src="https://github.com/user-attachments/assets/a24653cc-f9cf-46c2-9d45-3b2da8a500f5" />


### 리뷰

이에 대한 가감없는 팀원들의 의견 궁금합니다!



## 📎 Issue #20
<!-- closed #20 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Activity tracking: categorized activity records with dates, types, scores, deletion flag, and cumulative totals.
  - Rewards and penalties: predefined activity types with associated display names, point values, and reward/penalty classification.
  - Personal activity score: per-user balances initialized by member type and updatable as activities occur.
  - Score contract: a new interface for querying and updating score implementations.

- **Refactor**
  - Core base class made abstract to better support activity and scoring extensibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->