### PR TITLE
[Feat] 회원 조회 기능 추가

### DIFF
--- a/src/main/java/com/tavemakers/surf/domain/member/exception/ErrorMessage.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/exception/ErrorMessage.java
@@ -1,0 +1,16 @@
+package com.tavemakers.surf.domain.member.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorMessage {
+
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 [회원]입니다.");
+
+    private final HttpStatus status;
+    private final String message;
+
+}

--- a/src/main/java/com/tavemakers/surf/domain/member/exception/MemberNotFoundException.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/exception/MemberNotFoundException.java
@@ -1,0 +1,11 @@
+package com.tavemakers.surf.domain.member.exception;
+
+import com.tavemakers.surf.global.common.exception.BaseException;
+
+import static com.tavemakers.surf.domain.member.exception.ErrorMessage.MEMBER_NOT_FOUND;
+
+public class MemberNotFoundException extends BaseException {
+    public MemberNotFoundException() {
+        super(MEMBER_NOT_FOUND.getStatus(), MEMBER_NOT_FOUND.getMessage());
+    }
+}

--- a/src/main/java/com/tavemakers/surf/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/repository/MemberRepository.java
@@ -1,0 +1,15 @@
+package com.tavemakers.surf.domain.member.repository;
+
+import com.tavemakers.surf.domain.member.entity.Member;
+import com.tavemakers.surf.domain.member.entity.enums.MemberStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    Optional<Member> findByIdAndStatus(Long memberId, MemberStatus status);
+
+}

--- a/src/main/java/com/tavemakers/surf/domain/member/service/MemberGetService.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/service/MemberGetService.java
@@ -1,0 +1,21 @@
+package com.tavemakers.surf.domain.member.service;
+
+import com.tavemakers.surf.domain.member.entity.Member;
+import com.tavemakers.surf.domain.member.entity.enums.MemberStatus;
+import com.tavemakers.surf.domain.member.exception.MemberNotFoundException;
+import com.tavemakers.surf.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MemberGetService {
+
+    private final MemberRepository memberRepository;
+
+    public Member getMember(Long memberId) {
+        return memberRepository.findByIdAndStatus(memberId, MemberStatus.APPROVED)
+                .orElseThrow(MemberNotFoundException::new);
+    }
+
+}


### PR DESCRIPTION
## 📄 작업 내용 요약

작업 시 승인된 회원을 조회하는 로직이 필요합니다.   
저 말고도 다른 팀원들 작업 내용에 회원 조회가 필요하므로, `회원 조회 기능`을 우선으로 반영하고자 작업했습니다.

```java
    public Member getMember(Long memberId) {
        return memberRepository.findByIdAndStatus(memberId, MemberStatus.APPROVED)
                .orElseThrow(MemberNotFoundException::new);
    }
```

## 📎 Issue #22
<!-- closed #22 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added ability to retrieve approved member profiles by ID.
  - Returns a clear, localized message when a member does not exist.
  - Provides consistent not-found responses with appropriate status codes for API consumers.
- Improvements
  - More reliable member lookup to ensure only approved accounts are returned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->