### PR TITLE
[Refact] 전체 회원 조회시 최신 트랙 가져오기 + 스웨거 JWT 설정 추가

### DIFF
--- a/src/main/java/com/tavemakers/surf/domain/login/kakao/config/SecurityConfig.java
+++ b/src/main/java/com/tavemakers/surf/domain/login/kakao/config/SecurityConfig.java
@@ -8,12 +8,25 @@ import org.springframework.security.web.SecurityFilterChain;
 @Configuration
 public class SecurityConfig {
 
+    // 인증 없이 접근을 허용할 경로들을 배열로 정의
+    private static final String[] PERMITTED_URLS = {
+            // Swagger UI 접근을 위한 경로
+            "/swagger-ui/**",
+            "/v3/api-docs/**",
+            // 카카오 로그인을 위한 경로
+            "/kakao/login",
+            "/login/oauth2/code/kakao"
+    };
+
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
-                .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(PERMITTED_URLS).permitAll()
+                        .anyRequest().authenticated()
+                )
                 .csrf(csrf -> csrf.disable())
-                .headers(h -> h.frameOptions(f -> f.disable())); // H2 등 쓰면 편의상
+                .headers(h -> h.frameOptions(f -> f.disable()));
         return http.build();
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/member/controller/ResponseMessage.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/controller/ResponseMessage.java
@@ -8,8 +8,8 @@ import lombok.Getter;
 public enum ResponseMessage {
 
     // 이름 규칙 변경 및 메시지에 Placeholder(%s) 추가
-    MEMBER_SEARCH_SUCCESS("'%s'(으)로 활동 중인 회원을 조회했습니다."),
-    MEMBER_GROUP_SUCCESS("트랙별로 현재 활동 중인 회원을 조회했습니다.");
+    MEMBER_SEARCH_SUCCESS("'%s'(으)로 활동 중인 [회원]을 조회했습니다."),
+    MEMBER_GROUP_SUCCESS("[트랙]별로 현재 활동 중인 [회원]을 조회했습니다.");
 
     private final String message;
 

--- a/src/main/java/com/tavemakers/surf/domain/member/repository/TrackRepository.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/repository/TrackRepository.java
@@ -20,9 +20,12 @@ public interface TrackRepository extends JpaRepository<Track, Long> {
     List<Track> findLatestTracksByMemberIds(@Param("memberIds") List<Long> memberIds);
 
     /**
-     * Track을 조회할 때 연관된 현재 활동 중인 Member도 함께 조회하여 N+1 문제를 방지
-     * @return 현재 활동 중인 회원 전체 + 트랙 리스트
+     * Track을 조회할 때 연관된 현재 활동 중인 Member도 함께 조회하되,
+     * 각 회원의 '가장 최신 기수' 트랙만 조회하여 N+1 문제를 방지
+     * @return 현재 활동 중인 회원들의 최신 트랙 리스트
      */
-    @Query("SELECT t FROM Track t JOIN FETCH t.member m WHERE m.activityStatus = true")
+    @Query("SELECT t FROM Track t JOIN FETCH t.member m " +
+            "WHERE m.activityStatus = true " +
+            "AND t.generation = (SELECT MAX(t2.generation) FROM Track t2 WHERE t2.member = t.member)")
     List<Track> findAllWithActiveMember();
 }

--- a/src/main/java/com/tavemakers/surf/domain/member/usecase/MemberUsecase.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/usecase/MemberUsecase.java
@@ -26,30 +26,24 @@ public class MemberUsecase {
 
     // 여러 명의 회원을 조회하고, 각 회원의 트랙 정보를 DTO로 반환하는 메소드
     public List<MemberSearchResDTO> findMemberByNameAndTrack(String name) {
-        // 1. 이름으로 여러 명의 회원을 조회하여 ID 리스트 반환
         List<Member> members = memberGetService.getMemberByName(name);
 
-        // 2. 조회된 회원이 없으면 빈 리스트를 반환합니다.
         if (members.isEmpty()) {
             return List.of();
         }
 
-        //조회된 회원 id 리스트를 생성
         List<Long> memberIds = members.stream().map(Member::getId).collect(Collectors.toList());
 
-        // 3. 회원 id 리스트를 통해 트랙 리스트 가져옴
        List<Track> latestTracks = trackGetService.getTrack(memberIds);
 
-        // 4. 조회된 최신 트랙들을 Member ID를 Key로 하는 Map으로 변환
+        // 조회된 최신 트랙들을 Member ID를 Key로 하는 Map으로 변환
         Map<Long, Track> trackMap = latestTracks.stream()
                 .collect(Collectors.toMap(track -> track.getMember().getId(), track -> track));
 
-        // 5. DB 접근 없이 메모리에서 매핑하여 최종 DTO 생성
         List<MemberSearchResDTO> result = new ArrayList<>();
         for (Member member : members) {
             Track latestTrack = trackMap.get(member.getId());
 
-            // 트랙이 매핑되어있지 않은 멤버가 존재하는 경우 예외처리
             if (latestTrack == null) {
                 throw new TrackNotFoundException ("해당 회원의 트랙을 찾을 수 없습니다. 이름/id : " + member.getName() + "/" +member.getId());
             }

--- a/src/main/java/com/tavemakers/surf/domain/member/usecase/MemberUsecase.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/usecase/MemberUsecase.java
@@ -27,7 +27,6 @@ public class MemberUsecase {
     // 여러 명의 회원을 조회하고, 각 회원의 트랙 정보를 DTO로 반환하는 메소드
     public List<MemberSearchResDTO> findMemberByNameAndTrack(String name) {
         List<Member> members = memberGetService.getMemberByName(name);
-
         if (members.isEmpty()) {
             return List.of();
         }

--- a/src/main/java/com/tavemakers/surf/global/config/SwaggerConfig.java
+++ b/src/main/java/com/tavemakers/surf/global/config/SwaggerConfig.java
@@ -1,18 +1,32 @@
 package com.tavemakers.surf.global.config;
 
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
+@OpenAPIDefinition(
+        info = @io.swagger.v3.oas.annotations.info.Info(title = "Surf API", version = "v1"),
+        security = @SecurityRequirement(name = "BearerAuth")
+)
 public class SwaggerConfig {
     @Bean
     public OpenAPI openAPI() {
         return new OpenAPI()
-                .info(new Info()
-                        .title("Surf API Document")
-                        .description("TAVEMAKERS Surf 프로젝트의 API 명세서입니다.")
-                        .version("1.0.0"));
+                .addSecurityItem(new io.swagger.v3.oas.models.security.SecurityRequirement().addList("BearerAuth"))
+                .components(new Components()
+                        .addSecuritySchemes("BearerAuth",
+                                new SecurityScheme()
+                                        .name("Authorization")
+                                        .type(SecurityScheme.Type.HTTP)
+                                        .scheme("bearer")
+                                        .bearerFormat("JWT")
+                        )
+                );
     }
 }


### PR DESCRIPTION
## 📄 작업 내용 요약
- [x] 스웨거 BearerAuth 시큐리티 설정
- [x] 현재 활동 중인 회원 전체 조회시 해당 회원의 최신 트랙 정보 가져오게 함

</br>

## 1. 스웨거 BearerAuth 시큐리티 설정
JWT 기반의 API 인증을 Swagger UI에서 편리하게 테스트할 수 있도록 Bearer Token 인증 방식을 설정했습니다.

<img width="500" height="300" alt="image" src="https://github.com/user-attachments/assets/dee3f5f5-519d-4aa1-ae57-fe340867e1c7" />


```java
@Configuration
@OpenAPIDefinition(
        info = @io.swagger.v3.oas.annotations.info.Info(title = "Surf API", version = "v1"),
        security = @SecurityRequirement(name = "BearerAuth")
)
public class SwaggerConfig {
    @Bean
    public OpenAPI openAPI() {
        return new OpenAPI()
                .addSecurityItem(new io.swagger.v3.oas.models.security.SecurityRequirement().addList("BearerAuth"))
                .components(new Components()
                        .addSecuritySchemes("BearerAuth",
                                new SecurityScheme()
                                        .name("Authorization")
                                        .type(SecurityScheme.Type.HTTP)
                                        .scheme("bearer")
                                        .bearerFormat("JWT")
                        )
                );
    }
}
```
</br>

## 2. 현재 활동 중인 회원 전체 조회시 해당 회원의 최신 트랙 정보 가져오게 함

### 배경
기존 '이름 기반 검색' API(PR #35)는 여러 기수에서 활동한 회원의 최신 트랙만 반환하도록 개선되었으나, 
'전체 회원 조회' API에는 해당 로직이 누락되어 있었습니다.

### 문제점
두 API가 동일한 회원에 대해 다른 트랙 정보를 반환하여 데이터 일관성이 부족했습니다.

### 해결
'전체 회원 조회' 시에도 각 회원의 가장 최신 기수 트랙만 조회하도록 JPQL에 상관 서브쿼리를 추가하여 로직을 통일했습니다. 
이를 통해 모든 관련 API에서 일관된 데이터를 제공하도록 수정했습니다.

```java
    /**
     * Track을 조회할 때 연관된 현재 활동 중인 Member도 함께 조회하되,
     * 각 회원의 '가장 최신 기수' 트랙만 조회하여 N+1 문제를 방지
     * @return 현재 활동 중인 회원들의 최신 트랙 리스트
     */
    @Query("SELECT t FROM Track t JOIN FETCH t.member m " +
            "WHERE m.activityStatus = true " +
            "AND t.generation = (SELECT MAX(t2.generation) FROM Track t2 WHERE t2.member = t.member)")
    List<Track> findAllWithActiveMember();
```

## 📎 Issue 번호
closed #44 
closed #45 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신규 기능
  - API 문서에 JWT Bearer 인증을 추가해 Swagger UI에서 토큰 입력 및 보안 요청 테스트가 가능해졌습니다.
  - Swagger UI 및 관련 엔드포인트(문서/뷰/콜백)를 인증 예외로 허용해 접근성을 개선했습니다.
- 리팩터
  - 활성 회원의 트랙 조회가 회원별 최신 기수만 반환하도록 개선되어 중복/과거 트랙이 제외됩니다.
- 스타일
  - 회원 조회 응답 문구에 라벨 표기를 추가해 가독성과 명확성을 높였습니다.
- 잡무
  - 불필요한 주석을 정리해 코드 가독성을 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->