### PR TITLE
[Feat] 본인 프로필 타인 프로필 API 분리

### DIFF
--- a/src/main/java/com/tavemakers/surf/domain/member/controller/MemberSearchController.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/controller/MemberSearchController.java
@@ -5,6 +5,7 @@ import com.tavemakers.surf.domain.member.dto.response.MemberSimpleResDTO;
 import com.tavemakers.surf.domain.member.dto.response.MyPageProfileResDTO;
 import com.tavemakers.surf.domain.member.usecase.MemberUsecase;
 import com.tavemakers.surf.global.common.response.ApiResponse;
+import com.tavemakers.surf.global.util.SecurityUtils;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.NotBlank;
@@ -15,7 +16,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 import java.util.Map;
 
-import static com.tavemakers.surf.domain.member.controller.ResponseMessage.MYPAGE_PROFILE_READ;
+import static com.tavemakers.surf.domain.member.controller.ResponseMessage.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -52,14 +53,23 @@ public class MemberSearchController {
     }
 
     @Operation(
-            summary = "마이페이지에서 프로필 정보 조회",
-            description = "마이페이지에서 프로필 정보 조회")
-    @GetMapping("/mypage/profile/{memberId}")
-    public ApiResponse<MyPageProfileResDTO> getMyPageAndProfile(
-            @PathVariable Long memberId
-            // TODO 추후 Pathvariable이 아닌 인증 객체에서 추출한 memberId 사용
-    ) {
+            summary = "[본인] 마이페이지에서 프로필 정보 조회",
+            description = "[본인] 마이페이지에서 프로필 정보 조회")
+    @GetMapping("/me/mypage/profile")
+    public ApiResponse<MyPageProfileResDTO> getMyPageAndProfile() {
+        Long memberId = SecurityUtils.getCurrentMemberId();
         MyPageProfileResDTO response = memberUsecase.getMyPageAndProfile(memberId);
-        return ApiResponse.response(HttpStatus.OK, MYPAGE_PROFILE_READ.getMessage(), response);
+        return ApiResponse.response(HttpStatus.OK, MYPAGE_MY_PROFILE_READ.getMessage(), response);
+    }
+
+    @Operation(
+            summary = "[타인] 마이페이지에서 프로필 정보 조회",
+            description = "[타인] 마이페이지에서 프로필 정보 조회")
+    @GetMapping("/others/{memberId}/mypage/profile")
+    public ApiResponse<MyPageProfileResDTO> getOthersMyPageAndProfile(
+            @PathVariable Long memberId
+    ) {
+        MyPageProfileResDTO response = memberUsecase.getOthersMyPageAndProfile(memberId);
+        return ApiResponse.response(HttpStatus.OK, MYPAGE_OTHERS_PROFILE_READ.getMessage(), response);
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/member/controller/ResponseMessage.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/controller/ResponseMessage.java
@@ -15,7 +15,8 @@ public enum ResponseMessage {
     MEMBER_GROUP_SUCCESS("[트랙]별로 현재 활동 중인 [회원]을 조회했습니다."),
 
     // 프로필 조회
-    MYPAGE_PROFILE_READ("마이페이지에서 [프로필 정보]를 조회합니다."),
+    MYPAGE_MY_PROFILE_READ("본인 마이페이지에서 [프로필 정보]를 조회합니다."),
+    MYPAGE_OTHERS_PROFILE_READ("타인 마이페이지에서 [프로필 정보]를 조회합니다."),
 
     // 프로필 수정
     MYPAGE_PROFILE_UPDATE_SUCCESS("마이페이지에서 [프로필 정보]를 수정했습니다.");

--- a/src/main/java/com/tavemakers/surf/domain/member/usecase/MemberUsecase.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/usecase/MemberUsecase.java
@@ -42,7 +42,7 @@ public class MemberUsecase {
 
     public MyPageProfileResDTO getMyPageAndProfile(Long memberId) {
         Member member = memberGetService.getMemberByApprovedStatus(memberId);
-        List<TrackResDTO> trackList = getMyTracks(memberId);
+        List<TrackResDTO> myTracks = getMyTracks(memberId);
         List<CareerResDTO> myCareers = getMyCareers(memberId);
 
         BigDecimal score = null;
@@ -50,8 +50,16 @@ public class MemberUsecase {
             score = personalScoreGetService.getPersonalScore(memberId).getScore();
         }
 
-        return MyPageProfileResDTO.of(member, trackList, score, myCareers);
+        return MyPageProfileResDTO.of(member, myTracks, score, myCareers);
     }
+
+    public MyPageProfileResDTO getOthersMyPageAndProfile(Long memberId) {
+        Member member = memberGetService.getMemberByApprovedStatus(memberId);
+        List<TrackResDTO> othersTracks = getMyTracks(memberId);
+        List<CareerResDTO> othersCareers = getMyCareers(memberId);
+        return MyPageProfileResDTO.of(member, othersTracks, null, othersCareers);
+    }
+
 
     // 여러 명의 회원을 조회하고, 각 회원의 트랙 정보를 DTO로 반환하는 메소드
     public List<MemberSearchResDTO> findMemberByNameAndTrack(String name) {


### PR DESCRIPTION
## 📄 작업 내용 요약
본인 프로필 타인 프로필 API 분리

## 본인, 타인 API 분리

- 본인의 마이페이지 정보를 조회하는 경우   
`SecurityUtils.getMemberId()`를 사용합니다.   
`v1/member/me/mypage/profile`

- 타인의 마이페이지 정보를 조회하는 경우
Pathvariable의 memberId를 사용하도록합니다.   
`v1/member/others/{memberId}/mypage/profile`

위 두 과정을 각각 API로 분리했습니다.
member -> user는 이번 PR에 적용하지 않았습니당.

## 📎 Issue #79 
<!-- closed #79 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 다른 사용자의 마이페이지 프로필을 ID로 조회할 수 있습니다.
- 변경 사항
  - 내 마이페이지 프로필은 경로에 ID를 입력하지 않아도, 로그인한 계정 기준으로 자동 조회되도록 동작이 간소화되었습니다.
  - 프로필 조회 안내 문구가 ‘내 프로필’과 ‘타인 프로필’로 구분되어 표현이 더 명확해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->