### PR TITLE
[Refactor] 스웨거 정리 및 반환 타입 통일

### DIFF
--- a/src/main/java/com/tavemakers/surf/domain/board/controller/BoardController.java
+++ b/src/main/java/com/tavemakers/surf/domain/board/controller/BoardController.java
@@ -4,12 +4,15 @@ import com.tavemakers.surf.domain.board.dto.req.BoardCreateReqDTO;
 import com.tavemakers.surf.domain.board.dto.req.BoardUpdateReqDTO;
 import com.tavemakers.surf.domain.board.dto.res.BoardResDTO;
 import com.tavemakers.surf.domain.board.service.BoardService;
+import com.tavemakers.surf.global.common.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
+
+import static com.tavemakers.surf.domain.board.controller.ResponseMessage.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -20,31 +23,34 @@ public class BoardController {
 
     @Operation(summary = "게시판 생성", description = "새로운 게시판을 생성합니다.")
     @PostMapping
-    public ResponseEntity<BoardResDTO> createBoard(
+    public ApiResponse<BoardResDTO> createBoard(
             @Valid @RequestBody BoardCreateReqDTO req) {
-        return ResponseEntity.ok(boardService.createBoard(req));
+        BoardResDTO response = boardService.createBoard(req);
+        return ApiResponse.response(HttpStatus.CREATED, BOARD_CREATED.getMessage(), response);
     }
 
     @Operation(summary = "게시판 조회", description = "특정 ID의 게시판을 조회합니다.")
     @GetMapping("/{boardId}")
-    public ResponseEntity<BoardResDTO> getBoard(
+    public ApiResponse<BoardResDTO> getBoard(
             @PathVariable Long boardId) {
-        return ResponseEntity.ok(boardService.getBoard(boardId));
+        BoardResDTO response = boardService.getBoard(boardId);
+        return ApiResponse.response(HttpStatus.OK, BOARD_READ.getMessage(), response);
     }
 
     @Operation(summary = "게시판 수정", description = "특정 ID의 게시판을 수정합니다.")
     @PutMapping("/{boardId}")
-    public ResponseEntity<BoardResDTO> updateBoard(
+    public ApiResponse<BoardResDTO> updateBoard(
             @PathVariable Long boardId,
             @Valid @RequestBody BoardUpdateReqDTO req) {
-        return ResponseEntity.ok(boardService.updateBoard(boardId, req));
+        BoardResDTO response = boardService.updateBoard(boardId, req);
+        return ApiResponse.response(HttpStatus.OK, BOARD_UPDATED.getMessage(), response);
     }
 
     @Operation(summary = "게시판 삭제", description = "특정 ID의 게시판을 삭제합니다.")
     @DeleteMapping("/{boardId}")
-    public ResponseEntity<Void> deleteBoard(
+    public ApiResponse<Void> deleteBoard(
             @PathVariable Long boardId) {
         boardService.deleteBoard(boardId);
-        return ResponseEntity.noContent().build();
+        return ApiResponse.response(HttpStatus.NO_CONTENT, BOARD_DELETED.getMessage());
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/board/controller/BoardController.java
+++ b/src/main/java/com/tavemakers/surf/domain/board/controller/BoardController.java
@@ -4,6 +4,7 @@ import com.tavemakers.surf.domain.board.dto.req.BoardCreateReqDTO;
 import com.tavemakers.surf.domain.board.dto.req.BoardUpdateReqDTO;
 import com.tavemakers.surf.domain.board.dto.res.BoardResDTO;
 import com.tavemakers.surf.domain.board.service.BoardService;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -13,22 +14,25 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/v1/manager/boards")
-@Tag(name = "게시판", description = "추후 MVP를 통해 디벨롭 될 예정")
+@Tag(name = "게시판 관리", description = "추후 MVP를 통해 디벨롭 될 예정")
 public class BoardController {
     private final BoardService boardService;
 
+    @Operation(summary = "게시판 생성", description = "새로운 게시판을 생성합니다.")
     @PostMapping
     public ResponseEntity<BoardResDTO> createBoard(
             @Valid @RequestBody BoardCreateReqDTO req) {
         return ResponseEntity.ok(boardService.createBoard(req));
     }
 
+    @Operation(summary = "게시판 조회", description = "특정 ID의 게시판을 조회합니다.")
     @GetMapping("/{boardId}")
     public ResponseEntity<BoardResDTO> getBoard(
             @PathVariable Long boardId) {
         return ResponseEntity.ok(boardService.getBoard(boardId));
     }
 
+    @Operation(summary = "게시판 수정", description = "특정 ID의 게시판을 수정합니다.")
     @PutMapping("/{boardId}")
     public ResponseEntity<BoardResDTO> updateBoard(
             @PathVariable Long boardId,
@@ -36,6 +40,7 @@ public class BoardController {
         return ResponseEntity.ok(boardService.updateBoard(boardId, req));
     }
 
+    @Operation(summary = "게시판 삭제", description = "특정 ID의 게시판을 삭제합니다.")
     @DeleteMapping("/{boardId}")
     public ResponseEntity<Void> deleteBoard(
             @PathVariable Long boardId) {

--- a/src/main/java/com/tavemakers/surf/domain/board/controller/ResponseMessage.java
+++ b/src/main/java/com/tavemakers/surf/domain/board/controller/ResponseMessage.java
@@ -7,10 +7,10 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ResponseMessage {
 
-    BOARD_CREATED("게시글이 성공적으로 생성되었습니다."),
-    BOARD_UPDATED("게시글이 성공적으로 수정되었습니다."),
-    BOARD_DELETED("게시글이 성공적으로 삭제되었습니다."),
-    BOARD_READ("게시글이 성공적으로 조회되었습니다.");
+    BOARD_CREATED("[게시판]이 성공적으로 생성되었습니다."),
+    BOARD_UPDATED("[게시판]이 성공적으로 수정되었습니다."),
+    BOARD_DELETED("[게시판]이 성공적으로 삭제되었습니다."),
+    BOARD_READ("[게시판]이 성공적으로 조회되었습니다.");
 
     private final String message;
 

--- a/src/main/java/com/tavemakers/surf/domain/board/controller/ResponseMessage.java
+++ b/src/main/java/com/tavemakers/surf/domain/board/controller/ResponseMessage.java
@@ -1,0 +1,17 @@
+package com.tavemakers.surf.domain.board.controller;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ResponseMessage {
+
+    BOARD_CREATED("게시글이 성공적으로 생성되었습니다."),
+    BOARD_UPDATED("게시글이 성공적으로 수정되었습니다."),
+    BOARD_DELETED("게시글이 성공적으로 삭제되었습니다."),
+    BOARD_READ("게시글이 성공적으로 조회되었습니다.");
+
+    private final String message;
+
+}

--- a/src/main/java/com/tavemakers/surf/domain/board/dto/req/BoardCreateReqDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/board/dto/req/BoardCreateReqDTO.java
@@ -1,7 +1,6 @@
 package com.tavemakers.surf.domain.board.dto.req;
 
 import com.tavemakers.surf.domain.board.entity.BoardType;
-import io.netty.channel.ChannelHandler;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 

--- a/src/main/java/com/tavemakers/surf/domain/board/dto/req/BoardCreateReqDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/board/dto/req/BoardCreateReqDTO.java
@@ -1,10 +1,18 @@
 package com.tavemakers.surf.domain.board.dto.req;
 
 import com.tavemakers.surf.domain.board.entity.BoardType;
+import io.netty.channel.ChannelHandler;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 
+@Schema(description = "게시판 생성 요청 DTO")
+
 public record BoardCreateReqDTO(
+
+        @Schema(description = "게시판 이름", example = "공지사항")
         @NotNull String name,
+
+        @Schema(description = "게시판 타입", example = "NOTICE")
         @NotNull BoardType type
 ) {
 }

--- a/src/main/java/com/tavemakers/surf/domain/board/dto/req/BoardUpdateReqDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/board/dto/req/BoardUpdateReqDTO.java
@@ -1,9 +1,13 @@
 package com.tavemakers.surf.domain.board.dto.req;
 
 import com.tavemakers.surf.domain.board.entity.BoardType;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 
+@Schema(description = "게시판 수정 요청 DTO")
 public record BoardUpdateReqDTO(
+
+        @Schema(description = "게시판 타입", example = "NOTICE")
         @NotNull BoardType type
 ) {
 }

--- a/src/main/java/com/tavemakers/surf/domain/board/dto/res/BoardResDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/board/dto/res/BoardResDTO.java
@@ -2,10 +2,18 @@ package com.tavemakers.surf.domain.board.dto.res;
 
 import com.tavemakers.surf.domain.board.entity.Board;
 import com.tavemakers.surf.domain.board.entity.BoardType;
+import io.swagger.v3.oas.annotations.media.Schema;
 
+@Schema(description = "게시판 응답 DTO")
 public record BoardResDTO(
+
+        @Schema(description = "게시판 ID", example = "1")
         Long id,
+
+        @Schema(description = "게시판 이름", example = "공지사항")
         String name,
+
+        @Schema(description = "게시판 타입", example = "NOTICE")
         BoardType type
 ) {
     public static BoardResDTO from(Board board) {

--- a/src/main/java/com/tavemakers/surf/domain/feedback/controller/FeedbackController.java
+++ b/src/main/java/com/tavemakers/surf/domain/feedback/controller/FeedbackController.java
@@ -26,7 +26,7 @@ public class FeedbackController {
     private final FeedbackService feedbackService;
 
     /** 피드백 생성 (로그인 사용자) */
-    @Operation(summary = "피드백 생성")
+    @Operation(summary = "피드백 생성", description = "익명의 피드백을 생성합니다. (하루 3회 제한)")
     @PostMapping
     public ResponseEntity<FeedbackResDTO> createFeedback(
             @Valid @RequestBody FeedbackCreateReqDTO req
@@ -36,7 +36,7 @@ public class FeedbackController {
     }
 
     /** 피드백 조회 (운영진 전용) */
-    @Operation(summary = "피드백 조회")
+    @Operation(summary = "피드백 조회", description = "운영진이 피드백을 조회합니다.")
     @GetMapping
     @PreAuthorize("hasAnyRole('ROOT','MANAGER','PRESIDENT')")
     public ResponseEntity<Page<FeedbackResDTO>> getFeedbacks(

--- a/src/main/java/com/tavemakers/surf/domain/feedback/controller/FeedbackController.java
+++ b/src/main/java/com/tavemakers/surf/domain/feedback/controller/FeedbackController.java
@@ -3,19 +3,22 @@ package com.tavemakers.surf.domain.feedback.controller;
 import com.tavemakers.surf.domain.feedback.dto.req.FeedbackCreateReqDTO;
 import com.tavemakers.surf.domain.feedback.dto.res.FeedbackResDTO;
 import com.tavemakers.surf.domain.feedback.service.FeedbackService;
+import com.tavemakers.surf.global.common.response.ApiResponse;
 import com.tavemakers.surf.global.util.SecurityUtils;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
+
+import static com.tavemakers.surf.domain.feedback.controller.ResponseMessage.FEEDBACK_CREATED;
+import static com.tavemakers.surf.domain.feedback.controller.ResponseMessage.FEEDBACK_READ;
 
 @RestController
 @RequiredArgsConstructor
@@ -28,21 +31,23 @@ public class FeedbackController {
     /** 피드백 생성 (로그인 사용자) */
     @Operation(summary = "피드백 생성", description = "익명의 피드백을 생성합니다. (하루 3회 제한)")
     @PostMapping
-    public ResponseEntity<FeedbackResDTO> createFeedback(
+    public ApiResponse<FeedbackResDTO> createFeedback(
             @Valid @RequestBody FeedbackCreateReqDTO req
     ) {
         Long memberId = SecurityUtils.getCurrentMemberId();
-        return ResponseEntity.ok(feedbackService.createFeedback(req, memberId));
+        FeedbackResDTO response = feedbackService.createFeedback(req, memberId);
+        return ApiResponse.response(HttpStatus.CREATED, FEEDBACK_CREATED.getMessage(), response);
     }
 
     /** 피드백 조회 (운영진 전용) */
     @Operation(summary = "피드백 조회", description = "운영진이 피드백을 조회합니다.")
     @GetMapping
     @PreAuthorize("hasAnyRole('ROOT','MANAGER','PRESIDENT')")
-    public ResponseEntity<Page<FeedbackResDTO>> getFeedbacks(
+    public ApiResponse<Page<FeedbackResDTO>> getFeedbacks(
             @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC)
             Pageable pageable
     ) {
-        return ResponseEntity.ok(feedbackService.getFeedbacks(pageable));
+        Page<FeedbackResDTO> response = feedbackService.getFeedbacks(pageable);
+        return ApiResponse.response(HttpStatus.OK, FEEDBACK_READ.getMessage(), response);
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/feedback/controller/ResponseMessage.java
+++ b/src/main/java/com/tavemakers/surf/domain/feedback/controller/ResponseMessage.java
@@ -7,8 +7,8 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ResponseMessage {
 
-    FEEDBACK_CREATED("피드백이 성공적으로 생성되었습니다."),
-    FEEDBACK_READ("피드백이 성공적으로 조회되었습니다.");
+    FEEDBACK_CREATED("[피드백]이 성공적으로 생성되었습니다."),
+    FEEDBACK_READ("[피드백]이 성공적으로 조회되었습니다.");
 
     private final String message;
 

--- a/src/main/java/com/tavemakers/surf/domain/feedback/controller/ResponseMessage.java
+++ b/src/main/java/com/tavemakers/surf/domain/feedback/controller/ResponseMessage.java
@@ -1,0 +1,15 @@
+package com.tavemakers.surf.domain.feedback.controller;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ResponseMessage {
+
+    FEEDBACK_CREATED("피드백이 성공적으로 생성되었습니다."),
+    FEEDBACK_READ("피드백이 성공적으로 조회되었습니다.");
+
+    private final String message;
+
+}

--- a/src/main/java/com/tavemakers/surf/domain/feedback/dto/req/FeedbackCreateReqDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/feedback/dto/req/FeedbackCreateReqDTO.java
@@ -1,8 +1,12 @@
 package com.tavemakers.surf.domain.feedback.dto.req;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 
+@Schema(description = "피드백 생성 요청 DTO")
 public record FeedbackCreateReqDTO(
+
+        @Schema(description = "피드백 본문 내용", example = "열심히 일해주세요 ㅜ.ㅜ")
         @NotBlank String content
 ) {
 }

--- a/src/main/java/com/tavemakers/surf/domain/feedback/dto/res/FeedbackResDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/feedback/dto/res/FeedbackResDTO.java
@@ -1,12 +1,20 @@
 package com.tavemakers.surf.domain.feedback.dto.res;
 
 import com.tavemakers.surf.domain.feedback.entity.Feedback;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 
+@Schema(description = "피드백 응답 DTO")
 public record FeedbackResDTO(
+
+        @Schema(description = "피드백 ID", example = "1")
         Long id,
+
+        @Schema(description = "피드백 본문 내용", example = "열심히 일해주세요 ㅜ.ㅜ")
         String content,
+
+        @Schema(description = "피드백 생성 일시", example = "2023-10-05T14:48:00")
         LocalDateTime createdAt
 ) {
     public static FeedbackResDTO from(Feedback f) {

--- a/src/main/java/com/tavemakers/surf/domain/post/controller/PostController.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/controller/PostController.java
@@ -4,6 +4,7 @@ import com.tavemakers.surf.domain.post.dto.req.PostCreateReqDTO;
 import com.tavemakers.surf.domain.post.dto.req.PostUpdateReqDTO;
 import com.tavemakers.surf.domain.post.dto.res.PostResDTO;
 import com.tavemakers.surf.domain.post.service.PostService;
+import com.tavemakers.surf.global.common.response.ApiResponse;
 import com.tavemakers.surf.global.util.SecurityUtils;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -13,8 +14,10 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
+
+import static com.tavemakers.surf.domain.post.controller.ResponseMessage.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -27,74 +30,80 @@ public class PostController {
     /** 게시글 생성 (작성자 = 현재 로그인 사용자) */
     @Operation(summary = "게시글 생성", description = "게시글을 생성합니다.")
     @PostMapping
-    public ResponseEntity<PostResDTO> createPost(
+    public ApiResponse<PostResDTO> createPost(
             @Valid @RequestBody PostCreateReqDTO req
     ) {
         Long memberId = SecurityUtils.getCurrentMemberId();
-        return ResponseEntity.ok(postService.createPost(req, memberId));
+        PostResDTO response = postService.createPost(req, memberId);
+        return ApiResponse.response(HttpStatus.CREATED, POST_CREATED.getMessage(), response);
     }
 
     /** 게시글 단건 조회 (뷰어 = 현재 로그인 사용자; 스크랩 여부 등 계산용) */
     @Operation(summary = "게시글 단건 조회", description = "특정 ID의 게시글을 조회합니다.")
     @GetMapping("/{postId}")
-    public ResponseEntity<PostResDTO> getPost(
+    public ApiResponse<PostResDTO> getPost(
             @PathVariable Long postId
     ) {
         Long viewerId = SecurityUtils.getCurrentMemberId();
-        return ResponseEntity.ok(postService.getPost(postId, viewerId));
+        PostResDTO response = postService.getPost(postId, viewerId);
+        return ApiResponse.response(HttpStatus.OK, POST_READ.getMessage(), response);
     }
 
     /** 내가 작성한 게시글 목록 */
     @Operation(summary = "내가 작성한 게시글", description = "본인이 작성한 게시글 목록을 조회합니다.")
     @GetMapping("/me")
-    public ResponseEntity<Page<PostResDTO>> getMyPosts(
+    public ApiResponse<Page<PostResDTO>> getMyPosts(
             @PageableDefault(size = 12, sort = "postedAt", direction = Sort.Direction.DESC)
             Pageable pageable
     ) {
         Long me = SecurityUtils.getCurrentMemberId();
-        return ResponseEntity.ok(postService.getMyPosts(me, pageable));
+        Page<PostResDTO> response = postService.getMyPosts(me, pageable);
+        return ApiResponse.response(HttpStatus.OK, MY_POSTS_READ.getMessage(), response);
     }
 
     /** 특정 작성자의 게시글 목록 (뷰어 = 현재 로그인 사용자) */
     @Operation(summary = "특정 작성자의 게시글 목록", description = "특정 작성자가 작성한 게시글 목록을 조회합니다.")
     @GetMapping("/{authorId}/posts")
-    public ResponseEntity<Page<PostResDTO>> getPostsByMember(
+    public ApiResponse<Page<PostResDTO>> getPostsByMember(
             @PathVariable Long authorId,
             @PageableDefault(size = 12, sort = "postedAt", direction = Sort.Direction.DESC)
             Pageable pageable
     ) {
         Long viewerId = SecurityUtils.getCurrentMemberId();
-        return ResponseEntity.ok(postService.getPostsByMember(authorId, viewerId, pageable));
+        Page<PostResDTO> response = postService.getPostsByMember(authorId, viewerId, pageable);
+        return ApiResponse.response(HttpStatus.OK, POSTS_BY_MEMBER_READ.getMessage(), response);
     }
 
     /** 게시판별 게시글 목록 (뷰어 = 현재 로그인 사용자) */
     @Operation(summary = "게시판별 게시글 목록", description = "특정 게시판에 속한 게시글 목록을 조회합니다.")
     @GetMapping
-    public ResponseEntity<Page<PostResDTO>> getPostsByBoard(
+    public ApiResponse<Page<PostResDTO>> getPostsByBoard(
             @RequestParam Long boardId,
             @PageableDefault(size = 12, sort = "postedAt", direction = Sort.Direction.DESC)
             Pageable pageable
     ) {
         Long viewerId = SecurityUtils.getCurrentMemberId();
-        return ResponseEntity.ok(postService.getPostsByBoard(boardId, viewerId, pageable));
+        Page<PostResDTO> response = postService.getPostsByBoard(boardId, viewerId, pageable);
+        return ApiResponse.response(HttpStatus.OK, POSTS_BY_BOARD_READ.getMessage(), response);
     }
 
     /** 게시글 수정 (작성자 검증은 서비스에서) */
     @Operation(summary = "게시글 수정", description = "본인이 작성한 게시글을 수정합니다.")
     @PutMapping("/{postId}")
-    public ResponseEntity<PostResDTO> updatePost(
+    public ApiResponse<PostResDTO> updatePost(
             @PathVariable Long postId,
             @Valid @RequestBody PostUpdateReqDTO req
     ) {
         Long memberId = SecurityUtils.getCurrentMemberId();
-        return ResponseEntity.ok(postService.updatePost(postId, req, memberId));
+        PostResDTO response = postService.updatePost(postId, req, memberId);
+        return ApiResponse.response(HttpStatus.OK, POST_UPDATED.getMessage(), response);
     }
 
     /** 게시글 삭제 (작성자/권한 검증은 서비스에서) */
     @Operation(summary = "게시글 삭제", description = "본인이 작성한 게시글을 삭제합니다.")
     @DeleteMapping("/{postId}")
-    public ResponseEntity<Void> deletePost(@PathVariable Long postId) {
+    public ApiResponse<Void> deletePost(@PathVariable Long postId) {
         postService.deletePost(postId);
-        return ResponseEntity.noContent().build();
+        return ApiResponse.response(HttpStatus.NO_CONTENT, POST_DELETED.getMessage());
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/post/controller/PostController.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/controller/PostController.java
@@ -25,7 +25,7 @@ public class PostController {
     private final PostService postService;
 
     /** 게시글 생성 (작성자 = 현재 로그인 사용자) */
-    @Operation(summary = "게시글 생성 (작성자 = 현재 로그인 사용자)")
+    @Operation(summary = "게시글 생성", description = "게시글을 생성합니다.")
     @PostMapping
     public ResponseEntity<PostResDTO> createPost(
             @Valid @RequestBody PostCreateReqDTO req
@@ -35,7 +35,7 @@ public class PostController {
     }
 
     /** 게시글 단건 조회 (뷰어 = 현재 로그인 사용자; 스크랩 여부 등 계산용) */
-    @Operation(summary = "게시글 단건 조회")
+    @Operation(summary = "게시글 단건 조회", description = "특정 ID의 게시글을 조회합니다.")
     @GetMapping("/{postId}")
     public ResponseEntity<PostResDTO> getPost(
             @PathVariable Long postId
@@ -45,7 +45,7 @@ public class PostController {
     }
 
     /** 내가 작성한 게시글 목록 */
-    @Operation(summary = "내가 작성한 게시글 목록")
+    @Operation(summary = "내가 작성한 게시글", description = "본인이 작성한 게시글 목록을 조회합니다.")
     @GetMapping("/me")
     public ResponseEntity<Page<PostResDTO>> getMyPosts(
             @PageableDefault(size = 12, sort = "postedAt", direction = Sort.Direction.DESC)
@@ -56,7 +56,7 @@ public class PostController {
     }
 
     /** 특정 작성자의 게시글 목록 (뷰어 = 현재 로그인 사용자) */
-    @Operation(summary = "특정 작성사의 게시글 목록")
+    @Operation(summary = "특정 작성자의 게시글 목록", description = "특정 작성자가 작성한 게시글 목록을 조회합니다.")
     @GetMapping("/{authorId}/posts")
     public ResponseEntity<Page<PostResDTO>> getPostsByMember(
             @PathVariable Long authorId,
@@ -68,7 +68,7 @@ public class PostController {
     }
 
     /** 게시판별 게시글 목록 (뷰어 = 현재 로그인 사용자) */
-    @Operation(summary = "게시판별 게시글 목록")
+    @Operation(summary = "게시판별 게시글 목록", description = "특정 게시판에 속한 게시글 목록을 조회합니다.")
     @GetMapping
     public ResponseEntity<Page<PostResDTO>> getPostsByBoard(
             @RequestParam Long boardId,
@@ -80,7 +80,7 @@ public class PostController {
     }
 
     /** 게시글 수정 (작성자 검증은 서비스에서) */
-    @Operation(summary = "게시글 수정")
+    @Operation(summary = "게시글 수정", description = "본인이 작성한 게시글을 수정합니다.")
     @PutMapping("/{postId}")
     public ResponseEntity<PostResDTO> updatePost(
             @PathVariable Long postId,
@@ -91,7 +91,7 @@ public class PostController {
     }
 
     /** 게시글 삭제 (작성자/권한 검증은 서비스에서) */
-    @Operation(summary = "게시글 삭제")
+    @Operation(summary = "게시글 삭제", description = "본인이 작성한 게시글을 삭제합니다.")
     @DeleteMapping("/{postId}")
     public ResponseEntity<Void> deletePost(@PathVariable Long postId) {
         postService.deletePost(postId);

--- a/src/main/java/com/tavemakers/surf/domain/post/controller/ResponseMessage.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/controller/ResponseMessage.java
@@ -7,13 +7,13 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ResponseMessage {
 
-    POST_CREATED("게시글이 성공적으로 생성되었습니다."),
-    POST_UPDATED("게시글이 성공적으로 수정되었습니다."),
-    POST_DELETED("게시글이 성공적으로 삭제되었습니다."),
-    POST_READ("게시글이 성공적으로 조회되었습니다."),
-    MY_POSTS_READ("내가 작성한 게시글 목록을 성공적으로 조회했습니다."),
-    POSTS_BY_BOARD_READ("게시판별 게시글 목록을 성공적으로 조회했습니다."),
-    POSTS_BY_MEMBER_READ("특정 회원이 작성한 게시글 목록을 성공적으로 조회했습니다.");
+    POST_CREATED("[게시글]이 성공적으로 생성되었습니다."),
+    POST_UPDATED("[게시글]이 성공적으로 수정되었습니다."),
+    POST_DELETED("[게시글]이 성공적으로 삭제되었습니다."),
+    POST_READ("[게시글]이 성공적으로 조회되었습니다."),
+    MY_POSTS_READ("내가 작성한 [게시글] 목록을 성공적으로 조회했습니다."),
+    POSTS_BY_BOARD_READ("[게시판]별 [게시글] 목록을 성공적으로 조회했습니다."),
+    POSTS_BY_MEMBER_READ("특정 회원이 작성한 [게시글] 목록을 성공적으로 조회했습니다.");
 
     private final String message;
 

--- a/src/main/java/com/tavemakers/surf/domain/post/controller/ResponseMessage.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/controller/ResponseMessage.java
@@ -1,0 +1,20 @@
+package com.tavemakers.surf.domain.post.controller;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ResponseMessage {
+
+    POST_CREATED("게시글이 성공적으로 생성되었습니다."),
+    POST_UPDATED("게시글이 성공적으로 수정되었습니다."),
+    POST_DELETED("게시글이 성공적으로 삭제되었습니다."),
+    POST_READ("게시글이 성공적으로 조회되었습니다."),
+    MY_POSTS_READ("내가 작성한 게시글 목록을 성공적으로 조회했습니다."),
+    POSTS_BY_BOARD_READ("게시판별 게시글 목록을 성공적으로 조회했습니다."),
+    POSTS_BY_MEMBER_READ("특정 회원이 작성한 게시글 목록을 성공적으로 조회했습니다.");
+
+    private final String message;
+
+}

--- a/src/main/java/com/tavemakers/surf/domain/post/dto/req/PostCreateReqDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/dto/req/PostCreateReqDTO.java
@@ -1,15 +1,27 @@
 package com.tavemakers.surf.domain.post.dto.req;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 import java.time.LocalDateTime;
 
+@Schema(description = "게시글 생성 요청 DTO")
 public record PostCreateReqDTO(
+
+        @Schema(description = "게시판 ID", example = "1")
         @NotNull Long boardId,
+
+        @Schema(description = "게시글 제목", example = "만남의 장 공지사항")
         @NotBlank String title,
+
+        @Schema(description = "게시글 본문 내용", example = "전반기 만남의 장 언제 어디에 진행합니다!")
         @NotBlank String content,
+
+        @Schema(description = "게시글 상단 고정 여부", example = "true")
         Boolean pinned,
+
+        @Schema(description = "게시글 작성 일시", example = "2023-10-05T14:48:00")
         LocalDateTime postedAt
 ) {
 }

--- a/src/main/java/com/tavemakers/surf/domain/post/dto/req/PostUpdateReqDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/dto/req/PostUpdateReqDTO.java
@@ -1,13 +1,18 @@
 package com.tavemakers.surf.domain.post.dto.req;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 
-import java.time.LocalDateTime;
-
+@Schema(description = "게시글 수정 요청 DTO")
 public record PostUpdateReqDTO(
+
+        @Schema(description = "게시글 제목", example = "만남의 장 공지사항")
         @NotBlank String title,
+
+        @Schema(description = "게시글 본문 내용", example = "전반기 만남의 장 언제 어디에 진행합니다!")
         @NotBlank String content,
-        Boolean pinned,
-        LocalDateTime postedAt
+
+        @Schema(description = "게시글 상단 고정 여부", example = "true")
+        Boolean pinned
 ) {
 }

--- a/src/main/java/com/tavemakers/surf/domain/post/dto/res/PostResDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/dto/res/PostResDTO.java
@@ -1,17 +1,35 @@
 package com.tavemakers.surf.domain.post.dto.res;
 
 import com.tavemakers.surf.domain.post.entity.Post;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 
+@Schema(description = "게시글 응답 DTO")
 public record PostResDTO(
+
+        @Schema(description = "게시글 ID", example = "1")
         Long id,
+
+        @Schema(description = "게시글 제목", example = "만남의 장 공지사항")
         String title,
+
+        @Schema(description = "게시글 본문 내용", example = "전반기 만남의 장 언제 어디에 진행합니다!")
         String content,
+
+        @Schema(description = "게시글 상단 고정 여부", example = "true")
         boolean pinned,
+
+        @Schema(description = "게시글 작성 일시", example = "2023-10-05T14:48:00")
         LocalDateTime postedAt,
+
+        @Schema(description = "게시판 ID", example = "1")
         Long boardId,
+
+        @Schema(description = "내가 스크랩한 게시글인지 여부", example = "true")
         boolean scrappedByMe,
+
+        @Schema(description = "게시글이 스크랩된 수", example = "10")
         long scrapCount
 ) {
     public static PostResDTO from(Post post, boolean scrappedByMe) {

--- a/src/main/java/com/tavemakers/surf/domain/post/entity/Post.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/entity/Post.java
@@ -74,7 +74,6 @@ public class Post extends BaseEntity {
         this.title = req.title();
         this.content = req.content();
         this.pinned = req.pinned() != null ? req.pinned() : this.pinned;
-        this.postedAt = req.postedAt() != null ? req.postedAt() : this.postedAt;
         this.board = board;
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/scrap/controller/ResponseMessage.java
+++ b/src/main/java/com/tavemakers/surf/domain/scrap/controller/ResponseMessage.java
@@ -7,9 +7,9 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ResponseMessage {
 
-    SCRAP_CREATED("스크랩이 성공적으로 생성되었습니다."),
-    SCRAP_DELETED("스크랩이 성공적으로 삭제되었습니다."),
-    MY_SCRAP_LIST_READ("스크랩 목록이 성공적으로 조회되었습니다.");
+    SCRAP_CREATED("[스크랩]이 성공적으로 생성되었습니다."),
+    SCRAP_DELETED("[스크랩]이 성공적으로 삭제되었습니다."),
+    MY_SCRAP_LIST_READ("[스크랩] 목록이 성공적으로 조회되었습니다.");
 
     private final String message;
 

--- a/src/main/java/com/tavemakers/surf/domain/scrap/controller/ResponseMessage.java
+++ b/src/main/java/com/tavemakers/surf/domain/scrap/controller/ResponseMessage.java
@@ -1,0 +1,16 @@
+package com.tavemakers.surf.domain.scrap.controller;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ResponseMessage {
+
+    SCRAP_CREATED("스크랩이 성공적으로 생성되었습니다."),
+    SCRAP_DELETED("스크랩이 성공적으로 삭제되었습니다."),
+    MY_SCRAP_LIST_READ("스크랩 목록이 성공적으로 조회되었습니다.");
+
+    private final String message;
+
+}

--- a/src/main/java/com/tavemakers/surf/domain/scrap/controller/ScrapController.java
+++ b/src/main/java/com/tavemakers/surf/domain/scrap/controller/ScrapController.java
@@ -2,6 +2,7 @@ package com.tavemakers.surf.domain.scrap.controller;
 
 import com.tavemakers.surf.domain.post.dto.res.PostResDTO;
 import com.tavemakers.surf.domain.scrap.service.ScrapService;
+import com.tavemakers.surf.global.common.response.ApiResponse;
 import com.tavemakers.surf.global.util.SecurityUtils;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -10,8 +11,11 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import static com.tavemakers.surf.domain.scrap.controller.ResponseMessage.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -24,29 +28,30 @@ public class ScrapController {
     /** 스크랩 추가 (현재 로그인 사용자 기준) */
     @Operation(summary = "스크랩 추가", description = "특정 게시글을 스크랩합니다.")
     @PostMapping("/{postId}")
-    public ResponseEntity<Void> addScrap(@PathVariable Long postId) {
+    public ApiResponse<Void> addScrap(@PathVariable Long postId) {
         Long me = SecurityUtils.getCurrentMemberId();
         scrapService.addScrap(me, postId);
-        return ResponseEntity.noContent().build();
+        return ApiResponse.response(HttpStatus.CREATED, SCRAP_CREATED.getMessage());
     }
 
     /** 스크랩 삭제 (현재 로그인 사용자 기준) */
     @Operation(summary = "스크랩 삭제", description = "특정 게시글의 스크랩을 취소합니다.")
     @DeleteMapping("/{postId}")
-    public ResponseEntity<Void> removeScrap(@PathVariable Long postId) {
+    public ApiResponse<Void> removeScrap(@PathVariable Long postId) {
         Long me = SecurityUtils.getCurrentMemberId();
         scrapService.removeScrap(me, postId);
-        return ResponseEntity.noContent().build();
+        return ApiResponse.response(HttpStatus.NO_CONTENT, SCRAP_DELETED.getMessage());
     }
 
     /** 내가 스크랩한 게시글 목록 */
     @Operation(summary = "내가 스크랩한 게시글 목록", description = "본인이 스크랩한 게시글 목록을 조회합니다.")
     @GetMapping("/me")
-    public ResponseEntity<Page<PostResDTO>> myScraps(
+    public ApiResponse<Page<PostResDTO>> myScraps(
             @PageableDefault(size = 12, sort = "postedAt", direction = Sort.Direction.DESC)
             Pageable pageable
     ) {
         Long me = SecurityUtils.getCurrentMemberId();
-        return ResponseEntity.ok(scrapService.getMyScraps(me, pageable));
+        Page<PostResDTO> response = scrapService.getMyScraps(me, pageable);
+        return ApiResponse.response(HttpStatus.OK, MY_SCRAP_LIST_READ.getMessage(), response);
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/scrap/controller/ScrapController.java
+++ b/src/main/java/com/tavemakers/surf/domain/scrap/controller/ScrapController.java
@@ -22,7 +22,7 @@ public class ScrapController {
     private final ScrapService scrapService;
 
     /** 스크랩 추가 (현재 로그인 사용자 기준) */
-    @Operation(summary = "스크랩 추가")
+    @Operation(summary = "스크랩 추가", description = "특정 게시글을 스크랩합니다.")
     @PostMapping("/{postId}")
     public ResponseEntity<Void> addScrap(@PathVariable Long postId) {
         Long me = SecurityUtils.getCurrentMemberId();
@@ -31,7 +31,7 @@ public class ScrapController {
     }
 
     /** 스크랩 삭제 (현재 로그인 사용자 기준) */
-    @Operation(summary = "스크랩 삭제")
+    @Operation(summary = "스크랩 삭제", description = "특정 게시글의 스크랩을 취소합니다.")
     @DeleteMapping("/{postId}")
     public ResponseEntity<Void> removeScrap(@PathVariable Long postId) {
         Long me = SecurityUtils.getCurrentMemberId();
@@ -40,7 +40,7 @@ public class ScrapController {
     }
 
     /** 내가 스크랩한 게시글 목록 */
-    @Operation(summary = "내가 스크랩한 게시글 목록")
+    @Operation(summary = "내가 스크랩한 게시글 목록", description = "본인이 스크랩한 게시글 목록을 조회합니다.")
     @GetMapping("/me")
     public ResponseEntity<Page<PostResDTO>> myScraps(
             @PageableDefault(size = 12, sort = "postedAt", direction = Sort.Direction.DESC)


### PR DESCRIPTION
## 📄 작업 내용 요약

Board, Post, Scrap, Feedback 컨트롤러에 대한 스웨거 작성과 반환 타입을 ApiResponse로  통일하였습니다.

responseMessage 는 _CREATED, _UPDATED, _DELETED, _READ 로 맞췄습니다!

## 📎 Issue 번호
<!-- closed #72  -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 게시판/게시글/피드백/스크랩 모든 엔드포인트가 표준화된 ApiResponse(상태코드·메시지 포함)를 반환하도록 통일되어 응답 일관성이 향상되었습니다.

- Documentation
  - DTO와 엔드포인트에 Swagger/OpenAPI 설명 및 예제가 대폭 추가되어 API 문서 가독성과 활용성이 개선되었습니다.
  - 컨트롤러 태그 명칭이 일부 정리되었습니다.

- Breaking Changes
  - 게시글 수정 시 postedAt(게시 시간)이 더 이상 변경되지 않습니다. 기존 클라이언트는 주의하세요.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->