### PR TITLE
[Feat] 인증객체의 memberId 사용

### DIFF
--- a/src/main/java/com/tavemakers/surf/domain/activity/controller/ActivityRecordController.java
+++ b/src/main/java/com/tavemakers/surf/domain/activity/controller/ActivityRecordController.java
@@ -5,6 +5,7 @@ import com.tavemakers.surf.domain.activity.dto.response.ActivityRecordSliceResDT
 import com.tavemakers.surf.domain.activity.entity.enums.ScoreType;
 import com.tavemakers.surf.domain.activity.usecase.ActivityRecordUsecase;
 import com.tavemakers.surf.global.common.response.ApiResponse;
+import com.tavemakers.surf.global.util.SecurityUtils;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -29,14 +30,15 @@ public class ActivityRecordController {
     }
 
     @Operation(summary = "활동 기록 조회(무한스크롤)")
-    @GetMapping("/v1/user/members/{memberId}/activity-records")
+    @GetMapping("/v1/user/members/activity-records")
     public ApiResponse<ActivityRecordSliceResDTO> getActivityRecord(
-            @PathVariable Long memberId,
             @RequestParam ScoreType scoreType,
             @RequestParam int pageSize,
             @RequestParam int pageNum
     ) {
-        ActivityRecordSliceResDTO response = activityRecordUsecase.getActivityRecordList(memberId, scoreType, pageSize, pageNum);
+        Long memberId = SecurityUtils.getCurrentMemberId();
+        ActivityRecordSliceResDTO response =
+                activityRecordUsecase.getActivityRecordList(memberId, scoreType, pageSize, pageNum);
         return ApiResponse.response(HttpStatus.OK, ACTIVITY_RECORD_READ.getMessage(), response);
     }
 

--- a/src/main/java/com/tavemakers/surf/domain/score/controller/PersonalScoreController.java
+++ b/src/main/java/com/tavemakers/surf/domain/score/controller/PersonalScoreController.java
@@ -28,10 +28,9 @@ public class PersonalScoreController {
     )
     @GetMapping("/v1/user/members/personal-score/pinned5")
     public ApiResponse<PersonalScoreWithPinned5ResDto> getScoreAndPinned5(
-            @RequestParam(required = false) Long memberId
     ) {
-        memberId = memberId == null ? SecurityUtils.getCurrentMemberId() : memberId;
-        PersonalScoreWithPinned5ResDto response = personalScoreUsecase.findPersonalScoreAndPinned5(memberId);
+        PersonalScoreWithPinned5ResDto response =
+                personalScoreUsecase.findPersonalScoreAndPinned5(SecurityUtils.getCurrentMemberId());
         return ApiResponse.response(HttpStatus.OK, SCORE_AND_PINNED_5_READ.getMessage(), response);
     }
 

--- a/src/main/java/com/tavemakers/surf/domain/score/controller/PersonalScoreController.java
+++ b/src/main/java/com/tavemakers/surf/domain/score/controller/PersonalScoreController.java
@@ -3,12 +3,14 @@ package com.tavemakers.surf.domain.score.controller;
 import com.tavemakers.surf.domain.score.dto.response.PersonalScoreWithPinned5ResDto;
 import com.tavemakers.surf.domain.score.usecase.PersonalScoreUsecase;
 import com.tavemakers.surf.global.common.response.ApiResponse;
+import com.tavemakers.surf.global.util.SecurityUtils;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import static com.tavemakers.surf.domain.score.controller.ResponseMessage.SCORE_AND_PINNED_5_READ;
@@ -20,10 +22,17 @@ public class PersonalScoreController {
 
     private final PersonalScoreUsecase personalScoreUsecase;
 
-    @Operation(summary = "활동점수 + 상위 4개 활동 기록 조회)")
-    @GetMapping("/v1/user/members/{memberId}/personal-score/pinned5")
-    public ApiResponse<PersonalScoreWithPinned5ResDto> getScoreAndPinned5(@PathVariable Long memberId) {
+    @Operation(
+            summary = "[활동점수] + 고정 5개[활동기록] 조회)",
+            description = "[활동점수] + 고정 5개[활동기록] 조회"
+    )
+    @GetMapping("/v1/user/members/personal-score/pinned5")
+    public ApiResponse<PersonalScoreWithPinned5ResDto> getScoreAndPinned5(
+            @RequestParam(required = false) Long memberId
+    ) {
+        memberId = memberId == null ? SecurityUtils.getCurrentMemberId() : memberId;
         PersonalScoreWithPinned5ResDto response = personalScoreUsecase.findPersonalScoreAndPinned5(memberId);
         return ApiResponse.response(HttpStatus.OK, SCORE_AND_PINNED_5_READ.getMessage(), response);
     }
+
 }


### PR DESCRIPTION
## 📄 작업 내용 요약
인증객체의 memberId 사용 

## 설명

인증객체의 memberId를 사용하도록 개선했습니다.

```java
    @GetMapping("/v1/user/members/personal-score/pinned5")
    public ApiResponse<PersonalScoreWithPinned5ResDto> getScoreAndPinned5(
    ) {
        PersonalScoreWithPinned5ResDto response =
                personalScoreUsecase.findPersonalScoreAndPinned5(SecurityUtils.getCurrentMemberId());
        return ApiResponse.response(HttpStatus.OK, SCORE_AND_PINNED_5_READ.getMessage(), response);
    }
```

```java
    @Operation(summary = "활동 기록 조회(무한스크롤)")
    @GetMapping("/v1/user/members/activity-records")
    public ApiResponse<ActivityRecordSliceResDTO> getActivityRecord(
            @RequestParam ScoreType scoreType,
            @RequestParam int pageSize,
            @RequestParam int pageNum
    ) {
        Long memberId = SecurityUtils.getCurrentMemberId();
        ActivityRecordSliceResDTO response =
                activityRecordUsecase.getActivityRecordList(memberId, scoreType, pageSize, pageNum);
        return ApiResponse.response(HttpStatus.OK, ACTIVITY_RECORD_READ.getMessage(), response);
    }
```


## 📎 Issue 번호
<!-- closed #번호 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 로그인된 사용자 기준으로 개인 점수 및 고정 5를 조회하도록 API를 단순화했습니다.
  * 경로에서 memberId 전달이 더 이상 필요하지 않습니다.
* 리팩터링
  * 엔드포인트를 /v1/user/members/{memberId}/personal-score/pinned5 → /v1/user/members/personal-score/pinned5로 변경했습니다.
  * 엔드포인트 요약/설명을 최신화했습니다.
  * 클라이언트는 새 경로로 업데이트해야 합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->