### PR TITLE
[Feat] 마이페이지 프로필 조회 API 통일

### DIFF
--- a/src/main/java/com/tavemakers/surf/domain/member/controller/MemberSearchController.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/controller/MemberSearchController.java
@@ -53,23 +53,13 @@ public class MemberSearchController {
     }
 
     @Operation(
-            summary = "[본인] 마이페이지에서 프로필 정보 조회",
-            description = "[본인] 마이페이지에서 프로필 정보 조회")
-        @GetMapping("/v1/user/members/me/{memberId}/profile")
-    public ApiResponse<MyPageProfileResDTO> getMyPageAndProfile() {
-        Long memberId = SecurityUtils.getCurrentMemberId();
+            summary = "마이페이지에서 프로필 정보 조회",
+            description = "마이페이지에서 프로필 정보 조회")
+        @GetMapping("/v1/user/members/profile")
+    public ApiResponse<MyPageProfileResDTO> getMyPageAndProfile(@RequestParam(required = false) Long memberId) {
+        memberId = (memberId == null ? SecurityUtils.getCurrentMemberId() : memberId);
         MyPageProfileResDTO response = memberUsecase.getMyPageAndProfile(memberId);
         return ApiResponse.response(HttpStatus.OK, MYPAGE_MY_PROFILE_READ.getMessage(), response);
     }
 
-    @Operation(
-            summary = "[타인] 마이페이지에서 프로필 정보 조회",
-            description = "[타인] 마이페이지에서 프로필 정보 조회")
-    @GetMapping("v1/user/members/others/{memberId}/profile")
-    public ApiResponse<MyPageProfileResDTO> getOthersMyPageAndProfile(
-            @PathVariable Long memberId
-    ) {
-        MyPageProfileResDTO response = memberUsecase.getOthersMyPageAndProfile(memberId);
-        return ApiResponse.response(HttpStatus.OK, MYPAGE_OTHERS_PROFILE_READ.getMessage(), response);
-    }
 }

--- a/src/main/java/com/tavemakers/surf/domain/member/entity/Member.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/entity/Member.java
@@ -7,6 +7,7 @@ import com.tavemakers.surf.domain.member.dto.request.MemberSignupReqDTO;
 import com.tavemakers.surf.domain.member.entity.enums.MemberType;
 import com.tavemakers.surf.domain.member.entity.enums.MemberRole;
 import com.tavemakers.surf.domain.member.entity.enums.MemberStatus;
+import com.tavemakers.surf.global.util.SecurityUtils;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -15,6 +16,8 @@ import lombok.Builder;
 import com.tavemakers.surf.domain.member.entity.enums.Part;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
+
 import lombok.extern.slf4j.Slf4j;
 
 
@@ -214,5 +217,10 @@ public class Member extends BaseEntity {
         }
         this.role = newRole;
     }
+
+    public boolean isNotOwner() {
+        return !Objects.equals(this.id, SecurityUtils.getCurrentMemberId());
+    }
+
 }
 

