### PR TITLE
[Feat] jwt 토큰 발급 로직 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,7 +45,10 @@ dependencies {
 
     implementation ("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0")
 
-
+    // jwt
+    implementation("io.jsonwebtoken:jjwt-api:0.11.5")
+    runtimeOnly("io.jsonwebtoken:jjwt-impl:0.11.5")
+    runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.11.5")
 }
 
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -49,6 +49,9 @@ dependencies {
     implementation("io.jsonwebtoken:jjwt-api:0.11.5")
     runtimeOnly("io.jsonwebtoken:jjwt-impl:0.11.5")
     runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.11.5")
+
+    // Redis
+    implementation("org.springframework.boot:spring-boot-starter-data-redis")
 }
 
 

--- a/src/main/java/com/tavemakers/surf/domain/member/controller/AuthController.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/controller/AuthController.java
@@ -17,7 +17,6 @@ import org.springframework.web.bind.annotation.RestController;
 import reactor.core.publisher.Mono;
 
 import java.io.IOException;
-import java.time.Duration;
 
 @RestController
 @RequiredArgsConstructor

--- a/src/main/java/com/tavemakers/surf/domain/member/entity/CustomUserDetails.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/entity/CustomUserDetails.java
@@ -59,4 +59,6 @@ public class CustomUserDetails implements UserDetails {
     public Member getMember() {
         return member;
     }
+
+    public Long getId() { return member.getId(); }
 }

--- a/src/main/java/com/tavemakers/surf/domain/member/entity/Member.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/entity/Member.java
@@ -113,4 +113,21 @@ public class Member extends BaseEntity {
                 .activityStatus(true)
                 .build();
     }
+
+    public void applySignup(MemberSignupReqDTO req, String normalizedPhone) {
+        this.name = req.getName();
+        this.university = req.getUniversity();
+        this.graduateSchool = req.getGraduateSchool();
+        this.phoneNumber = normalizedPhone;
+
+        // 기본 정책 보정 (비어있을 수 있는 값들)
+        if (this.role == null) this.role = MemberRole.MEMBER;
+        if (this.memberType == null) this.memberType = MemberType.YB;
+        this.activityStatus = true;
+
+        // 상태 전이: REGISTERING -> WAITING (또는 정책상 APPROVED)
+        if (this.status == MemberStatus.REGISTERING) {
+            this.status = MemberStatus.WAITING;
+        }
+    }
 }

--- a/src/main/java/com/tavemakers/surf/domain/member/entity/Member.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/entity/Member.java
@@ -1,5 +1,6 @@
 package com.tavemakers.surf.domain.member.entity;
 
+import com.tavemakers.surf.domain.login.kakao.dto.KakaoUserInfoDto;
 import com.tavemakers.surf.global.common.entity.BaseEntity;
 import com.tavemakers.surf.domain.member.dto.request.MemberSignupReqDTO;
 import com.tavemakers.surf.domain.member.entity.enums.MemberType;
