### PR TITLE
[HOTFIX]: 카카오 프로필 정보 누락 해결 #32

### DIFF
--- a/src/main/java/com/tavemakers/surf/domain/login/kakao/service/KakaoAuthServiceImpl.java
+++ b/src/main/java/com/tavemakers/surf/domain/login/kakao/service/KakaoAuthServiceImpl.java
@@ -28,7 +28,7 @@ public class KakaoAuthServiceImpl implements AuthService<KakaoTokenResponseDto, 
         return "https://kauth.kakao.com/oauth/authorize?response_type=code"
                 + "&client_id=" + props.getClientId()
                 + "&redirect_uri=" + props.getRedirectUri()
-                + "&scope=account_email"; // 필요 시 확장
+                + "&scope=account_email profile_nickname profile_image";
     }
 
     @Override


### PR DESCRIPTION
## 📄 작업 내용 요약
- 카카오 로그인 시 신규 사용자 계정에서 프로필 닉네임/이미지 값이 null로 내려오는 버그 수정
- `KakaoAuthServiceImpl.buildAuthorizeUrl()`에 scope 추가 (`profile_nickname profile_image`)

## 📎 Issue 번호
closed #32

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 새로운 기능
  - 카카오 로그인 연동이 확장되어 프로필 닉네임과 프로필 이미지를 함께 가져올 수 있습니다. 로그인 후 사용자 프로필 표시가 더욱 풍부해집니다.
  - 로그인 동의 화면에서 이메일뿐 아니라 프로필 닉네임/이미지 권한 요청이 추가됩니다. 사용자는 필요한 항목에 동의하여 맞춤형 경험을 이용할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->