--- a/src/main/java/com/tavemakers/surf/domain/member/usecase/MemberUsecase.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/usecase/MemberUsecase.java
@@ -45,6 +45,10 @@ public class MemberUsecase {
         List<TrackResDTO> myTracks = getMyTracks(memberId);
         List<CareerResDTO> myCareers = getMyCareers(memberId);
 
+        if (member.isNotOwner()) {
+            return MyPageProfileResDTO.of(member, myTracks, null, myCareers);
+        }
+
         BigDecimal score = null;
         if (member.isActive()) {
             score = personalScoreGetService.getPersonalScore(memberId).getScore();
@@ -52,14 +56,6 @@ public class MemberUsecase {
 
         return MyPageProfileResDTO.of(member, myTracks, score, myCareers);
     }
-
-    public MyPageProfileResDTO getOthersMyPageAndProfile(Long memberId) {
-        Member member = memberGetService.getMemberByApprovedStatus(memberId);
-        List<TrackResDTO> othersTracks = getMyTracks(memberId);
-        List<CareerResDTO> othersCareers = getMyCareers(memberId);
-        return MyPageProfileResDTO.of(member, othersTracks, null, othersCareers);
-    }
-
 
     // 여러 명의 회원을 조회하고, 각 회원의 트랙 정보를 DTO로 반환하는 메소드
     public List<MemberSearchResDTO> findMemberByNameAndTrack(String name) {

--- a/src/main/java/com/tavemakers/surf/domain/member/usecase/MemberUsecase.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/usecase/MemberUsecase.java
@@ -40,10 +40,10 @@ public class MemberUsecase {
     private final MemberService memberService;
 
 
-    public MyPageProfileResDTO getMyPageAndProfile(Long memberId) {
-        Member member = memberGetService.getMemberByApprovedStatus(memberId);
-        List<TrackResDTO> myTracks = getMyTracks(memberId);
-        List<CareerResDTO> myCareers = getMyCareers(memberId);
+    public MyPageProfileResDTO getMyPageAndProfile(Long targetId) {
+        Member member = memberGetService.getMemberByApprovedStatus(targetId);
+        List<TrackResDTO> myTracks = getMyTracks(targetId);
+        List<CareerResDTO> myCareers = getMyCareers(targetId);
 
         if (member.isNotOwner()) { // SURF Rule - 타인의 활동점수는 조회 불가
             return MyPageProfileResDTO.of(member, myTracks, null, myCareers);
@@ -51,7 +51,7 @@ public class MemberUsecase {
 
         BigDecimal score = null;
         if (member.isActive()) { // SURF Rule - 활동 중인 회원만 활동점수를 보여준다.
-            score = personalScoreGetService.getPersonalScore(memberId).getScore();
+            score = personalScoreGetService.getPersonalScore(targetId).getScore();
         }
 
         return MyPageProfileResDTO.of(member, myTracks, score, myCareers);

--- a/src/main/java/com/tavemakers/surf/domain/member/usecase/MemberUsecase.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/usecase/MemberUsecase.java
@@ -45,12 +45,12 @@ public class MemberUsecase {
         List<TrackResDTO> myTracks = getMyTracks(memberId);
         List<CareerResDTO> myCareers = getMyCareers(memberId);
 
-        if (member.isNotOwner()) {
+        if (member.isNotOwner()) { // SURF Rule - 타인의 활동점수는 조회 불가
             return MyPageProfileResDTO.of(member, myTracks, null, myCareers);
         }
 
         BigDecimal score = null;
-        if (member.isActive()) {
+        if (member.isActive()) { // SURF Rule - 활동 중인 회원만 활동점수를 보여준다.
             score = personalScoreGetService.getPersonalScore(memberId).getScore();
         }
 


### PR DESCRIPTION
## 📄 작업 내용 요약
마이페이지 프로필 조회 API 통일

## 통일

기존에 `@Pathvariable` Long memberId를 사용했습니다.   
이는 null을 받을 수 없어서 프론트와 상의 후 requestparam으로 변경했습니다.   

Member 객체에 조회되는 멤버와 요청자 토큰의 Id와 비교하여, 소유자인지 아닌지 검증하는 도메인 로직을 추가했습니다.
```java
    public boolean isNotOwner() {
        return !Objects.equals(this.id, SecurityUtils.getCurrentMemberId());
    }
```

## 주석

- 타인의 활동점수는 조회할 수 없다.
- 활동 중인 회원만 활동점수를 보여준다.

와 같은 SURF 어플 규칙을 주석으로 적어두었습니다.
클린코드 챕터 4장 좋은 주석을 읽고 적용해보았습니다!

```java
        if (member.isNotOwner()) { // SURF Rule - 타인의 활동점수는 조회 불가
            return MyPageProfileResDTO.of(member, myTracks, null, myCareers);
        }

        BigDecimal score = null;
        if (member.isActive()) { // SURF Rule - 활동 중인 회원만 활동점수를 보여준다.
            score = personalScoreGetService.getPersonalScore(memberId).getScore();
        }
```

## 📎 Issue #94
<!-- closed #94 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 프로필 조회 API 통합: /v1/user/members/profile 하나로 본인·타인 조회 지원. memberId 파라미터로 타인 조회, 미지정 시 본인 자동 선택.
  - 개인정보 보호 강화: 타인 프로필 조회 시 점수·일부 항목은 노출되지 않도록 제한.

- 문서
  - API 문서 업데이트: 경로·파라미터 변경 반영 및 기존 타인 전용 엔드포인트 문서 제거.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->