@@ -27,7 +28,6 @@ public class Member extends BaseEntity {
 
     private String profileImageUrl;
 
-    @Column(nullable = false)
     private String university;
 
     private String graduateSchool;
@@ -35,11 +35,9 @@ public class Member extends BaseEntity {
     @Column(nullable = false, unique = true) // 이메일은 고유해야 함
     private String email;
 
-    @Column(nullable = false)
     private String phoneNumber;
 
     /** ===== [시스템/운영자가 관리하는 필드] ===== */
-    @Column(nullable = false)
     private int activityScore;
 
     @Enumerated(EnumType.STRING)
@@ -103,6 +101,16 @@ public class Member extends BaseEntity {
                 .build();
     }
 
-
-
+    public static Member createRegisteringFromKakao(KakaoUserInfoDto info) {
+        var acc = info.kakaoAccount();
+        return Member.builder()
+                .name(acc.profile().nickname())
+                .email(acc.email())
+                .profileImageUrl(acc.profile().profileImageUrl())
+                .status(MemberStatus.REGISTERING)
+                .role(MemberRole.MEMBER)
+                .memberType(MemberType.YB)
+                .activityStatus(true)
+                .build();
+    }
 }

--- a/src/main/java/com/tavemakers/surf/domain/member/entity/Member.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/entity/Member.java
@@ -103,6 +103,11 @@ public class Member extends BaseEntity {
 
     public static Member createRegisteringFromKakao(KakaoUserInfoDto info) {
         var acc = info.kakaoAccount();
+
+        if (acc == null || acc.email() == null || acc.email().isBlank()) {
+            throw new IllegalStateException("카카오 계정 이메일 권한이 필요합니다.");
+        }
+
         return Member.builder()
                 .name(acc.profile().nickname())
                 .email(acc.email())

--- a/src/main/java/com/tavemakers/surf/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/service/MemberServiceImpl.java
@@ -9,9 +9,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import com.tavemakers.surf.domain.member.exception.MemberAlreadyExistsException;
 import com.tavemakers.surf.domain.member.entity.enums.MemberStatus;
-import com.tavemakers.surf.domain.member.entity.enums.MemberRole;
 import java.util.Locale;
-import org.springframework.dao.DataIntegrityViolationException;
 
 
 @Service
@@ -32,16 +30,21 @@ public class MemberServiceImpl implements MemberService {
         // 2) 선조회
         Member member = memberRepository.findByEmail(normalizedEmail).orElse(null);
 
-        // 3) REGISTERING 상태만 가입 진행 허용
+        // 3) 선행 조건 검증: 사전 등록(카카오 콜백) 미존재 시 에러
+        if (member == null) {
+            throw new IllegalStateException("사전 등록된 회원이 없습니다. 카카오 로그인 콜백을 먼저 진행하세요.");
+        }
+
+        // 4) REGISTERING 상태만 가입 진행 허용
         if (member.getStatus() != MemberStatus.REGISTERING) {
             // 이미 WAITING/APPROVED 등인 경우
             throw new MemberAlreadyExistsException();
         }
 
-        // 4) 가입 정보 반영 (도메인 메서드가 상태 전이까지 수행)
+        // 5) 가입 정보 반영 (도메인 메서드가 상태 전이까지 수행)
         member.applySignup(request, normalizedPhone);
 
-        // 5) 응답 변환 (영속 엔티티 → DTO)
+        // 6) 응답 변환 (영속 엔티티 → DTO)
         return MemberSignupResDTO.from(member);
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/member/service/MemberUpsertService.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/service/MemberUpsertService.java
@@ -1,0 +1,31 @@
+package com.tavemakers.surf.domain.member.service;
+
+import com.tavemakers.surf.domain.login.kakao.dto.KakaoUserInfoDto;
+import com.tavemakers.surf.domain.member.entity.Member;
+import com.tavemakers.surf.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MemberUpsertService {
+
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public Member upsertRegisteringFromKakao(KakaoUserInfoDto info) {
+        var acc = info.kakaoAccount();
+        final String email = acc.email().trim().toLowerCase();
+
+        return memberRepository.findByEmail(email).orElseGet(() -> {
+            Member toSave = Member.createRegisteringFromKakao(info);
+            try {
+                return memberRepository.save(toSave);
+            } catch (org.springframework.dao.DataIntegrityViolationException e) {
+                return memberRepository.findByEmail(email)
+                        .orElseThrow(() -> e);
+            }
+        });
+    }
+}

--- a/src/main/java/com/tavemakers/surf/global/config/SecurityConfig.java
+++ b/src/main/java/com/tavemakers/surf/global/config/SecurityConfig.java
@@ -1,25 +1,39 @@
 package com.tavemakers.surf.global.config;
 
+import com.tavemakers.surf.domain.member.repository.MemberRepository;
 import com.tavemakers.surf.domain.member.service.CustomUserDetailsService;
+import com.tavemakers.surf.global.jwt.JwtAuthenticationFilter;
+import com.tavemakers.surf.global.jwt.JwtService;
+import com.tavemakers.surf.global.jwt.JwtServiceImpl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 /**
  * Spring Security 전역 설정
  */
 @Configuration
 @RequiredArgsConstructor
+@EnableWebSecurity
+@EnableMethodSecurity
 public class SecurityConfig {
 
     private final CustomUserDetailsService customUserDetailsService;
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final JwtService jwtService;
+    private final MemberRepository memberRepository;
+    private final RedisTemplate<String, String> redisTemplate;
+
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -33,6 +47,7 @@ public class SecurityConfig {
                 .formLogin(form -> form.disable()) // 우리는 소셜 로그인 + JWT 사용 → formLogin 비활성화
                 .httpBasic(basic -> basic.disable()); // Basic Auth도 비활성화
 
+        http.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
         return http.build();
     }
 
@@ -44,5 +59,10 @@ public class SecurityConfig {
     @Bean
     public AuthenticationManager authenticationManager(AuthenticationConfiguration config) throws Exception {
         return config.getAuthenticationManager();
+    }
+
+    @Bean
+    public JwtAuthenticationFilter jwtAuthenticationFilter() {
+        return new JwtAuthenticationFilter(jwtService, memberRepository, redisTemplate);
     }
 }

--- a/src/main/java/com/tavemakers/surf/global/config/SecurityConfig.java
+++ b/src/main/java/com/tavemakers/surf/global/config/SecurityConfig.java
@@ -4,12 +4,11 @@ import com.tavemakers.surf.domain.member.repository.MemberRepository;
 import com.tavemakers.surf.domain.member.service.CustomUserDetailsService;
 import com.tavemakers.surf.global.jwt.JwtAuthenticationFilter;
 import com.tavemakers.surf.global.jwt.JwtService;
-import com.tavemakers.surf.global.jwt.JwtServiceImpl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.authentication.AuthenticationManager;
-import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -28,7 +27,6 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @EnableMethodSecurity
 public class SecurityConfig {
 
-    private final CustomUserDetailsService customUserDetailsService;
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final JwtService jwtService;
     private final MemberRepository memberRepository;

--- a/src/main/java/com/tavemakers/surf/global/config/SecurityConfig.java
+++ b/src/main/java/com/tavemakers/surf/global/config/SecurityConfig.java
@@ -27,7 +27,6 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @EnableMethodSecurity
 public class SecurityConfig {
 
-    private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final JwtService jwtService;
     private final MemberRepository memberRepository;
     private final RedisTemplate<String, String> redisTemplate;
@@ -45,7 +44,7 @@ public class SecurityConfig {
                 .formLogin(form -> form.disable()) // 우리는 소셜 로그인 + JWT 사용 → formLogin 비활성화
                 .httpBasic(basic -> basic.disable()); // Basic Auth도 비활성화
 
-        http.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+        http.addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);
         return http.build();
     }
 

--- a/src/main/java/com/tavemakers/surf/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/tavemakers/surf/global/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,133 @@
+package com.tavemakers.surf.global.jwt;
+
+import com.tavemakers.surf.domain.member.entity.CustomUserDetails;
+import com.tavemakers.surf.domain.member.entity.Member;
+import com.tavemakers.surf.domain.member.repository.MemberRepository;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+@Slf4j
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtService jwtService;
+    private final MemberRepository memberRepository;
+    private final RedisTemplate<String, String> redisTemplate; // 없으면 null 주입 가능
+
+    // 필요에 맞게 경로 조정
+    private static final String LOGIN_URL = "/login/**";
+    private static final String SIGNUP_URL = "/api/members/signup";
+    private static final String LOGOUT_URL = "/auth/logout";
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain chain) throws ServletException, IOException {
+
+        final String uri = request.getRequestURI();
+
+        // 로그인/로그아웃 등은 패스
+        if (uri.startsWith(LOGIN_URL) || uri.startsWith(SIGNUP_URL) || uri.equals(LOGOUT_URL)) {
+            chain.doFilter(request, response);
+            return;
+        }
+
+        String refreshToken = jwtService.extractRefreshToken(request)
+                .filter(jwtService::isTokenValid).orElse(null);
+
+        String accessToken = jwtService.extractAccessToken(request)
+                .filter(jwtService::isTokenValid).orElse(null);
+
+        log.debug("URI: {}, accessToken? {}, refreshToken? {}", uri, accessToken != null, refreshToken != null);
+
+        // 둘 다 있는 경우: 액세스 토큰 블랙리스트만 체크하고 통과
+        if (accessToken != null && refreshToken != null) {
+            if (isBlacklisted(accessToken)) {
+                unauthorized(response);
+                return;
+            }
+            authenticateUser(accessToken, request);
+            chain.doFilter(request, response);
+            return;
+        }
+
+        // 액세스 없음 + 리프레시만 있는 경우: 재발급 후 401로 재시도 유도
+        if (accessToken == null && refreshToken != null) {
+            String newAccess = reIssueAccessToken(refreshToken);
+            jwtService.sendAccessToken(response, newAccess);
+
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            response.getWriter().write("Access token re-issued. Please retry with the new token.");
+            return;
+        }
+
+        // 액세스만 있는 경우: 블랙리스트 체크 후 인증 주입
+        if (accessToken != null) {
+            if (isBlacklisted(accessToken)) {
+                unauthorized(response);
+                return;
+            }
+            authenticateUser(accessToken, request);
+        }
+
+        chain.doFilter(request, response);
+    }
+
+    /** AccessToken → memberId → Member 로드 → SecurityContext 주입 */
+    private void authenticateUser(String accessToken, HttpServletRequest req) {
+        jwtService.extractMemberId(accessToken).flatMap(memberRepository::findById).ifPresent(member -> {
+            CustomUserDetails principal = new CustomUserDetails(member);
+            UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(
+                    principal, null, principal.getAuthorities());
+            auth
+                    .setDetails(new WebAuthenticationDetailsSource().buildDetails(req));
+
+            SecurityContext context = SecurityContextHolder.createEmptyContext();
+            context.setAuthentication(auth);
+            SecurityContextHolder.setContext(context);
+        });
+    }
+
+    /** RefreshToken 검증 → 저장값(옵션)과 일치 시 새 AccessToken 생성 */
+    private String reIssueAccessToken(String refreshToken) {
+        Long memberId = jwtService.extractMemberId(refreshToken)
+                .orElseThrow(() -> new IllegalArgumentException("Cannot extract memberId from refresh token"));
+
+        // (옵션) Redis에 저장된 리프레시와 일치하는지 확인
+        if (redisTemplate != null) {
+            String key = "refresh:" + memberId;
+            String stored = redisTemplate.opsForValue().get(key);
+            if (!StringUtils.hasText(stored) || !refreshToken.equals(stored)) {
+                throw new IllegalArgumentException("Invalid refresh token (not stored or mismatched).");
+            }
+        }
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("Member not found for refresh token"));
+
+        // role은 DB에서 가져와 넣어줌
+        return jwtService.createAccessToken(member.getId(), member.getRole().name());
+    }
+
+    private boolean isBlacklisted(String accessToken) {
+        if (redisTemplate == null) return false;
+        return redisTemplate.opsForValue().get("blacklist:" + accessToken) != null;
+    }
+
+    private void unauthorized(HttpServletResponse res) throws IOException {
+        res.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        res.getWriter().write("This access token is blacklisted (logged out).");
+    }
+}

--- a/src/main/java/com/tavemakers/surf/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/tavemakers/surf/global/jwt/JwtAuthenticationFilter.java
@@ -9,6 +9,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;

--- a/src/main/java/com/tavemakers/surf/global/jwt/JwtService.java
+++ b/src/main/java/com/tavemakers/surf/global/jwt/JwtService.java
@@ -1,0 +1,22 @@
+package com.tavemakers.surf.global.jwt;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.util.Optional;
+
+public interface JwtService {
+
+    String createAccessToken(Long memberId, String role);
+    String createRefreshToken(Long memberId);
+
+    Optional<String> extractAccessToken(HttpServletRequest request);
+    Optional<String> extractRefreshToken(HttpServletRequest request);
+
+    Optional<Long> extractMemberId(String token);
+    boolean isTokenValid(String token);
+    long getExpiration(String token);
+
+    void sendAccessAndRefreshToken(HttpServletResponse res, String accessToken, String refreshToken);
+    void sendAccessToken(HttpServletResponse res, String accessToken);
+}

--- a/src/main/java/com/tavemakers/surf/global/jwt/JwtServiceImpl.java
+++ b/src/main/java/com/tavemakers/surf/global/jwt/JwtServiceImpl.java
@@ -1,0 +1,160 @@
+package com.tavemakers.surf.global.jwt;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseCookie;
+import org.springframework.security.oauth2.jwt.JwtException;
+import org.springframework.stereotype.Service;
+
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.time.Duration;
+import java.util.Date;
+import java.util.Optional;
+
+@Service
+@Slf4j
+public class JwtServiceImpl implements JwtService {
+
+    private static final String AUTH_HEADER = "Authorization";
+    private static final String BEARER_PREFIX = "Bearer ";
+    private static final String REFRESH_COOKIE_NAME = "refreshToken";
+
+    @Value("${jwt.secret}")
+    private String jwtSecret;
+
+    @Value("${jwt.access.expiration}")
+    private long accessTokenExpireMs;
+
+    @Value("${jwt.refresh.expiration}")
+    private long refreshTokenExpireMs;
+
+    @Value("${spring.profiles.active:dev}")
+    private String activeProfile; // prod일 때만 Secure+SameSite=None
+
+    private Key secretKey;
+
+    @PostConstruct
+    public void init() {
+        this.secretKey = Keys.hmacShaKeyFor(jwtSecret.getBytes(StandardCharsets.UTF_8));
+    }
+
+    @Override
+    public String createAccessToken(Long memberId, String role) {
+        Date now = new Date();
+        return Jwts.builder()
+                .setSubject(String.valueOf(memberId))
+                .claim("role", role)
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime() + accessTokenExpireMs))
+                .signWith(secretKey, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    @Override
+    public String createRefreshToken(Long memberId) {
+        Date now = new Date();
+        return Jwts.builder()
+                .setSubject(String.valueOf(memberId))   // ← memberId만 사용
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime() + refreshTokenExpireMs))
+                .signWith(secretKey, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    @Override
+    public Optional<String> extractAccessToken(HttpServletRequest request) {
+        String header = request.getHeader(AUTH_HEADER);
+        if (header != null && header.startsWith(BEARER_PREFIX)) {
+            return Optional.of(header.substring(BEARER_PREFIX.length()));
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<String> extractRefreshToken(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies == null) return Optional.empty();
+        for (Cookie c : cookies) {
+            if (REFRESH_COOKIE_NAME.equals(c.getName())) {
+                return Optional.ofNullable(c.getValue());
+            }
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<Long> extractMemberId(String token) {
+        try {
+            Claims claims = parseClaims(token);
+            String sub = claims.getSubject(); // subject = memberId
+            return Optional.of(Long.parseLong(sub));
+        } catch (JwtException | NumberFormatException e) {
+            log.error("토큰에서 memberId 추출 실패: {}", e.getMessage());
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public boolean isTokenValid(String token) {
+        try {
+            Jwts.parserBuilder().setSigningKey(secretKey).build().parseClaimsJws(token);
+            return true;
+        } catch (io.jsonwebtoken.JwtException e) {
+            log.error("토큰 유효성 검사 실패: {}", e.getMessage());
+            return false;
+        }
+    }
+
+    @Override
+    public long getExpiration(String token) {
+        try {
+            Claims claims = Jwts.parserBuilder()
+                    .setSigningKey(secretKey)
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody();
+            return claims.getExpiration().getTime();
+        } catch (io.jsonwebtoken.JwtException e) {
+            log.error("토큰 만료 시간 추출 실패: {}", e.getMessage());
+            throw new IllegalArgumentException("유효하지 않은 토큰입니다.");
+        }
+    }
+
+    @Override
+    public void sendAccessAndRefreshToken(HttpServletResponse res, String accessToken, String refreshToken) {
+        boolean isProd = "prod".equalsIgnoreCase(activeProfile);
+        // SameSite=None이면 Secure=true가 필수
+        String sameSite = isProd ? "None" : "Lax";
+
+        ResponseCookie cookie = ResponseCookie.from(REFRESH_COOKIE_NAME, refreshToken)
+                .httpOnly(true)
+                .secure(isProd)
+                .path("/")
+                .maxAge(Duration.ofMillis(refreshTokenExpireMs))
+                .sameSite(sameSite)
+                .build();
+
+        res.setHeader(AUTH_HEADER, BEARER_PREFIX + accessToken);
+        res.addHeader("Set-Cookie", cookie.toString());
+    }
+
+    @Override
+    public void sendAccessToken(HttpServletResponse res, String newAccessToken) {
+        res.setHeader(AUTH_HEADER, BEARER_PREFIX + newAccessToken);
+    }
+
+    private Claims parseClaims(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(secretKey)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+}

--- a/src/main/java/com/tavemakers/surf/global/util/SecurityUtils.java
+++ b/src/main/java/com/tavemakers/surf/global/util/SecurityUtils.java
@@ -1,0 +1,36 @@
+package com.tavemakers.surf.global.util;
+
+import com.tavemakers.surf.domain.member.entity.CustomUserDetails;
+import com.tavemakers.surf.domain.member.entity.Member;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class SecurityUtils {
+
+    public static Authentication getAuthentication() {
+        return SecurityContextHolder.getContext().getAuthentication();
+    }
+
+    public static CustomUserDetails getCurrentUserDetails() {
+        Authentication authentication = getAuthentication();
+        if (authentication == null || !authentication.isAuthenticated()) {
+            throw new IllegalStateException("현재 인증된 사용자가 없습니다.");
+        }
+        Object principal = authentication.getPrincipal();
+        if (!(principal instanceof CustomUserDetails)) {
+            throw new IllegalStateException("인증 주체가 CustomUserDetails가 아닙니다.");
+        }
+        return (CustomUserDetails) principal;
+    }
+
+    public static Member getCurrentMember() {
+        return getCurrentUserDetails().getMember();
+    }
+
+    public static Long getCurrentMemberId() {
+        return getCurrentMember().getId();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,6 +15,12 @@ spring:
           batch_size: 50
         order_inserts: true
         order_updates: true
+  data:
+    redis:
+      host: localhost
+      port: 6379
+      password:
+
 
 kakao:
   client-id: ${KAKAO_CLIENT_ID}
@@ -32,3 +38,4 @@ jwt:
   refresh:
     expiration: 86400000 # 1 day
     header: RefreshToken
+

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,3 +22,13 @@ kakao:
   redirect-uri: ${KAKAO_REDIRECT_URI}
   token-uri: ${KAKAO_TOKEN_URI}
   userinfo-uri: ${KAKAO_USER_INFO}
+
+
+jwt:
+  secret: ${JWT_SECRET}
+  access:
+    expiration: 3600000 # 1 hour
+    header: Authorization
+  refresh:
+    expiration: 86400000 # 1 day
+    header: RefreshToken


### PR DESCRIPTION
## 📄 작업 내용 요약
카카오 콜백에서 가져온 정보들로 임시 member 정보를 db에 저장한 이후, singup을 통해 회원가입을 완료합니다.

콜백 시점에서 db에 memberId 등 필수 정보들을 저장하기 때문에 서버에서 발급하는 jwt 토큰을 제공할 수 있습니다.

<img width="524" height="204" alt="스크린샷 2025-09-23 오후 4 33 32" src="https://github.com/user-attachments/assets/8507372f-f8f4-403d-9283-3209b5b565b1" />

해당 메서드를 통해 인증객체에서 현재 member 정보를 가져와서 사용할 수 있습니다.

## 📎 Issue 번호
<!-- closed #52  -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - JWT 기반 인증 도입: 액세스/리프레시 토큰 발급, 헤더/쿠키 전달 및 자동 재발급 지원.
  - 카카오 로그인 시 계정 자동 생성/업서트 및 프로필 정보와 토큰 동시 반환.
  - Redis 연동 추가로 토큰 블랙리스트 및 세션 관리 강화.

- 변경 사항
  - 회원가입 흐름 개선: REGISTERING 단계 도입 및 기존 가입자 처리 강화.
  - 회원 정보 입력 완화: 대학 및 전화번호의 필수 제약 해제.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->