### PR TITLE
[Bug] 마이페이지 조회 비지니스 로직 복원

### DIFF
--- a/src/main/java/com/tavemakers/surf/domain/member/controller/MemberSearchController.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/controller/MemberSearchController.java
@@ -55,8 +55,10 @@ public class MemberSearchController {
     @Operation(
             summary = "마이페이지에서 프로필 정보 조회",
             description = "마이페이지에서 프로필 정보 조회")
-        @GetMapping("/v1/user/members/profile")
-    public ApiResponse<MyPageProfileResDTO> getMyPageAndProfile(@RequestParam(required = false) Long memberId) {
+    @GetMapping("/v1/user/members/profile")
+    public ApiResponse<MyPageProfileResDTO> getMyPageAndProfile(
+            @RequestParam(required = false) Long memberId
+    ) {
         memberId = (memberId == null ? SecurityUtils.getCurrentMemberId() : memberId);
         MyPageProfileResDTO response = memberUsecase.getMyPageAndProfile(memberId);
         return ApiResponse.response(HttpStatus.OK, MYPAGE_MY_PROFILE_READ.getMessage(), response);

--- a/src/main/java/com/tavemakers/surf/domain/member/dto/response/MyPageProfileResDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/dto/response/MyPageProfileResDTO.java
@@ -19,9 +19,10 @@ public record MyPageProfileResDTO(
         List<CareerResDTO> careerList
 ) {
     public static MyPageProfileResDTO of(Member member, List<TrackResDTO> trackList, BigDecimal activityScore, List<CareerResDTO> careerList) {
+        boolean isPhoneNumberVisible = !member.isNotOwner() || member.getPhoneNumberPublic();
         return MyPageProfileResDTO.builder()
                 .username(member.getName())
-                .phoneNumber(member.getPhoneNumberPublic() ? member.getPhoneNumber() : null) // 파라미터로 받은 전화번호 사용
+                .phoneNumber(isPhoneNumberVisible ? member.getPhoneNumber() : null) // 파라미터로 받은 전화번호 사용
                 .email(member.getEmail())
                 .university(member.getUniversity())
                 .graduateSchool(member.getGraduateSchool())

--- a/src/main/java/com/tavemakers/surf/domain/member/dto/response/MyPageProfileResDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/dto/response/MyPageProfileResDTO.java
@@ -18,10 +18,10 @@ public record MyPageProfileResDTO(
         List<TrackResDTO> trackList,
         List<CareerResDTO> careerList
 ) {
-    public static MyPageProfileResDTO of(Member member, List<TrackResDTO> trackList, BigDecimal activityScore, List<CareerResDTO> careerList, String phoneNumber) {
+    public static MyPageProfileResDTO of(Member member, List<TrackResDTO> trackList, BigDecimal activityScore, List<CareerResDTO> careerList) {
         return MyPageProfileResDTO.builder()
                 .username(member.getName())
-                .phoneNumber(phoneNumber) // 파라미터로 받은 전화번호 사용
+                .phoneNumber(member.getPhoneNumberPublic() ? member.getPhoneNumber() : null) // 파라미터로 받은 전화번호 사용
                 .email(member.getEmail())
                 .university(member.getUniversity())
                 .graduateSchool(member.getGraduateSchool())

--- a/src/main/java/com/tavemakers/surf/domain/score/controller/PersonalScoreController.java
+++ b/src/main/java/com/tavemakers/surf/domain/score/controller/PersonalScoreController.java
@@ -9,8 +9,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import static com.tavemakers.surf.domain.score.controller.ResponseMessage.SCORE_AND_PINNED_5_READ;


### PR DESCRIPTION
## 📄 작업 내용 요약
마이페이지 조회 비지니스 로직 복원

- 병합 및 컨플릭트 과정에서 손실된 코드를 복원했습니다.
- `@GetMapping` 들여쓰기가 잘못된 부분을 수정했습니다.
- 사용하지 않는 import문을 삭제했습니다.

## 📎 Issue #100
<!-- closed #100 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Bug Fixes
  * 프로필/마이페이지에서 전화번호는 소유자이면서 공개 설정일 때만 표시되도록 수정(비공개 시 숨김).
  * 활동 점수 노출 정책 수정: 본인이면서 활성 상태일 때만 점수를 표시하고, 타인 프로필에는 점수를 표시하지 않음.
* Refactor
  * 컨트롤러·유스케이스 정리 및 불필요한 의존성/임포트 제거, 코드 재정렬(동작 변화 없음).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->