### PR TITLE
[Hotifx] swagger server url 추가

### DIFF
--- a/src/main/java/com/tavemakers/surf/global/config/SwaggerConfig.java
+++ b/src/main/java/com/tavemakers/surf/global/config/SwaggerConfig.java
@@ -2,6 +2,7 @@ package com.tavemakers.surf.global.config;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.servers.Server;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
@@ -12,7 +13,11 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 @OpenAPIDefinition(
         info = @io.swagger.v3.oas.annotations.info.Info(title = "Surf API", version = "v1"),
-        security = @SecurityRequirement(name = "BearerAuth")
+        security = @SecurityRequirement(name = "BearerAuth"),
+        servers = {
+                @Server(url = "https://34.64.195.243.nip.io", description = "dev 배포 서버"),
+                @Server(url = "http://localhost:8080", description = "로컬 서버")
+        }
 )
 public class SwaggerConfig {
     @Bean


### PR DESCRIPTION
## 📄 작업 내용 요약
swagger server url 추가

``` java
@Configuration
@OpenAPIDefinition(
        info = @io.swagger.v3.oas.annotations.info.Info(title = "Surf API", version = "v1"),
        security = @SecurityRequirement(name = "BearerAuth"),
        servers = {
                @Server(url = "https://34.64.195.243.nip.io", description = "dev 배포 서버"),
                @Server(url = "http://localhost:8080", description = "로컬 서버")
        }
)
public class SwaggerConfig {
    @Bean
```

## 📎 Issue 번호
<!-- closed #번호 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 문서(Documentation)
  * Swagger/OpenAPI 문서에 서버 정보(개발 배포, 로컬)를 추가하여 Swagger UI에서 환경별 베이스 URL을 선택·전환할 수 있습니다.
  * API 엔드포인트와 보안 스키마(Bearer)는 변경되지 않았으며, 문서에서 여러 실행 환경을 손쉽게 테스트하고 검증할 수 있도록 가시성과 편의성을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->