### PR TITLE
[Refactor] 타인과 본인 구분 로직 추가

### DIFF
--- a/src/main/java/com/tavemakers/surf/domain/badge/controller/MemberBadgeController.java
+++ b/src/main/java/com/tavemakers/surf/domain/badge/controller/MemberBadgeController.java
@@ -2,9 +2,9 @@ package com.tavemakers.surf.domain.badge.controller;
 
 import com.tavemakers.surf.domain.badge.dto.request.MemberBadgeReqDTO;
 import com.tavemakers.surf.domain.badge.dto.response.MemberBadgeSliceResDTO;
-import com.tavemakers.surf.domain.badge.entity.MemberBadge;
 import com.tavemakers.surf.domain.badge.usecase.MemberBadgeUsecase;
 import com.tavemakers.surf.global.common.response.ApiResponse;
+import com.tavemakers.surf.global.util.SecurityUtils;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -12,8 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
-import static com.tavemakers.surf.domain.badge.controller.ResponseMessage.MEMBER_BADGE_LIST_CREATED;
-import static com.tavemakers.surf.domain.badge.controller.ResponseMessage.MEMBER_BADGE_LIST_READ;
+import static com.tavemakers.surf.domain.badge.controller.ResponseMessage.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -22,20 +21,27 @@ public class MemberBadgeController {
 
     private final MemberBadgeUsecase memberBadgeusecase;
 
-    @Operation(summary = "활동 뱃지 부여")
+    @Operation(
+            summary = "활동 뱃지 부여 API",
+            description = "활동 뱃지 부여 API"
+    )
     @PostMapping("/v1/admin/members/badges")
     public ApiResponse<Void> createBadge(@RequestBody @Valid MemberBadgeReqDTO dto) {
         memberBadgeusecase.saveMemberBadgeList(dto);
         return ApiResponse.response(HttpStatus.CREATED, MEMBER_BADGE_LIST_CREATED.getMessage(), null);
     }
 
-    @Operation(summary = "마이페이지 활동 뱃지 조회")
-    @GetMapping("/v1/user/members/{memberId}/badges")
-    public ApiResponse<MemberBadgeSliceResDTO> getBadge(
-            @PathVariable("memberId") Long memberId,
+    @Operation(
+            summary = "마이페이지 [활동 뱃지] 조회",
+            description = "마이페이지 [활동 뱃지] 조회"
+    )
+    @GetMapping("/v1/user/members/badges")
+    public ApiResponse<MemberBadgeSliceResDTO> getMyBadges(
+            @RequestParam(required = false) Long memberId,
             @RequestParam int pageSize,
             @RequestParam int pageNum
     ) {
+        memberId = (memberId == null ? SecurityUtils.getCurrentMemberId() : memberId);
         MemberBadgeSliceResDTO response = memberBadgeusecase.getMemberBadgeWithSlice(memberId, pageSize, pageNum);
         return ApiResponse.response(HttpStatus.OK, MEMBER_BADGE_LIST_READ.getMessage(), response);
     }


### PR DESCRIPTION
## 📄 작업 내용 요약
타인과 본인 구분 로직 추가

## 본인, 타인 구분

기존에는 `@Pathvariable` Long memberId를 사용했습니다.
이러면 null을 받을 수 없어서 (경로에 포함되므로), 프론트와 합의 후 requestparam으로 받도록 수정했습니다.

```java
    @GetMapping("/v1/user/members/badges")
    public ApiResponse<MemberBadgeSliceResDTO> getMyBadges(
            @RequestParam(required = false) Long memberId,
            @RequestParam int pageSize,
            @RequestParam int pageNum
    ) {
        memberId = (memberId == null ? SecurityUtils.getCurrentMemberId() : memberId);
        MemberBadgeSliceResDTO response = memberBadgeusecase.getMemberBadgeWithSlice(memberId, pageSize, pageNum);
        return ApiResponse.response(HttpStatus.OK, MEMBER_BADGE_LIST_READ.getMessage(), response);
    }
```

## 📎 Issue #92 
<!-- closed #92 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 배지 조회 시 memberId 없이도 현재 로그인 사용자의 배지를 조회할 수 있도록 선택적 요청 파라미터 지원.
- Refactor
  - 배지 조회 엔드포인트 경로를 /v1/user/members/{memberId}/badges → /v1/user/members/badges 로 단순화.
  - memberId 전달 방식이 경로 변수에서 요청 파라미터(옵션)로 변경.
- Documentation
  - 변경된 엔드포인트와 파라미터 동작을 반영하도록 Swagger/OpenAPI 문서 갱신.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->