### PR TITLE
[Feat] 마이프로필 회원정보 조회

### DIFF
--- a/src/main/java/com/tavemakers/surf/domain/member/controller/MemberSearchController.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/controller/MemberSearchController.java
@@ -2,6 +2,7 @@ package com.tavemakers.surf.domain.member.controller;
 
 import com.tavemakers.surf.domain.member.dto.MemberSearchResDTO;
 import com.tavemakers.surf.domain.member.dto.MemberSimpleResDTO;
+import com.tavemakers.surf.domain.member.dto.response.MyPageProfileResDTO;
 import com.tavemakers.surf.domain.member.usecase.MemberUsecase;
 import com.tavemakers.surf.global.common.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -9,13 +10,12 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 import java.util.Map;
+
+import static com.tavemakers.surf.domain.member.controller.ResponseMessage.MYPAGE_PROFILE_READ;
 
 @RestController
 @RequiredArgsConstructor
@@ -49,5 +49,17 @@ public class MemberSearchController {
                 HttpStatus.OK,
                 ResponseMessage.MEMBER_GROUP_SUCCESS.getMessage(),
                 memberUsecase.getMembersGroupedByTrack());
+    }
+
+    @Operation(
+            summary = "마이페이지에서 프로필 정보 조회",
+            description = "마이페이지에서 프로필 정보 조회")
+    @GetMapping("/mypage/profile/{memberId}")
+    public ApiResponse<MyPageProfileResDTO> getMyPageAndProfile(
+            @PathVariable Long memberId
+            // TODO 추후 Pathvariable이 아닌 인증 객체에서 추출한 memberId 사용
+    ) {
+        MyPageProfileResDTO response = memberUsecase.getMyPageAndProfile(memberId);
+        return ApiResponse.response(HttpStatus.OK, MYPAGE_PROFILE_READ.getMessage(), response);
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/member/controller/ResponseMessage.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/controller/ResponseMessage.java
@@ -9,7 +9,10 @@ public enum ResponseMessage {
 
     // 이름 규칙 변경 및 메시지에 Placeholder(%s) 추가
     MEMBER_SEARCH_SUCCESS("'%s'(으)로 활동 중인 회원을 조회했습니다."),
-    MEMBER_GROUP_SUCCESS("트랙별로 현재 활동 중인 회원을 조회했습니다.");
+    MEMBER_GROUP_SUCCESS("트랙별로 현재 활동 중인 회원을 조회했습니다."),
+
+    // 프로필 조회
+    MYPAGE_PROFILE_READ("마이페이지에서 [프로필 정보]를 조회합니다.");
 
     private final String message;
 

--- a/src/main/java/com/tavemakers/surf/domain/member/dto/response/MyPageProfileResDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/dto/response/MyPageProfileResDTO.java
@@ -1,0 +1,30 @@
+package com.tavemakers.surf.domain.member.dto.response;
+
+import com.tavemakers.surf.domain.member.entity.Member;
+import lombok.Builder;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+@Builder
+public record MyPageProfileResDTO(
+        String username,
+        String phoneNumber,
+        String email,
+        String university,
+        String graduateSchool,
+        BigDecimal activityScore,
+        List<TrackResDTO> trackList
+) {
+    public static MyPageProfileResDTO of(Member member, List<TrackResDTO> trackList, BigDecimal activityScore) {
+        return MyPageProfileResDTO.builder()
+                .username(member.getName())
+                .phoneNumber(member.getPhoneNumber())
+                .email(member.getEmail())
+                .university(member.getUniversity())
+                .graduateSchool(member.getGraduateSchool())
+                .activityScore(activityScore)
+                .trackList(trackList)
+                .build();
+    }
+}

--- a/src/main/java/com/tavemakers/surf/domain/member/dto/response/TrackResDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/dto/response/TrackResDTO.java
@@ -1,0 +1,17 @@
+package com.tavemakers.surf.domain.member.dto.response;
+
+import com.tavemakers.surf.domain.member.entity.Track;
+import lombok.Builder;
+
+@Builder
+public record TrackResDTO(
+        Integer generation,
+        String part
+) {
+    public static TrackResDTO from(Track track) {
+        return TrackResDTO.builder()
+                .generation(track.getGeneration())
+                .part(track.getPart().name())
+                .build();
+    }
+}

--- a/src/main/java/com/tavemakers/surf/domain/member/dto/response/TrackResDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/dto/response/TrackResDTO.java
@@ -11,7 +11,7 @@ public record TrackResDTO(
     public static TrackResDTO from(Track track) {
         return TrackResDTO.builder()
                 .generation(track.getGeneration())
-                .part(track.getPart().name())
+                .part(track.getPart().getDisplayName())
                 .build();
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/member/entity/Member.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/entity/Member.java
@@ -55,4 +55,8 @@ public class Member extends BaseEntity {
         return memberType == MemberType.YB;
     }
 
+    public boolean isActive() {
+        return activityStatus;
+    }
+
 }

--- a/src/main/java/com/tavemakers/surf/domain/member/entity/enums/Part.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/entity/enums/Part.java
@@ -1,10 +1,18 @@
 package com.tavemakers.surf.domain.member.entity.enums;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
 public enum Part {
-    BACKEND,
-    WEB_FRONTEND,
-    APP_FRONTEND,
-    DESIGN,
-    DATA_ANALYSIS,
-    DEEP_LEARNING
+
+    BACKEND("백엔드"),
+    WEB_FRONTEND("웹 프론트엔드"),
+    APP_FRONTEND("앱 프론트엔드"),
+    DESIGN("디자인"),
+    DATA_ANALYSIS("데이터 분석"),
+    DEEP_LEARNING("딥러닝");
+
+    private final String displayName;
 }

--- a/src/main/java/com/tavemakers/surf/domain/member/exception/TrackNotFoundException.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/exception/TrackNotFoundException.java
@@ -7,5 +7,11 @@ import static com.tavemakers.surf.domain.member.exception.ErrorMessage.TRACK_NOT
 public class TrackNotFoundException extends BaseException {
 
     public TrackNotFoundException(String s) {
-        super(TRACK_NOT_FOUND.getStatus(), TRACK_NOT_FOUND.getMessage());}
+        super(TRACK_NOT_FOUND.getStatus(), TRACK_NOT_FOUND.getMessage());
+    }
+
+    public TrackNotFoundException() {
+        super(TRACK_NOT_FOUND.getStatus(), TRACK_NOT_FOUND.getMessage());
+    }
+
 }

--- a/src/main/java/com/tavemakers/surf/domain/member/repository/TrackRepository.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/repository/TrackRepository.java
@@ -25,4 +25,6 @@ public interface TrackRepository extends JpaRepository<Track, Long> {
      */
     @Query("SELECT t FROM Track t JOIN FETCH t.member m WHERE m.activityStatus = true")
     List<Track> findAllWithActiveMember();
+
+    List<Track> findByMemberId(Long memberId);
 }

--- a/src/main/java/com/tavemakers/surf/domain/member/service/TrackGetService.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/service/TrackGetService.java
@@ -21,6 +21,10 @@ public class TrackGetService {
         return trackRepository.findLatestTracksByMemberIds(memberIds);
     }
 
+    public List<Track> getTrack(Long memberId) {
+        return trackRepository.findByMemberId(memberId);
+    }
+
     //트랙과 함께 모든 회원 반환
     public List<Track> getAllTracksWithMember() {
         return trackRepository.findAllWithActiveMember();

--- a/src/main/java/com/tavemakers/surf/domain/member/usecase/MemberUsecase.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/usecase/MemberUsecase.java
@@ -1,15 +1,21 @@
 package com.tavemakers.surf.domain.member.usecase;
 
+import com.tavemakers.surf.domain.activity.service.ActivityRecordGetService;
 import com.tavemakers.surf.domain.member.dto.MemberSearchResDTO;
 import com.tavemakers.surf.domain.member.dto.MemberSimpleResDTO;
+import com.tavemakers.surf.domain.member.dto.response.MyPageProfileResDTO;
+import com.tavemakers.surf.domain.member.dto.response.TrackResDTO;
 import com.tavemakers.surf.domain.member.entity.Member;
 import com.tavemakers.surf.domain.member.entity.Track;
 import com.tavemakers.surf.domain.member.exception.TrackNotFoundException;
 import com.tavemakers.surf.domain.member.service.MemberGetService;
 import com.tavemakers.surf.domain.member.service.TrackGetService;
+import com.tavemakers.surf.domain.score.entity.PersonalActivityScore;
+import com.tavemakers.surf.domain.score.service.PersonalScoreGetService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -22,7 +28,20 @@ public class MemberUsecase {
 
     private final MemberGetService memberGetService;
     private final TrackGetService trackGetService;
+    private final PersonalScoreGetService personalScoreGetService;
 
+    public MyPageProfileResDTO getMyPageAndProfile(Long memberId) {
+        Member member = memberGetService.getMember(memberId);
+        List<TrackResDTO> trackList = trackGetService.getTrack(memberId)
+                .stream().map(TrackResDTO::from).toList();
+
+        BigDecimal score = null;
+        if (member.isActive()) {
+            score = personalScoreGetService.getPersonalScore(memberId).getScore();
+        }
+
+        return MyPageProfileResDTO.of(member, trackList, score);
+    }
 
     // 여러 명의 회원을 조회하고, 각 회원의 트랙 정보를 DTO로 반환하는 메소드
     public List<MemberSearchResDTO> findMemberByNameAndTrack(String name) {


### PR DESCRIPTION
## 📄 작업 내용 요약

마이프로필 회원정보(프로필) 조회

## 1. 마이페이지 유즈케이스

이 기능이 언제 사용되는 지 확인하는 데 유즈케이스가 용이할 거 같아서 작성해봤습니다.
유즈케이스는 처음 작성해봐서 잘못 작성한 부분이 있다면 말씀해주세요!

<img width="630" height="560" alt="마이페이지 유즈케이스" src="https://github.com/user-attachments/assets/153819fa-7eeb-49c4-931e-f0d0c774c06d" />

## 2. 마이페이지 프로필 조회 비지니스 로직 흐름

비지니스 로직 흐름입니다.

<img width="630" height="200" alt="마이페이지 비지니스 로직 흐름" src="https://github.com/user-attachments/assets/f94ba24d-0f1f-4d9a-bea3-5b39bd93bd56" />




## 3. 고민되는 부분

어려운 비지니스 로직이 아니라 상세한 설명은 없어도 괜찮을 거 같습니다.
코드를 작성할 때 고민한 부분을 공유해보고 싶어요.

```java
    public MyPageProfileResDTO getMyPageAndProfile(Long memberId) {
        Member member = memberGetService.getMember(memberId);
        List<TrackResDTO> trackList = trackGetService.getTrack(memberId)
                .stream().map(TrackResDTO::from).toList();

        BigDecimal score = null;
        if (member.isActive()) {
            score = personalScoreGetService.getPersonalScore(memberId).getScore();
        }

        return MyPageProfileResDTO.of(member, trackList, score);
    }
```

```java
    public MyPageProfileResDTO getMyPageAndProfile(Long memberId) {
        Member member = memberGetService.getMember(memberId);
        List<TrackResDTO> trackList = trackGetService.getTrack(memberId)
                .stream().map(TrackResDTO::from).toList();

        if (member.isActive()) {
            BigDecimal score = personalScoreGetService.getPersonalScore(memberId).getScore();
            return MyPageProfileResDTO.of(member, trackList, score);
        }

        return MyPageProfileResDTO.of(member, trackList, null);
    }
```

첫번째는 마지막에 반환하는 Single Return 입니다.
두번째는 Guard Clause 패턴을 적용한 코드입니다.

첫번째는 맨 마지막에 `return`문을 사용하여서 단일 책임 원칙에 조금 더 만족하는 거 같습니다.
그러나 BigDecimal 을 선언하는 부분이 조금 예뻐 보이지가 않네요....

두번째는 `return`을 분기로 처리하여 각각 사용하는데요. 개인적으로 코드가 간겨랗고 가독성이 더 좋아보입니다.
그러나 getMyPageAndProfile()라는 메서드가 이렇게 반환될 수 있고 저렇게 반환될 수 있다라는 여러 가능성을 보여주는 코드라, 단일 책임 원칙에 약간 어긋나지 않나라는 생각이 드네요.

여러분들은 어떤 코드가 더 나아보이는 지 궁금하네용

## 4. 실행 결과

```json
{
    "code": 200,
    "message": "마이페이지에서 [프로필 정보]를 조회합니다.",
    "data": {
        "username": "테스트유저02",
        "phoneNumber": "010-1234-5678",
        "email": "test02@gmail.com",
        "university": "가천대학교",
        "graduateSchool": null,
        "activityScore": 351.0,
        "trackList": [
            {
                "generation": 13,
                "part": "백엔드"
            },
            {
                "generation": 14,
                "part": "웹 프론트엔드"
            },
            {
                "generation": 15,
                "part": "디자인"
            }
        ]
    }
}
```

## 📎 Issue 번호
<!-- closed #번호 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신기능**
  - 마이페이지 프로필 조회 API 추가: 회원 기본정보, 연락처, 학력, 트랙 이력, 활동 점수를 통합 반환합니다.
- **개선**
  - 트랙 파트의 표시명 현지화로 응답이 더 읽기 쉬워졌습니다.
  - 단일 회원 기준 트랙 조회 로직 및 프로필 구성 흐름 보강.
  - 회원 활성 여부(isActive) 조회 가능 추가로 상태 기반 처리 개선.
- **안정성**
  - 트랙 조회 관련 예외 처리 확대로 실패 시 응답 일관성 향상.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->