### PR TITLE
[FEAT] 게시글 조회 시 누락된 데이터 추가

### DIFF
--- a/src/main/java/com/tavemakers/surf/domain/board/controller/BoardController.java
+++ b/src/main/java/com/tavemakers/surf/domain/board/controller/BoardController.java
@@ -47,7 +47,7 @@ public class BoardController {
     }
 
     @Operation(summary = "게시판 수정", description = "특정 ID의 게시판을 수정합니다.")
-    @PutMapping("/v1/admin/boards/{boardId}")
+    @PatchMapping("/v1/admin/boards/{boardId}")
     public ApiResponse<BoardResDTO> updateBoard(
             @PathVariable Long boardId,
             @Valid @RequestBody BoardUpdateReqDTO req) {

--- a/src/main/java/com/tavemakers/surf/domain/board/controller/BoardController.java
+++ b/src/main/java/com/tavemakers/surf/domain/board/controller/BoardController.java
@@ -23,6 +23,7 @@ import static com.tavemakers.surf.domain.board.controller.ResponseMessage.*;
 public class BoardController {
     private final BoardService boardService;
 
+    @Operation(summary = "게시판 생성", description = "새로운 게시판을 생성합니다.")
     @PostMapping("/v1/admin/boards")
     public ApiResponse<BoardResDTO> createBoard(
             @Valid @RequestBody BoardCreateReqDTO req) {
@@ -30,6 +31,7 @@ public class BoardController {
         return ApiResponse.response(HttpStatus.CREATED, BOARD_CREATED.getMessage(), response);
     }
 
+    @Operation(summary = "게시판 목록 조회", description = "모든 게시판을 조회합니다.")
     @GetMapping("/v1/users/boards")
     public ApiResponse<List<BoardResDTO>> getBoards() {
         List<BoardResDTO> response = boardService.getBoards();

--- a/src/main/java/com/tavemakers/surf/domain/board/controller/BoardController.java
+++ b/src/main/java/com/tavemakers/surf/domain/board/controller/BoardController.java
@@ -12,6 +12,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 import static com.tavemakers.surf.domain.board.controller.ResponseMessage.*;
 
 @RestController
@@ -21,13 +23,18 @@ import static com.tavemakers.surf.domain.board.controller.ResponseMessage.*;
 public class BoardController {
     private final BoardService boardService;
 
-    @PostMapping("/v1/admin/boards/{boardId}")
+    @PostMapping("/v1/admin/boards")
     public ApiResponse<BoardResDTO> createBoard(
             @Valid @RequestBody BoardCreateReqDTO req) {
         BoardResDTO response = boardService.createBoard(req);
         return ApiResponse.response(HttpStatus.CREATED, BOARD_CREATED.getMessage(), response);
     }
 
+    @GetMapping("/v1/users/boards")
+    public ApiResponse<List<BoardResDTO>> getBoards() {
+        List<BoardResDTO> response = boardService.getBoards();
+        return ApiResponse.response(HttpStatus.OK, BOARD_READ.getMessage(), response);
+    }
 
     @Operation(summary = "게시판 조회", description = "특정 ID의 게시판을 조회합니다.")
     @GetMapping("/v1/admin/boards/{boardId}")

--- a/src/main/java/com/tavemakers/surf/domain/board/controller/BoardController.java
+++ b/src/main/java/com/tavemakers/surf/domain/board/controller/BoardController.java
@@ -32,7 +32,7 @@ public class BoardController {
     }
 
     @Operation(summary = "게시판 목록 조회", description = "모든 게시판을 조회합니다.")
-    @GetMapping("/v1/users/boards")
+    @GetMapping("/v1/user/boards")
     public ApiResponse<List<BoardResDTO>> getBoards() {
         List<BoardResDTO> response = boardService.getBoards();
         return ApiResponse.response(HttpStatus.OK, BOARD_READ.getMessage(), response);

--- a/src/main/java/com/tavemakers/surf/domain/board/dto/req/BoardCreateReqDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/board/dto/req/BoardCreateReqDTO.java
@@ -2,6 +2,7 @@ package com.tavemakers.surf.domain.board.dto.req;
 
 import com.tavemakers.surf.domain.board.entity.BoardType;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 @Schema(description = "게시판 생성 요청 DTO")
@@ -9,7 +10,7 @@ import jakarta.validation.constraints.NotNull;
 public record BoardCreateReqDTO(
 
         @Schema(description = "게시판 이름", example = "공지사항")
-        @NotNull String name,
+        @NotBlank String name,
 
         @Schema(description = "게시판 타입", example = "NOTICE")
         @NotNull BoardType type

--- a/src/main/java/com/tavemakers/surf/domain/board/dto/req/BoardUpdateReqDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/board/dto/req/BoardUpdateReqDTO.java
@@ -7,6 +7,9 @@ import jakarta.validation.constraints.NotNull;
 @Schema(description = "게시판 수정 요청 DTO")
 public record BoardUpdateReqDTO(
 
+        @Schema(description = "게시판 이름", example = "공지사항")
+        @NotNull String name,
+
         @Schema(description = "게시판 타입", example = "NOTICE")
         @NotNull BoardType type
 ) {

--- a/src/main/java/com/tavemakers/surf/domain/board/dto/req/BoardUpdateReqDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/board/dto/req/BoardUpdateReqDTO.java
@@ -2,13 +2,14 @@ package com.tavemakers.surf.domain.board.dto.req;
 
 import com.tavemakers.surf.domain.board.entity.BoardType;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 @Schema(description = "게시판 수정 요청 DTO")
 public record BoardUpdateReqDTO(
 
         @Schema(description = "게시판 이름", example = "공지사항")
-        @NotNull String name,
+        @NotBlank String name,
 
         @Schema(description = "게시판 타입", example = "NOTICE")
         @NotNull BoardType type

--- a/src/main/java/com/tavemakers/surf/domain/board/entity/Board.java
+++ b/src/main/java/com/tavemakers/surf/domain/board/entity/Board.java
@@ -39,7 +39,8 @@ public class Board extends BaseEntity {
                 .build();
     }
 
-    public void changeType(BoardType type) {
+    public void update(String name, BoardType type) {
+        this.name = name;
         this.type = type;
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/board/service/BoardService.java
+++ b/src/main/java/com/tavemakers/surf/domain/board/service/BoardService.java
@@ -10,6 +10,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -23,6 +25,13 @@ public class BoardService {
         return BoardResDTO.from(saved);
     }
 
+    public List<BoardResDTO> getBoards() {
+        List<Board> boards = boardRepository.findAll();
+        return boards.stream()
+                .map(BoardResDTO::from)
+                .toList();
+    }
+
     public BoardResDTO getBoard(Long id) {
         Board board = boardRepository.findById(id)
                 .orElseThrow(BoardNotFoundException::new);
@@ -33,7 +42,7 @@ public class BoardService {
     public BoardResDTO updateBoard(Long id, BoardUpdateReqDTO req) {
         Board board = boardRepository.findById(id)
                 .orElseThrow(BoardNotFoundException::new);
-        board.changeType(req.type());
+        board.update(req.name(), req.type());
         return BoardResDTO.from(board);
     }
 

--- a/src/main/java/com/tavemakers/surf/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/tavemakers/surf/domain/comment/controller/CommentController.java
@@ -29,7 +29,7 @@ public class CommentController {
                                                     @Valid @RequestBody CommentCreateReqDTO req) {
         Long memberId = SecurityUtils.getCurrentMemberId();
         CommentResDTO response = commentService.createComment(postId, memberId, req);
-        return ApiResponse.response(HttpStatus.CREATED, "댓글이 생성되었습니다.", response);
+        return ApiResponse.response(HttpStatus.CREATED, COMMENT_CREATED.getMessage(), response);
     }
 
     @Operation(summary = "댓글 목록 조회 (페이징)", description = "루트 댓글과 대댓글 모두 포함. 페이징 처리")

--- a/src/main/java/com/tavemakers/surf/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/tavemakers/surf/domain/comment/controller/CommentController.java
@@ -42,7 +42,7 @@ public class CommentController {
     }
 
     @Operation(summary = "댓글 수정 (내 댓글만)", description = "본인이 작성한 댓글만 수정 가능")
-    @PutMapping("/v1/user/posts/{postId}/comments/{commentId}")
+    @PatchMapping("/v1/user/posts/{postId}/comments/{commentId}")
     public ApiResponse<CommentResDTO> updateComment(@PathVariable Long postId,
                                               @PathVariable Long commentId,
                                               @Valid @RequestBody CommentUpdateReqDTO req) {

--- a/src/main/java/com/tavemakers/surf/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/tavemakers/surf/domain/comment/controller/CommentController.java
@@ -7,6 +7,7 @@ import com.tavemakers.surf.domain.comment.service.CommentService;
 import com.tavemakers.surf.global.common.response.ApiResponse;
 import com.tavemakers.surf.global.util.SecurityUtils;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -19,6 +20,7 @@ import static com.tavemakers.surf.domain.comment.controller.ResponseMessage.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping
+@Tag(name = "댓글", description = "댓글 CRUD 관련 API, 대댓글 1단계 가능")
 public class CommentController {
 
     private final CommentService commentService;
@@ -49,7 +51,7 @@ public class CommentController {
         return ApiResponse.response(HttpStatus.OK, COMMENT_UPDATED.getMessage(), response);
     }
 
-    @Operation(summary = "댓글 삭제 (내 댓글만)", description = "본인이 작성한 댓글만 삭제 가능")
+    @Operation(summary = "댓글 삭제 (내 댓글만)", description = "본인이 작성한 댓글만 삭제 가능, 대댓글 존재 시 내용만 삭제(삭제된 댓글입니다 처리)")
     @DeleteMapping("/v1/user/posts/{postId}/comments/{commentId}")
     public ApiResponse<Void> deleteComment(@PathVariable Long postId,
                                     @PathVariable Long commentId) {

--- a/src/main/java/com/tavemakers/surf/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/tavemakers/surf/domain/comment/controller/CommentController.java
@@ -1,0 +1,60 @@
+package com.tavemakers.surf.domain.comment.controller;
+
+import com.tavemakers.surf.domain.comment.dto.req.CommentCreateReqDTO;
+import com.tavemakers.surf.domain.comment.dto.req.CommentUpdateReqDTO;
+import com.tavemakers.surf.domain.comment.dto.res.CommentResDTO;
+import com.tavemakers.surf.domain.comment.service.CommentService;
+import com.tavemakers.surf.global.common.response.ApiResponse;
+import com.tavemakers.surf.global.util.SecurityUtils;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import static com.tavemakers.surf.domain.comment.controller.ResponseMessage.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping
+public class CommentController {
+
+    private final CommentService commentService;
+
+    @Operation(summary = "댓글 생성 (루트/대댓글)", description = "parentId가 null이면 루트")
+    @PostMapping("/v1/user/posts/{postId}/comments")
+    public ApiResponse<CommentResDTO> createComment(@PathVariable Long postId,
+                                                    @Valid @RequestBody CommentCreateReqDTO req) {
+        Long memberId = SecurityUtils.getCurrentMemberId();
+        CommentResDTO response = commentService.createComment(postId, memberId, req);
+        return ApiResponse.response(HttpStatus.CREATED, "댓글이 생성되었습니다.", response);
+    }
+
+    @Operation(summary = "댓글 목록 조회 (페이징)", description = "루트 댓글과 대댓글 모두 포함. 페이징 처리")
+    @GetMapping("/v1/user/posts/{postId}/comments")
+    public ApiResponse<Slice<CommentResDTO>> getComments(@PathVariable Long postId, Pageable pageable) {
+        Slice<CommentResDTO> response = commentService.getComments(postId, pageable);
+        return ApiResponse.response(HttpStatus.OK, COMMENT_READ.getMessage(), response);
+    }
+
+    @Operation(summary = "댓글 수정 (내 댓글만)", description = "본인이 작성한 댓글만 수정 가능")
+    @PutMapping("/v1/user/posts/{postId}/comments/{commentId}")
+    public ApiResponse<CommentResDTO> updateComment(@PathVariable Long postId,
+                                              @PathVariable Long commentId,
+                                              @Valid @RequestBody CommentUpdateReqDTO req) {
+        Long memberId = SecurityUtils.getCurrentMemberId();
+        CommentResDTO response = commentService.updateComment(postId, commentId, memberId, req);
+        return ApiResponse.response(HttpStatus.OK, COMMENT_UPDATED.getMessage(), response);
+    }
+
+    @Operation(summary = "댓글 삭제 (내 댓글만)", description = "본인이 작성한 댓글만 삭제 가능")
+    @DeleteMapping("/v1/user/posts/{postId}/comments/{commentId}")
+    public ApiResponse<Void> deleteComment(@PathVariable Long postId,
+                                    @PathVariable Long commentId) {
+        Long memberId = SecurityUtils.getCurrentMemberId();
+        commentService.deleteComment(postId, commentId, memberId);
+        return ApiResponse.response(HttpStatus.NO_CONTENT, COMMENT_DELETED.getMessage());
+    }
+}

--- a/src/main/java/com/tavemakers/surf/domain/comment/controller/ResponseMessage.java
+++ b/src/main/java/com/tavemakers/surf/domain/comment/controller/ResponseMessage.java
@@ -1,0 +1,16 @@
+package com.tavemakers.surf.domain.comment.controller;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ResponseMessage {
+
+    COMMENT_CREATED("[댓글]이 성공적으로 생성되었습니다."),
+    COMMENT_READ("[댓글]이 성공적으로 조회되었습니다."),
+    COMMENT_UPDATED("[댓글]이 성공적으로 수정되었습니다."),
+    COMMENT_DELETED("[댓글]이 성공적으로 삭제되었습니다.");
+
+    private final String message;
+}

--- a/src/main/java/com/tavemakers/surf/domain/comment/dto/req/CommentCreateReqDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/comment/dto/req/CommentCreateReqDTO.java
@@ -1,0 +1,12 @@
+package com.tavemakers.surf.domain.comment.dto.req;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(description = "댓글 생성 DTO")
+public record CommentCreateReqDTO(
+        @Schema(description = "부모 댓글 ID (루트면 null)", example = "null")
+        Long parentId,
+        @Schema(description = "내용", example = "좋은 공지 감사합니다!")
+        @NotBlank String content
+) {}

--- a/src/main/java/com/tavemakers/surf/domain/comment/dto/req/CommentUpdateReqDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/comment/dto/req/CommentUpdateReqDTO.java
@@ -1,0 +1,10 @@
+package com.tavemakers.surf.domain.comment.dto.req;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(description = "댓글 수정 DTO")
+public record CommentUpdateReqDTO(
+        @Schema(description = "내용", example = "내용 수정합니다.")
+        @NotBlank String content
+) {}

--- a/src/main/java/com/tavemakers/surf/domain/comment/dto/res/CommentResDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/comment/dto/res/CommentResDTO.java
@@ -3,7 +3,6 @@ package com.tavemakers.surf.domain.comment.dto.res;
 import com.tavemakers.surf.domain.comment.entity.Comment;
 import io.swagger.v3.oas.annotations.media.Schema;
 
-import java.time.LocalDateTime;
 
 @Schema(description = "댓글 응답 DTO")
 public record CommentResDTO(
@@ -14,9 +13,7 @@ public record CommentResDTO(
         int depth,
         String content,
         Long memberId,
-        String nickname,
-        LocalDateTime createdAt,
-        LocalDateTime updatedAt
+        String nickname
 ) {
     public static CommentResDTO from(Comment comment) {
         return new CommentResDTO(
@@ -27,9 +24,7 @@ public record CommentResDTO(
                 comment.getDepth(),
                 comment.getContent(),
                 comment.getMember().getId(),
-                comment.getMember().getName(),
-                comment.getCreatedAt(),
-                comment.getUpdatedAt()
+                comment.getMember().getName()
         );
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/comment/dto/res/CommentResDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/comment/dto/res/CommentResDTO.java
@@ -1,0 +1,35 @@
+package com.tavemakers.surf.domain.comment.dto.res;
+
+import com.tavemakers.surf.domain.comment.entity.Comment;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+@Schema(description = "댓글 응답 DTO")
+public record CommentResDTO(
+        Long id,
+        Long postId,
+        Long parentId,
+        Long rootId,
+        int depth,
+        String content,
+        Long memberId,
+        String nickname,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+    public static CommentResDTO from(Comment comment) {
+        return new CommentResDTO(
+                comment.getId(),
+                comment.getPost().getId(),
+                comment.getParent() != null ? comment.getParent().getId() : null,
+                comment.getParent() == null ? comment.getId() : comment.getRootId(),
+                comment.getDepth(),
+                comment.getContent(),
+                comment.getMember().getId(),
+                comment.getMember().getName(),
+                comment.getCreatedAt(),
+                comment.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/tavemakers/surf/domain/comment/entity/Comment.java
+++ b/src/main/java/com/tavemakers/surf/domain/comment/entity/Comment.java
@@ -9,10 +9,12 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Where;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Where(clause="deleted=false")
 public class Comment extends BaseEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/tavemakers/surf/domain/comment/entity/Comment.java
+++ b/src/main/java/com/tavemakers/surf/domain/comment/entity/Comment.java
@@ -1,5 +1,6 @@
 package com.tavemakers.surf.domain.comment.entity;
 
+import com.tavemakers.surf.domain.comment.exception.AlreadyDeletedCommentException;
 import com.tavemakers.surf.domain.comment.exception.CommentDepthExceedException;
 import com.tavemakers.surf.domain.member.entity.Member;
 import com.tavemakers.surf.domain.post.entity.Post;
@@ -93,9 +94,8 @@ public class Comment extends BaseEntity {
 
     public void update(String content) {
         if (this.deleted) {
-            throw new IllegalStateException("삭제된 댓글은 수정할 수 없습니다.");
+            throw new AlreadyDeletedCommentException();
         }
-
         this.content = content;
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/comment/entity/Comment.java
+++ b/src/main/java/com/tavemakers/surf/domain/comment/entity/Comment.java
@@ -37,6 +37,14 @@ public class Comment extends BaseEntity {
     @Column(nullable = false, length = 1000)
     private String content;
 
+    @Column(nullable = false)
+    private boolean deleted = false;
+
+    public void softDelete() {
+        this.deleted = true;
+        this.content = "(삭제된 댓글입니다.)";
+    }
+
     @Builder
     private Comment(Post post, Member member, String content, Comment parent, Long rootId, int depth) {
         this.post = post;

--- a/src/main/java/com/tavemakers/surf/domain/comment/entity/Comment.java
+++ b/src/main/java/com/tavemakers/surf/domain/comment/entity/Comment.java
@@ -1,0 +1,87 @@
+package com.tavemakers.surf.domain.comment.entity;
+
+import com.tavemakers.surf.domain.comment.exception.CommentDepthExceedException;
+import com.tavemakers.surf.domain.member.entity.Member;
+import com.tavemakers.surf.domain.post.entity.Post;
+import com.tavemakers.surf.global.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Comment extends BaseEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long rootId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_id")
+    private Comment parent;
+
+    private int depth = 0;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "post_id", nullable = false)
+    private Post post;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Column(nullable = false, length = 1000)
+    private String content;
+
+    @Builder
+    private Comment(Post post, Member member, String content, Comment parent, Long rootId, int depth) {
+        this.post = post;
+        this.member = member;
+        this.content = content;
+        this.parent = parent;
+        this.rootId = rootId;
+        this.depth = depth;
+    }
+
+    /** 루트 댓글 생성 */
+    public static Comment root(Post post, Member member, String content) {
+        return Comment.builder()
+                .post(post)
+                .member(member)
+                .content(content)
+                .parent(null)
+                .depth(0)
+                .build();
+    }
+
+    /** 대댓글 생성 */
+    public static Comment child(Post post, Member member, String content, Comment parent) {
+        if (parent.getDepth() >= 1) { // 루트(0) 밑의 한 단계(1)까지만 허용
+            throw new CommentDepthExceedException();
+        }
+        Long root = (parent.getParent() == null) ? parent.getId() : parent.getRootId(); // 안전
+        return Comment.builder()
+                .post(post)
+                .member(member)
+                .content(content)
+                .parent(parent)
+                .rootId(root)
+                .depth(parent.getDepth() + 1)
+                .build();
+    }
+
+    /** 저장 후 rootId 세팅 (루트 댓글일 때만) */
+    public void markAsRoot() {
+        if (this.parent == null && this.rootId == null) {
+            this.rootId = this.id;
+        }
+    }
+
+    public void update(String content) {
+        this.content = content;
+    }
+}

--- a/src/main/java/com/tavemakers/surf/domain/comment/entity/Comment.java
+++ b/src/main/java/com/tavemakers/surf/domain/comment/entity/Comment.java
@@ -92,6 +92,10 @@ public class Comment extends BaseEntity {
     }
 
     public void update(String content) {
+        if (this.deleted) {
+            throw new IllegalStateException("삭제된 댓글은 수정할 수 없습니다.");
+        }
+
         this.content = content;
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/comment/exception/AlreadyDeletedCommentException.java
+++ b/src/main/java/com/tavemakers/surf/domain/comment/exception/AlreadyDeletedCommentException.java
@@ -1,0 +1,11 @@
+package com.tavemakers.surf.domain.comment.exception;
+
+import com.tavemakers.surf.global.common.exception.BaseException;
+
+import static com.tavemakers.surf.domain.comment.exception.ErrorMessage.ALREADY_DELETED_COMMENT;
+
+public class AlreadyDeletedCommentException extends BaseException {
+    public AlreadyDeletedCommentException() {
+        super(ALREADY_DELETED_COMMENT.getStatus(), ALREADY_DELETED_COMMENT.getMessage());
+    }
+}

--- a/src/main/java/com/tavemakers/surf/domain/comment/exception/CommentDepthExceedException.java
+++ b/src/main/java/com/tavemakers/surf/domain/comment/exception/CommentDepthExceedException.java
@@ -1,0 +1,9 @@
+package com.tavemakers.surf.domain.comment.exception;
+
+import com.tavemakers.surf.global.common.exception.BaseException;
+
+public class CommentDepthExceedException extends BaseException {
+    public CommentDepthExceedException() {
+        super(ErrorMessage.COMMENT_DEPTH_EXCEEDED.getStatus(), ErrorMessage.COMMENT_DEPTH_EXCEEDED.getMessage());
+    }
+}

--- a/src/main/java/com/tavemakers/surf/domain/comment/exception/CommentNotFoundException.java
+++ b/src/main/java/com/tavemakers/surf/domain/comment/exception/CommentNotFoundException.java
@@ -1,0 +1,11 @@
+package com.tavemakers.surf.domain.comment.exception;
+
+import com.tavemakers.surf.global.common.exception.BaseException;
+
+import static com.tavemakers.surf.domain.comment.exception.ErrorMessage.COMMENT_NOT_FOUND;
+
+public class CommentNotFoundException extends BaseException {
+    public CommentNotFoundException() {
+        super(COMMENT_NOT_FOUND.getStatus(), COMMENT_NOT_FOUND.getMessage());
+    }
+}

--- a/src/main/java/com/tavemakers/surf/domain/comment/exception/ErrorMessage.java
+++ b/src/main/java/com/tavemakers/surf/domain/comment/exception/ErrorMessage.java
@@ -10,7 +10,8 @@ public enum ErrorMessage {
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 [댓글]입니다."),
     COMMENT_DEPTH_EXCEEDED(HttpStatus.BAD_REQUEST, "[댓글]의 최대 깊이(2)를 초과했습니다."),
     NOT_MY_COMMENT(HttpStatus.FORBIDDEN, "본인의 [댓글]이 아닙니다."),
-    INVALID_BLANK_COMMENT(HttpStatus.BAD_REQUEST, "[댓글] 내용은 공백일 수 없습니다.");
+    INVALID_BLANK_COMMENT(HttpStatus.BAD_REQUEST, "[댓글] 내용은 공백일 수 없습니다."),
+    ALREADY_DELETED_COMMENT(HttpStatus.BAD_REQUEST, "이미 삭제된 [댓글]입니다.");
 
 
 

--- a/src/main/java/com/tavemakers/surf/domain/comment/exception/ErrorMessage.java
+++ b/src/main/java/com/tavemakers/surf/domain/comment/exception/ErrorMessage.java
@@ -1,0 +1,19 @@
+package com.tavemakers.surf.domain.comment.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorMessage {
+    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 [댓글]입니다."),
+    COMMENT_DEPTH_EXCEEDED(HttpStatus.BAD_REQUEST, "[댓글]의 최대 깊이(2)를 초과했습니다."),
+    NOT_MY_COMMENT(HttpStatus.FORBIDDEN, "본인의 [댓글]이 아닙니다."),
+
+
+
+    private final HttpStatus status;
+    private final String message;
+
+}

--- a/src/main/java/com/tavemakers/surf/domain/comment/exception/ErrorMessage.java
+++ b/src/main/java/com/tavemakers/surf/domain/comment/exception/ErrorMessage.java
@@ -9,7 +9,7 @@ import org.springframework.http.HttpStatus;
 public enum ErrorMessage {
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 [댓글]입니다."),
     COMMENT_DEPTH_EXCEEDED(HttpStatus.BAD_REQUEST, "[댓글]의 최대 깊이(2)를 초과했습니다."),
-    NOT_MY_COMMENT(HttpStatus.FORBIDDEN, "본인의 [댓글]이 아닙니다."),
+    NOT_MY_COMMENT(HttpStatus.FORBIDDEN, "본인의 [댓글]이 아닙니다.");
 
 
 

--- a/src/main/java/com/tavemakers/surf/domain/comment/exception/ErrorMessage.java
+++ b/src/main/java/com/tavemakers/surf/domain/comment/exception/ErrorMessage.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 public enum ErrorMessage {
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 [댓글]입니다."),
     COMMENT_DEPTH_EXCEEDED(HttpStatus.BAD_REQUEST, "[댓글]의 최대 깊이(2)를 초과했습니다."),
-    NOT_MY_COMMENT(HttpStatus.FORBIDDEN, "본인의 [댓글]이 아닙니다.");
+    NOT_MY_COMMENT(HttpStatus.FORBIDDEN, "본인의 [댓글]이 아닙니다."),
+    INVALID_BLANK_COMMENT(HttpStatus.BAD_REQUEST, "[댓글] 내용은 공백일 수 없습니다.");
 
 
 

--- a/src/main/java/com/tavemakers/surf/domain/comment/exception/ErrorMessage.java
+++ b/src/main/java/com/tavemakers/surf/domain/comment/exception/ErrorMessage.java
@@ -13,8 +13,6 @@ public enum ErrorMessage {
     INVALID_BLANK_COMMENT(HttpStatus.BAD_REQUEST, "[댓글] 내용은 공백일 수 없습니다."),
     ALREADY_DELETED_COMMENT(HttpStatus.BAD_REQUEST, "이미 삭제된 [댓글]입니다.");
 
-
-
     private final HttpStatus status;
     private final String message;
 

--- a/src/main/java/com/tavemakers/surf/domain/comment/exception/InvalidBlankCommentException.java
+++ b/src/main/java/com/tavemakers/surf/domain/comment/exception/InvalidBlankCommentException.java
@@ -1,0 +1,11 @@
+package com.tavemakers.surf.domain.comment.exception;
+
+import com.tavemakers.surf.global.common.exception.BaseException;
+
+import static com.tavemakers.surf.domain.comment.exception.ErrorMessage.INVALID_BLANK_COMMENT;
+
+public class InvalidBlankCommentException extends BaseException {
+    public InvalidBlankCommentException() {
+        super(INVALID_BLANK_COMMENT.getStatus(), INVALID_BLANK_COMMENT.getMessage());
+    }
+}

--- a/src/main/java/com/tavemakers/surf/domain/comment/exception/NotMyCommentException.java
+++ b/src/main/java/com/tavemakers/surf/domain/comment/exception/NotMyCommentException.java
@@ -1,0 +1,9 @@
+package com.tavemakers.surf.domain.comment.exception;
+
+import com.tavemakers.surf.global.common.exception.BaseException;
+
+public class NotMyCommentException extends BaseException {
+    public NotMyCommentException() {
+        super(ErrorMessage.NOT_MY_COMMENT.getStatus(), ErrorMessage.NOT_MY_COMMENT.getMessage());
+    }
+}

--- a/src/main/java/com/tavemakers/surf/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/tavemakers/surf/domain/comment/repository/CommentRepository.java
@@ -7,6 +7,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
+    boolean existsByParentId(Long parentId);
+
     long deleteByIdAndPostIdAndMemberId(Long id, Long postId, Long memberId);
 
     Slice<Comment> findByPostId(Long postId, Pageable pageable);

--- a/src/main/java/com/tavemakers/surf/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/tavemakers/surf/domain/comment/repository/CommentRepository.java
@@ -1,0 +1,13 @@
+package com.tavemakers.surf.domain.comment.repository;
+
+import com.tavemakers.surf.domain.comment.entity.Comment;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+    long deleteByIdAndPostIdAndMemberId(Long id, Long postId, Long memberId);
+
+    Slice<Comment> findByPostId(Long postId, Pageable pageable);
+}

--- a/src/main/java/com/tavemakers/surf/domain/comment/service/CommentService.java
+++ b/src/main/java/com/tavemakers/surf/domain/comment/service/CommentService.java
@@ -6,6 +6,7 @@ import com.tavemakers.surf.domain.comment.dto.res.CommentResDTO;
 import com.tavemakers.surf.domain.comment.entity.Comment;
 import com.tavemakers.surf.domain.comment.exception.CommentDepthExceedException;
 import com.tavemakers.surf.domain.comment.exception.CommentNotFoundException;
+import com.tavemakers.surf.domain.comment.exception.InvalidBlankCommentException;
 import com.tavemakers.surf.domain.comment.exception.NotMyCommentException;
 import com.tavemakers.surf.domain.comment.repository.CommentRepository;
 import com.tavemakers.surf.domain.member.entity.Member;
@@ -32,6 +33,9 @@ public class CommentService {
     public CommentResDTO createComment(Long postId, Long memberId, CommentCreateReqDTO req) {
         Post post = postRepository.findById(postId).orElseThrow(PostNotFoundException::new);
         Member member = memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
+        if (req.content() == null || req.content().isEmpty()) {
+            throw new InvalidBlankCommentException();
+        }
 
         Comment saved;
         if (req.parentId() == null) {
@@ -62,6 +66,9 @@ public class CommentService {
         Comment comment = commentRepository.findById(commentId).orElseThrow(CommentNotFoundException::new);
         if (!comment.getPost().getId().equals(postId) || !comment.getMember().getId().equals(memberId)) {
             throw new NotMyCommentException();
+        }
+        if (req.content() == null || req.content().isEmpty()) {
+            throw new InvalidBlankCommentException();
         }
         comment.update(req.content());
 

--- a/src/main/java/com/tavemakers/surf/domain/comment/service/CommentService.java
+++ b/src/main/java/com/tavemakers/surf/domain/comment/service/CommentService.java
@@ -1,0 +1,85 @@
+package com.tavemakers.surf.domain.comment.service;
+
+import com.tavemakers.surf.domain.comment.dto.req.CommentCreateReqDTO;
+import com.tavemakers.surf.domain.comment.dto.req.CommentUpdateReqDTO;
+import com.tavemakers.surf.domain.comment.dto.res.CommentResDTO;
+import com.tavemakers.surf.domain.comment.entity.Comment;
+import com.tavemakers.surf.domain.comment.exception.CommentDepthExceedException;
+import com.tavemakers.surf.domain.comment.exception.CommentNotFoundException;
+import com.tavemakers.surf.domain.comment.exception.NotMyCommentException;
+import com.tavemakers.surf.domain.comment.repository.CommentRepository;
+import com.tavemakers.surf.domain.member.entity.Member;
+import com.tavemakers.surf.domain.member.exception.MemberNotFoundException;
+import com.tavemakers.surf.domain.member.repository.MemberRepository;
+import com.tavemakers.surf.domain.post.entity.Post;
+import com.tavemakers.surf.domain.post.exception.PostNotFoundException;
+import com.tavemakers.surf.domain.post.repository.PostRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CommentService {
+
+    private final CommentRepository commentRepository;
+    private final PostRepository postRepository;
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public CommentResDTO createComment(Long postId, Long memberId, CommentCreateReqDTO req) {
+        Post post = postRepository.findById(postId).orElseThrow(PostNotFoundException::new);
+        Member member = memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
+
+        Comment saved;
+        if (req.parentId() == null) {
+            // 루트 댓글
+            Comment comment = Comment.root(post, member, req.content());
+            saved = commentRepository.save(comment);
+            saved.markAsRoot();          // 저장 후 rootId = id
+        } else {
+            // 대댓글 (한 단계만 허용)
+            Comment parent = commentRepository.findById(req.parentId())
+                    .orElseThrow(CommentNotFoundException::new);
+            if (!parent.getPost().getId().equals(postId)) {
+                throw new CommentNotFoundException();
+            }
+            if (parent.getDepth() >= 1) {   // 루트(0) 아래 한 단계(1)까지만 허용
+                throw new CommentDepthExceedException();
+            }
+            Comment comment = Comment.child(post, member, req.content(), parent);
+            saved = commentRepository.save(comment);
+        }
+
+        post.increaseCommentCount();
+        return CommentResDTO.from(saved);
+    }
+
+    @Transactional
+    public CommentResDTO updateComment(Long postId, Long commentId, Long memberId, CommentUpdateReqDTO req) {
+        Comment comment = commentRepository.findById(commentId).orElseThrow(CommentNotFoundException::new);
+        if (!comment.getPost().getId().equals(postId) || !comment.getMember().getId().equals(memberId)) {
+            throw new NotMyCommentException();
+        }
+        comment.update(req.content());
+
+        return CommentResDTO.from(comment);
+    }
+
+    @Transactional
+    public void deleteComment(Long postId, Long commentId, Long memberId) {
+        long deleted = commentRepository.deleteByIdAndPostIdAndMemberId(commentId, postId, memberId);
+        if (deleted > 0) {
+            Post post = postRepository.findById(postId).orElseThrow(PostNotFoundException::new);
+            post.decreaseCommentCount();
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public Slice<CommentResDTO> getComments(Long postId, Pageable pageable) {
+        return commentRepository.findByPostId(postId, pageable)
+                .map(CommentResDTO::from);
+    }
+}

--- a/src/main/java/com/tavemakers/surf/domain/feedback/controller/FeedbackController.java
+++ b/src/main/java/com/tavemakers/surf/domain/feedback/controller/FeedbackController.java
@@ -9,8 +9,8 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
@@ -43,11 +43,11 @@ public class FeedbackController {
     @Operation(summary = "피드백 조회", description = "운영진이 피드백을 조회합니다.")
     @GetMapping("/v1/admin/feedbacks")
     @PreAuthorize("hasAnyRole('ROOT','MANAGER','PRESIDENT')")
-    public ApiResponse<Page<FeedbackResDTO>> getFeedbacks(
+    public ApiResponse<Slice<FeedbackResDTO>> getFeedbacks(
             @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC)
             Pageable pageable
     ) {
-        Page<FeedbackResDTO> response = feedbackService.getFeedbacks(pageable);
+        Slice<FeedbackResDTO> response = feedbackService.getFeedbacks(pageable);
         return ApiResponse.response(HttpStatus.OK, FEEDBACK_READ.getMessage(), response);
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/feedback/repository/FeedbackRepository.java
+++ b/src/main/java/com/tavemakers/surf/domain/feedback/repository/FeedbackRepository.java
@@ -1,12 +1,12 @@
 package com.tavemakers.surf.domain.feedback.repository;
 
 import com.tavemakers.surf.domain.feedback.entity.Feedback;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface FeedbackRepository extends JpaRepository<Feedback, Long> {
     long countByWriterHash(String writerHash);
 
-    Page<Feedback> findAllByOrderByCreatedAtDesc(Pageable pageable);
+    Slice<Feedback> findAllByOrderByCreatedAtDesc(Pageable pageable);
 }

--- a/src/main/java/com/tavemakers/surf/domain/feedback/service/FeedbackService.java
+++ b/src/main/java/com/tavemakers/surf/domain/feedback/service/FeedbackService.java
@@ -6,8 +6,8 @@ import com.tavemakers.surf.domain.feedback.entity.Feedback;
 import com.tavemakers.surf.domain.feedback.exception.TooManyFeedbackException;
 import com.tavemakers.surf.domain.feedback.repository.FeedbackRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -40,7 +40,7 @@ public class FeedbackService {
         return FeedbackResDTO.from(saved);
     }
 
-    public Page<FeedbackResDTO> getFeedbacks(Pageable pageable) {
+    public Slice<FeedbackResDTO> getFeedbacks(Pageable pageable) {
         return feedbackRepository.findAllByOrderByCreatedAtDesc(pageable)
                 .map(FeedbackResDTO::from);
     }

--- a/src/main/java/com/tavemakers/surf/domain/post/controller/PostController.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/controller/PostController.java
@@ -12,6 +12,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
@@ -52,38 +53,38 @@ public class PostController {
     /** 내가 작성한 게시글 목록 */
     @Operation(summary = "내가 작성한 게시글", description = "본인이 작성한 게시글 목록을 조회합니다.")
     @GetMapping("/v1/user/posts/me")
-    public ApiResponse<Page<PostResDTO>> getMyPosts(
+    public ApiResponse<Slice<PostResDTO>> getMyPosts(
             @PageableDefault(size = 12, sort = "postedAt", direction = Sort.Direction.DESC)
             Pageable pageable
     ) {
         Long me = SecurityUtils.getCurrentMemberId();
-        Page<PostResDTO> response = postService.getMyPosts(me, pageable);
+        Slice<PostResDTO> response = postService.getMyPosts(me, pageable);
         return ApiResponse.response(HttpStatus.OK, MY_POSTS_READ.getMessage(), response);
     }
 
     /** 특정 작성자의 게시글 목록 (뷰어 = 현재 로그인 사용자) */
     @Operation(summary = "특정 작성자의 게시글 목록", description = "특정 작성자가 작성한 게시글 목록을 조회합니다.")
     @GetMapping("/v1/user/posts/author/{authorId}")
-    public ApiResponse<Page<PostResDTO>> getPostsByMember(
+    public ApiResponse<Slice<PostResDTO>> getPostsByMember(
             @PathVariable (name = "authorId") Long authorId,
             @PageableDefault(size = 12, sort = "postedAt", direction = Sort.Direction.DESC)
             Pageable pageable
     ) {
         Long viewerId = SecurityUtils.getCurrentMemberId();
-        Page<PostResDTO> response = postService.getPostsByMember(authorId, viewerId, pageable);
+        Slice<PostResDTO> response = postService.getPostsByMember(authorId, viewerId, pageable);
         return ApiResponse.response(HttpStatus.OK, POSTS_BY_MEMBER_READ.getMessage(), response);
     }
 
     /** 게시판별 게시글 목록 (뷰어 = 현재 로그인 사용자) */
     @Operation(summary = "게시판별 게시글 목록", description = "특정 게시판에 속한 게시글 목록을 조회합니다.")
     @GetMapping("/v1/user/posts/board/{boardId}")
-    public ApiResponse<Page<PostResDTO>> getPostsByBoard(
+    public ApiResponse<Slice<PostResDTO>> getPostsByBoard(
             @PathVariable(name = "boardId") Long boardId,
             @PageableDefault(size = 12, sort = "postedAt", direction = Sort.Direction.DESC)
             Pageable pageable
     ) {
         Long viewerId = SecurityUtils.getCurrentMemberId();
-        Page<PostResDTO> response = postService.getPostsByBoard(boardId, viewerId, pageable);
+        Slice<PostResDTO> response = postService.getPostsByBoard(boardId, viewerId, pageable);
         return ApiResponse.response(HttpStatus.OK, POSTS_BY_BOARD_READ.getMessage(), response);
     }
 

--- a/src/main/java/com/tavemakers/surf/domain/post/controller/PostController.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/controller/PostController.java
@@ -10,7 +10,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;

--- a/src/main/java/com/tavemakers/surf/domain/post/controller/PostController.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/controller/PostController.java
@@ -89,7 +89,7 @@ public class PostController {
 
     /** 게시글 수정 (작성자 검증은 서비스에서) */
     @Operation(summary = "게시글 수정", description = "본인이 작성한 게시글을 수정합니다.")
-    @PutMapping("/v1/user/posts/{postId}")
+    @PatchMapping("/v1/user/posts/{postId}")
     public ApiResponse<PostResDTO> updatePost(
             @PathVariable(name = "postId") Long postId,
             @Valid @RequestBody PostUpdateReqDTO req

--- a/src/main/java/com/tavemakers/surf/domain/post/controller/PostController.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/controller/PostController.java
@@ -42,7 +42,7 @@ public class PostController {
     @Operation(summary = "게시글 단건 조회", description = "특정 ID의 게시글을 조회합니다.")
     @GetMapping("/v1/user/posts/{postId}")
     public ApiResponse<PostResDTO> getPost(
-            @PathVariable Long postId
+            @PathVariable(name = "postId") Long postId
     ) {
         Long viewerId = SecurityUtils.getCurrentMemberId();
         PostResDTO response = postService.getPost(postId, viewerId);
@@ -63,9 +63,9 @@ public class PostController {
 
     /** 특정 작성자의 게시글 목록 (뷰어 = 현재 로그인 사용자) */
     @Operation(summary = "특정 작성자의 게시글 목록", description = "특정 작성자가 작성한 게시글 목록을 조회합니다.")
-    @GetMapping("/v1/user/posts/{authorId}/posts")
+    @GetMapping("/v1/user/posts/author/{authorId}")
     public ApiResponse<Page<PostResDTO>> getPostsByMember(
-            @PathVariable Long authorId,
+            @PathVariable (name = "authorId") Long authorId,
             @PageableDefault(size = 12, sort = "postedAt", direction = Sort.Direction.DESC)
             Pageable pageable
     ) {
@@ -76,9 +76,9 @@ public class PostController {
 
     /** 게시판별 게시글 목록 (뷰어 = 현재 로그인 사용자) */
     @Operation(summary = "게시판별 게시글 목록", description = "특정 게시판에 속한 게시글 목록을 조회합니다.")
-    @GetMapping("/v1/user/posts")
+    @GetMapping("/v1/user/posts/board/{boardId}")
     public ApiResponse<Page<PostResDTO>> getPostsByBoard(
-            @RequestParam Long boardId,
+            @PathVariable(name = "boardId") Long boardId,
             @PageableDefault(size = 12, sort = "postedAt", direction = Sort.Direction.DESC)
             Pageable pageable
     ) {
@@ -89,9 +89,9 @@ public class PostController {
 
     /** 게시글 수정 (작성자 검증은 서비스에서) */
     @Operation(summary = "게시글 수정", description = "본인이 작성한 게시글을 수정합니다.")
-    @PutMapping("/v1/user/posts{postId}")
+    @PutMapping("/v1/user/posts/{postId}")
     public ApiResponse<PostResDTO> updatePost(
-            @PathVariable Long postId,
+            @PathVariable(name = "postId") Long postId,
             @Valid @RequestBody PostUpdateReqDTO req
     ) {
         Long memberId = SecurityUtils.getCurrentMemberId();
@@ -102,7 +102,8 @@ public class PostController {
     /** 게시글 삭제 (작성자/권한 검증은 서비스에서) */
     @Operation(summary = "게시글 삭제", description = "본인이 작성한 게시글을 삭제합니다.")
     @DeleteMapping("/v1/user/posts/{postId}")
-    public ApiResponse<Void> deletePost(@PathVariable Long postId) {
+    public ApiResponse<Void> deletePost(
+            @PathVariable(name = "postId") Long postId) {
         postService.deletePost(postId);
         return ApiResponse.response(HttpStatus.NO_CONTENT, POST_DELETED.getMessage());
     }

--- a/src/main/java/com/tavemakers/surf/domain/post/controller/PostLikeController.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/controller/PostLikeController.java
@@ -1,0 +1,26 @@
+package com.tavemakers.surf.domain.post.controller;
+
+import com.tavemakers.surf.domain.post.service.PostLikeService;
+import com.tavemakers.surf.global.common.response.ApiResponse;
+import com.tavemakers.surf.global.util.SecurityUtils;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/user/posts/{postId}/like")
+public class PostLikeController {
+
+    private final PostLikeService postLikeService;
+
+    @PostMapping
+    public ApiResponse<LikeToggleRes> toggle(@PathVariable Long postId) {
+        Long memberId = SecurityUtils.getCurrentMemberId();
+        boolean liked = postLikeService.toggleLike(postId, memberId);
+        return ApiResponse.response(HttpStatus.OK, liked ? "좋아요" : "좋아요 취소",
+                new LikeToggleRes(liked));
+    }
+
+    public record LikeToggleRes(boolean liked) {}
+}

--- a/src/main/java/com/tavemakers/surf/domain/post/controller/PostLikeController.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/controller/PostLikeController.java
@@ -22,7 +22,7 @@ public class PostLikeController {
     private final PostLikeService postLikeService;
 
     @Operation(summary = "좋아요 설정", description = "이미 좋아요 상태여도 200(OK) 반환")
-    @PatchMapping("/v1/user/posts/{postId}/like")
+    @PostMapping("/v1/user/posts/{postId}/like")
     public ApiResponse<Void> like(@PathVariable Long postId) {
         Long memberId = SecurityUtils.getCurrentMemberId();
         postLikeService.like(postId, memberId);

--- a/src/main/java/com/tavemakers/surf/domain/post/controller/PostLikeController.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/controller/PostLikeController.java
@@ -9,13 +9,13 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/v1/user/posts/{postId}/like")
+@RequestMapping
 public class PostLikeController {
 
     private final PostLikeService postLikeService;
 
     @Operation(summary = "좋아요 설정", description = "이미 좋아요 상태여도 204(No Content) 반환")
-    @PutMapping
+    @PutMapping("/v1/user/posts/{postId}/like")
     public ResponseEntity<Void> like(@PathVariable Long postId) {
         Long memberId = SecurityUtils.getCurrentMemberId();
         postLikeService.like(postId, memberId);
@@ -23,7 +23,7 @@ public class PostLikeController {
     }
 
     @Operation(summary = "좋아요 해제", description = "이미 해제 상태여도 204(No Content) 반환")
-    @DeleteMapping
+    @DeleteMapping("/v1/user/posts/{postId}/like")
     public ResponseEntity<Void> unlike(@PathVariable Long postId) {
         Long memberId = SecurityUtils.getCurrentMemberId();
         postLikeService.unlike(postId, memberId);

--- a/src/main/java/com/tavemakers/surf/domain/post/controller/PostLikeController.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/controller/PostLikeController.java
@@ -1,10 +1,10 @@
 package com.tavemakers.surf.domain.post.controller;
 
 import com.tavemakers.surf.domain.post.service.PostLikeService;
-import com.tavemakers.surf.global.common.response.ApiResponse;
 import com.tavemakers.surf.global.util.SecurityUtils;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -14,13 +14,19 @@ public class PostLikeController {
 
     private final PostLikeService postLikeService;
 
-    @PostMapping
-    public ApiResponse<LikeToggleRes> toggle(@PathVariable Long postId) {
+    @Operation(summary = "좋아요 설정", description = "이미 좋아요 상태여도 204(No Content) 반환")
+    @PutMapping
+    public ResponseEntity<Void> like(@PathVariable Long postId) {
         Long memberId = SecurityUtils.getCurrentMemberId();
-        boolean liked = postLikeService.toggleLike(postId, memberId);
-        return ApiResponse.response(HttpStatus.OK, liked ? "좋아요" : "좋아요 취소",
-                new LikeToggleRes(liked));
+        postLikeService.like(postId, memberId);
+        return ResponseEntity.noContent().build();
     }
 
-    public record LikeToggleRes(boolean liked) {}
+    @Operation(summary = "좋아요 해제", description = "이미 해제 상태여도 204(No Content) 반환")
+    @DeleteMapping
+    public ResponseEntity<Void> unlike(@PathVariable Long postId) {
+        Long memberId = SecurityUtils.getCurrentMemberId();
+        postLikeService.unlike(postId, memberId);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/tavemakers/surf/domain/post/controller/PostLikeController.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/controller/PostLikeController.java
@@ -22,7 +22,7 @@ public class PostLikeController {
     private final PostLikeService postLikeService;
 
     @Operation(summary = "좋아요 설정", description = "이미 좋아요 상태여도 204(No Content) 반환")
-    @PutMapping("/v1/user/posts/{postId}/like")
+    @PatchMapping("/v1/user/posts/{postId}/like")
     public ApiResponse<Void> like(@PathVariable Long postId) {
         Long memberId = SecurityUtils.getCurrentMemberId();
         postLikeService.like(postId, memberId);

--- a/src/main/java/com/tavemakers/surf/domain/post/controller/PostLikeController.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/controller/PostLikeController.java
@@ -4,6 +4,7 @@ import com.tavemakers.surf.domain.post.service.PostLikeService;
 import com.tavemakers.surf.global.common.response.ApiResponse;
 import com.tavemakers.surf.global.util.SecurityUtils;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -15,6 +16,7 @@ import static com.tavemakers.surf.domain.post.controller.ResponseMessage.POST_LI
 @RestController
 @RequiredArgsConstructor
 @RequestMapping
+@Tag(name = "게시물 좋아요", description = "게시물 좋아요 기능 관련 API")
 public class PostLikeController {
 
     private final PostLikeService postLikeService;

--- a/src/main/java/com/tavemakers/surf/domain/post/controller/PostLikeController.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/controller/PostLikeController.java
@@ -1,11 +1,16 @@
 package com.tavemakers.surf.domain.post.controller;
 
 import com.tavemakers.surf.domain.post.service.PostLikeService;
+import com.tavemakers.surf.global.common.response.ApiResponse;
 import com.tavemakers.surf.global.util.SecurityUtils;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import static com.tavemakers.surf.domain.post.controller.ResponseMessage.POST_LIKE_CREATED;
+import static com.tavemakers.surf.domain.post.controller.ResponseMessage.POST_LIKE_DELETED;
 
 @RestController
 @RequiredArgsConstructor
@@ -16,17 +21,17 @@ public class PostLikeController {
 
     @Operation(summary = "좋아요 설정", description = "이미 좋아요 상태여도 204(No Content) 반환")
     @PutMapping("/v1/user/posts/{postId}/like")
-    public ResponseEntity<Void> like(@PathVariable Long postId) {
+    public ApiResponse<Void> like(@PathVariable Long postId) {
         Long memberId = SecurityUtils.getCurrentMemberId();
         postLikeService.like(postId, memberId);
-        return ResponseEntity.noContent().build();
+        return ApiResponse.response(HttpStatus.OK, POST_LIKE_CREATED.getMessage());
     }
 
     @Operation(summary = "좋아요 해제", description = "이미 해제 상태여도 204(No Content) 반환")
     @DeleteMapping("/v1/user/posts/{postId}/like")
-    public ResponseEntity<Void> unlike(@PathVariable Long postId) {
+    public ApiResponse<Void> unlike(@PathVariable Long postId) {
         Long memberId = SecurityUtils.getCurrentMemberId();
         postLikeService.unlike(postId, memberId);
-        return ResponseEntity.noContent().build();
+        return ApiResponse.response(HttpStatus.NO_CONTENT, POST_LIKE_DELETED.getMessage());
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/post/controller/PostLikeController.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/controller/PostLikeController.java
@@ -21,7 +21,7 @@ public class PostLikeController {
 
     private final PostLikeService postLikeService;
 
-    @Operation(summary = "좋아요 설정", description = "이미 좋아요 상태여도 204(No Content) 반환")
+    @Operation(summary = "좋아요 설정", description = "이미 좋아요 상태여도 200(OK) 반환")
     @PatchMapping("/v1/user/posts/{postId}/like")
     public ApiResponse<Void> like(@PathVariable Long postId) {
         Long memberId = SecurityUtils.getCurrentMemberId();
@@ -29,7 +29,7 @@ public class PostLikeController {
         return ApiResponse.response(HttpStatus.OK, POST_LIKE_CREATED.getMessage());
     }
 
-    @Operation(summary = "좋아요 해제", description = "이미 해제 상태여도 204(No Content) 반환")
+    @Operation(summary = "좋아요 해제", description = "이미 좋아요 해제 상태여도 204(NO_CONTENT) 반환")
     @DeleteMapping("/v1/user/posts/{postId}/like")
     public ApiResponse<Void> unlike(@PathVariable Long postId) {
         Long memberId = SecurityUtils.getCurrentMemberId();

--- a/src/main/java/com/tavemakers/surf/domain/post/controller/ResponseMessage.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/controller/ResponseMessage.java
@@ -13,7 +13,10 @@ public enum ResponseMessage {
     POST_READ("[게시글]이 성공적으로 조회되었습니다."),
     MY_POSTS_READ("내가 작성한 [게시글] 목록을 성공적으로 조회했습니다."),
     POSTS_BY_BOARD_READ("[게시판]별 [게시글] 목록을 성공적으로 조회했습니다."),
-    POSTS_BY_MEMBER_READ("특정 회원이 작성한 [게시글] 목록을 성공적으로 조회했습니다.");
+    POSTS_BY_MEMBER_READ("특정 회원이 작성한 [게시글] 목록을 성공적으로 조회했습니다."),
+
+    POST_LIKE_CREATED("[게시글] 좋아요가 성공적으로 추가되었습니다."),
+    POST_LIKE_DELETED("[게시글] 좋아요가 성공적으로 취소되었습니다.");
 
     private final String message;
 

--- a/src/main/java/com/tavemakers/surf/domain/post/dto/req/PostCreateReqDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/dto/req/PostCreateReqDTO.java
@@ -19,9 +19,6 @@ public record PostCreateReqDTO(
         @NotBlank String content,
 
         @Schema(description = "게시글 상단 고정 여부", example = "true")
-        Boolean pinned,
-
-        @Schema(description = "게시글 작성 일시", example = "2023-10-05T14:48:00")
-        LocalDateTime postedAt
+        Boolean pinned
 ) {
 }

--- a/src/main/java/com/tavemakers/surf/domain/post/dto/res/PostResDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/dto/res/PostResDTO.java
@@ -30,7 +30,10 @@ public record PostResDTO(
         boolean scrappedByMe,
 
         @Schema(description = "게시글이 스크랩된 수", example = "10")
-        long scrapCount
+        long scrapCount,
+
+        @Schema(description = "게시글 작성자 닉네임", example = "홍길동")
+        String nickname
 ) {
     public static PostResDTO from(Post post, boolean scrappedByMe) {
         return new PostResDTO(
@@ -41,7 +44,9 @@ public record PostResDTO(
                 post.getPostedAt(),
                 post.getBoard().getId(),
                 scrappedByMe,
-                post.getScrapCount()
+                post.getScrapCount(),
+                post.getMember().getName()
+
         );
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/post/dto/res/PostResDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/dto/res/PostResDTO.java
@@ -38,6 +38,9 @@ public record PostResDTO(
         @Schema(description = "게시글이 좋아요된 수", example = "5")
         long likeCount,
 
+        @Schema(description = "게시글 댓글 수", example = "0")
+        long commentCount,
+
         @Schema(description = "게시글 작성자 닉네임", example = "홍길동")
         String nickname
 ) {
@@ -53,8 +56,8 @@ public record PostResDTO(
                 post.getScrapCount(),
                 likedByMe,
                 post.getLikeCount(),
+                post.getCommentCount(),
                 post.getMember().getName()
-
         );
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/post/dto/res/PostResDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/dto/res/PostResDTO.java
@@ -32,10 +32,16 @@ public record PostResDTO(
         @Schema(description = "게시글이 스크랩된 수", example = "10")
         long scrapCount,
 
+        @Schema(description = "내가 좋아요한 게시글인지 여부", example = "true")
+        boolean likedByMe,
+
+        @Schema(description = "게시글이 좋아요된 수", example = "5")
+        long likeCount,
+
         @Schema(description = "게시글 작성자 닉네임", example = "홍길동")
         String nickname
 ) {
-    public static PostResDTO from(Post post, boolean scrappedByMe) {
+    public static PostResDTO from(Post post, boolean scrappedByMe, boolean likedByMe) {
         return new PostResDTO(
                 post.getId(),
                 post.getTitle(),
@@ -45,6 +51,8 @@ public record PostResDTO(
                 post.getBoard().getId(),
                 scrappedByMe,
                 post.getScrapCount(),
+                likedByMe,
+                post.getLikeCount(),
                 post.getMember().getName()
 
         );

--- a/src/main/java/com/tavemakers/surf/domain/post/entity/Post.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/entity/Post.java
@@ -85,9 +85,6 @@ public class Post extends BaseEntity {
         this.board = board;
     }
 
-    public void increaseLikeCount() { this.likeCount++; }
-    public void decreaseLikeCount() { if (this.likeCount > 0) this.likeCount--; }
-
     public void increaseCommentCount() { this.commentCount++; }
     public void decreaseCommentCount() { if (this.commentCount > 0) this.commentCount--; }
 }

--- a/src/main/java/com/tavemakers/surf/domain/post/entity/Post.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/entity/Post.java
@@ -36,6 +36,8 @@ public class Post extends BaseEntity {
     @Column(nullable = false)
     private long scrapCount = 0L;
 
+    private long likeCount = 0L;
+
     @Version
     private Long version;
 
@@ -76,4 +78,7 @@ public class Post extends BaseEntity {
         this.pinned = req.pinned() != null ? req.pinned() : this.pinned;
         this.board = board;
     }
+
+    public void increaseLikeCount() { this.likeCount++; }
+    public void decreaseLikeCount() { if (this.likeCount > 0) this.likeCount--; }
 }

--- a/src/main/java/com/tavemakers/surf/domain/post/entity/Post.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/entity/Post.java
@@ -69,7 +69,7 @@ public class Post extends BaseEntity {
                 .title(req.title())
                 .content(req.content())
                 .pinned(req.pinned() != null ? req.pinned() : false)
-                .postedAt(req.postedAt() != null ? req.postedAt() : LocalDateTime.now())
+                .postedAt(LocalDateTime.now())
                 .board(board)
                 .member(member)
                 .scrapCount(0L)

--- a/src/main/java/com/tavemakers/surf/domain/post/entity/Post.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/entity/Post.java
@@ -38,6 +38,8 @@ public class Post extends BaseEntity {
 
     private long likeCount = 0L;
 
+    private long commentCount = 0L;
+
     @Version
     private Long version;
 
@@ -50,12 +52,13 @@ public class Post extends BaseEntity {
     private Member member;
 
     @Builder
-    private Post(String title, String content, boolean pinned, long scrapCount, long likeCount, LocalDateTime postedAt, Board board, Member member) {
+    private Post(String title, String content, boolean pinned, long scrapCount, long likeCount, long commentCount, LocalDateTime postedAt, Board board, Member member) {
         this.title = title;
         this.content = content;
         this.pinned = pinned;
         this.scrapCount = scrapCount;
         this.likeCount = likeCount;
+        this.commentCount = commentCount;
         this.postedAt = postedAt;
         this.board = board;
         this.member = member;
@@ -71,6 +74,7 @@ public class Post extends BaseEntity {
                 .member(member)
                 .scrapCount(0L)
                 .likeCount(0L)
+                .commentCount(0L)
                 .build();
     }
 
@@ -83,4 +87,7 @@ public class Post extends BaseEntity {
 
     public void increaseLikeCount() { this.likeCount++; }
     public void decreaseLikeCount() { if (this.likeCount > 0) this.likeCount--; }
+
+    public void increaseCommentCount() { this.commentCount++; }
+    public void decreaseCommentCount() { if (this.commentCount > 0) this.commentCount--; }
 }

--- a/src/main/java/com/tavemakers/surf/domain/post/entity/Post.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/entity/Post.java
@@ -50,11 +50,12 @@ public class Post extends BaseEntity {
     private Member member;
 
     @Builder
-    private Post(String title, String content, boolean pinned, long scrapCount, LocalDateTime postedAt, Board board, Member member) {
+    private Post(String title, String content, boolean pinned, long scrapCount, long likeCount, LocalDateTime postedAt, Board board, Member member) {
         this.title = title;
         this.content = content;
         this.pinned = pinned;
         this.scrapCount = scrapCount;
+        this.likeCount = likeCount;
         this.postedAt = postedAt;
         this.board = board;
         this.member = member;
@@ -69,6 +70,7 @@ public class Post extends BaseEntity {
                 .board(board)
                 .member(member)
                 .scrapCount(0L)
+                .likeCount(0L)
                 .build();
     }
 

--- a/src/main/java/com/tavemakers/surf/domain/post/entity/PostLike.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/entity/PostLike.java
@@ -11,6 +11,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(uniqueConstraints = @UniqueConstraint(columnNames = {"post_id","member_id"}))
 public class PostLike extends BaseEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/tavemakers/surf/domain/post/entity/PostLike.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/entity/PostLike.java
@@ -1,0 +1,39 @@
+package com.tavemakers.surf.domain.post.entity;
+
+import com.tavemakers.surf.domain.member.entity.Member;
+import com.tavemakers.surf.global.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PostLike extends BaseEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "post_id", nullable = false)
+    private Post post;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Builder
+    private PostLike(Post post, Member member) {
+        this.post = post;
+        this.member = member;
+    }
+
+    public static PostLike of(Post post, Member member) {
+        return PostLike.builder()
+                .post(post)
+                .member(member)
+                .build();
+    }
+}

--- a/src/main/java/com/tavemakers/surf/domain/post/repository/PostLikeRepository.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/repository/PostLikeRepository.java
@@ -2,14 +2,26 @@ package com.tavemakers.surf.domain.post.repository;
 
 import com.tavemakers.surf.domain.post.entity.PostLike;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
 public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
 
     boolean existsByPostIdAndMemberId(Long postId, Long memberId);
 
-    Optional<PostLike> findByPostIdAndMemberId(Long postId, Long memberId);
 
-    long countByPostId(Long postId);
+    @Query("select pl.post.id " +
+            "from PostLike pl " +
+            "where pl.member.id = :memberId " +
+            "and pl.post.id in :postIds")
+    List<Long> findLikedPostIdsByMemberAndPostIds(
+            @Param("memberId") Long memberId,
+            @Param("postIds") Collection<Long> postIds
+    );
+
+    long deleteByPostIdAndMemberId(Long postId, Long memberId);
 }

--- a/src/main/java/com/tavemakers/surf/domain/post/repository/PostLikeRepository.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/repository/PostLikeRepository.java
@@ -1,0 +1,15 @@
+package com.tavemakers.surf.domain.post.repository;
+
+import com.tavemakers.surf.domain.post.entity.PostLike;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
+
+    boolean existsByPostIdAndMemberId(Long postId, Long memberId);
+
+    Optional<PostLike> findByPostIdAndMemberId(Long postId, Long memberId);
+
+    long countByPostId(Long postId);
+}

--- a/src/main/java/com/tavemakers/surf/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/repository/PostRepository.java
@@ -1,7 +1,6 @@
 package com.tavemakers.surf.domain.post.repository;
 
 import com.tavemakers.surf.domain.post.entity.Post;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/src/main/java/com/tavemakers/surf/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/repository/PostRepository.java
@@ -3,15 +3,16 @@ package com.tavemakers.surf.domain.post.repository;
 import com.tavemakers.surf.domain.post.entity.Post;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
-    Page<Post> findByBoardId(Long boardId, Pageable pageable);
+    Slice<Post> findByBoardId(Long boardId, Pageable pageable);
 
-    Page<Post> findByMemberId(Long memberId, Pageable pageable);
+    Slice<Post> findByMemberId(Long memberId, Pageable pageable);
 
     @Query("select p.version from Post p where p.id = :id")
     Long findVersionById(@Param("id") Long id);

--- a/src/main/java/com/tavemakers/surf/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/repository/PostRepository.java
@@ -25,4 +25,12 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     @Query("update Post p set p.scrapCount = p.scrapCount - 1, p.version = p.version + 1 " +
             "where p.id = :id and p.version = :version and p.scrapCount > 0")
     int decreaseScrapCount(@Param("id") Long id, @Param("version") Long version);
+
+    @Modifying
+    @Query("update Post p set p.likeCount = p.likeCount + 1 where p.id = :postId")
+    void increaseLikeCount(@Param("postId") Long postId);
+
+    @Modifying
+    @Query("update Post p set p.likeCount = case when p.likeCount > 0 then p.likeCount - 1 else 0 end where p.id = :postId")
+    void decreaseLikeCount(@Param("postId") Long postId);
 }

--- a/src/main/java/com/tavemakers/surf/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/repository/PostRepository.java
@@ -27,10 +27,12 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     int decreaseScrapCount(@Param("id") Long id, @Param("version") Long version);
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
-    @Query("update Post p set p.likeCount = p.likeCount + 1 where p.id = :postId")
-    void increaseLikeCount(@Param("postId") Long postId);
+    @Query("update Post p set p.likeCount = p.likeCount + 1, p.version = p.version + 1 " +
+            "where p.id = :id and p.version = :version")
+    int increaseLikeCount(@Param("postId") Long postId, @Param("version") Long version);
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
-    @Query("update Post p set p.likeCount = case when p.likeCount > 0 then p.likeCount - 1 else 0 end where p.id = :postId")
-    void decreaseLikeCount(@Param("postId") Long postId);
+    @Query("update Post p set p.likeCount = p.likeCount - 1, p.version   = p.version + 1" +
+            " where p.id = :id and p.version = :version and p.likeCount > 0")
+    int decreaseLikeCount(@Param("postId") Long postId, @Param("version") Long version);
 }

--- a/src/main/java/com/tavemakers/surf/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/repository/PostRepository.java
@@ -29,10 +29,10 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("update Post p set p.likeCount = p.likeCount + 1, p.version = p.version + 1 " +
             "where p.id = :id and p.version = :version")
-    int increaseLikeCount(@Param("postId") Long postId, @Param("version") Long version);
+    int increaseLikeCount(@Param("id") Long postId, @Param("version") Long version);
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("update Post p set p.likeCount = p.likeCount - 1, p.version   = p.version + 1" +
             " where p.id = :id and p.version = :version and p.likeCount > 0")
-    int decreaseLikeCount(@Param("postId") Long postId, @Param("version") Long version);
+    int decreaseLikeCount(@Param("id") Long postId, @Param("version") Long version);
 }

--- a/src/main/java/com/tavemakers/surf/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/repository/PostRepository.java
@@ -26,11 +26,11 @@ public interface PostRepository extends JpaRepository<Post, Long> {
             "where p.id = :id and p.version = :version and p.scrapCount > 0")
     int decreaseScrapCount(@Param("id") Long id, @Param("version") Long version);
 
-    @Modifying
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("update Post p set p.likeCount = p.likeCount + 1 where p.id = :postId")
     void increaseLikeCount(@Param("postId") Long postId);
 
-    @Modifying
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("update Post p set p.likeCount = case when p.likeCount > 0 then p.likeCount - 1 else 0 end where p.id = :postId")
     void decreaseLikeCount(@Param("postId") Long postId);
 }

--- a/src/main/java/com/tavemakers/surf/domain/post/service/PostLikeService.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/service/PostLikeService.java
@@ -1,0 +1,59 @@
+package com.tavemakers.surf.domain.post.service;
+
+import com.tavemakers.surf.domain.member.entity.Member;
+import com.tavemakers.surf.domain.member.exception.MemberNotFoundException;
+import com.tavemakers.surf.domain.member.repository.MemberRepository;
+import com.tavemakers.surf.domain.post.entity.Post;
+import com.tavemakers.surf.domain.post.entity.PostLike;
+import com.tavemakers.surf.domain.post.exception.PostNotFoundException;
+import com.tavemakers.surf.domain.post.repository.PostLikeRepository;
+import com.tavemakers.surf.domain.post.repository.PostRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PostLikeService {
+
+    private final PostRepository postRepository;
+    private final PostLikeRepository postLikeRepository;
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public boolean toggleLike(Long postId, Long memberId) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(PostNotFoundException::new);
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(MemberNotFoundException::new);
+
+        return postLikeRepository.findByPostIdAndMemberId(postId, memberId)
+                .map(existing -> {
+                    postLikeRepository.delete(existing);
+                    post.decreaseLikeCount();
+                    return false;                // 현재 상태: 좋아요 해제
+                })
+                .orElseGet(() -> {
+                    postLikeRepository.save(PostLike.of(post, member));
+                    post.increaseLikeCount();
+                    return true;                 // 현재 상태: 좋아요 추가
+                });
+    }
+
+    @Transactional(readOnly = true)
+    public boolean isLiked(Long postId, Long memberId) {
+        return postLikeRepository.existsByPostIdAndMemberId(postId, memberId);
+    }
+
+    @Transactional
+    public void like(Long postId, Long memberId) {
+        if (isLiked(postId, memberId)) return;
+        toggleLike(postId, memberId);
+    }
+
+    @Transactional
+    public void unlike(Long postId, Long memberId) {
+        if (!isLiked(postId, memberId)) return;
+        toggleLike(postId, memberId);
+    }
+}

--- a/src/main/java/com/tavemakers/surf/domain/post/service/PostLikeService.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/service/PostLikeService.java
@@ -52,7 +52,7 @@ public class PostLikeService {
     }
 
     @Transactional(readOnly = true)
-    public boolean isLikedByMe(Long postId, Long memberId) {
+    public boolean isLikedByMe(Long memberId, Long postId) {
         return postLikeRepository.existsByPostIdAndMemberId(postId, memberId);
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/post/service/PostLikeService.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/service/PostLikeService.java
@@ -34,7 +34,7 @@ public class PostLikeService {
 
         try {
             postLikeRepository.save(PostLike.of(post, member));
-            post.increaseLikeCount();
+            postRepository.increaseLikeCount(postId);
         } catch (DataIntegrityViolationException e) {
             // 이미 좋아요 되어 있으면 무시(멱등)
         }
@@ -47,7 +47,7 @@ public class PostLikeService {
         if (deleted > 0) {
             Post post = postRepository.findById(postId)
                     .orElseThrow(PostNotFoundException::new);
-            post.decreaseLikeCount();
+            postRepository.decreaseLikeCount(postId);
         }
     }
 

--- a/src/main/java/com/tavemakers/surf/domain/post/service/PostService.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/service/PostService.java
@@ -29,6 +29,7 @@ public class PostService {
     private final MemberRepository memberRepository;
 
     private final ScrapService scrapService;
+    private final PostLikeService postLikeService;
 
     @Transactional
     public PostResDTO createPost(PostCreateReqDTO req, Long memberId) {
@@ -41,7 +42,7 @@ public class PostService {
         Post post = Post.of(req, board, member);
         Post saved = postRepository.save(post);
 
-        return PostResDTO.from(saved, false);
+        return PostResDTO.from(saved, false, false);
     }
 
     @Transactional(readOnly = true)
@@ -50,8 +51,9 @@ public class PostService {
                 .orElseThrow(PostNotFoundException::new);
 
         boolean scrappedByMe = scrapService.isScrappedByMe(memberId, postId);
+        boolean likedByMe = postLikeService.isLikedByMe(memberId, postId);
 
-        return PostResDTO.from(post, scrappedByMe);
+        return PostResDTO.from(post, scrappedByMe, likedByMe);
     }
 
     @Transactional(readOnly = true)
@@ -62,7 +64,8 @@ public class PostService {
         Page<Post> page = postRepository.findByMemberId(myId, pageable);
         return page.map(p -> PostResDTO.from(
                 p,
-                scrapService.isScrappedByMe(myId, p.getId())
+                scrapService.isScrappedByMe(myId, p.getId()),
+                postLikeService.isLikedByMe(myId, p.getId())
         ));
     }
 
@@ -73,7 +76,8 @@ public class PostService {
         Page<Post> page = postRepository.findByMemberId(authorId, pageable);
         return page.map(p -> PostResDTO.from(
                 p,
-                scrapService.isScrappedByMe(viewerId, p.getId())
+                scrapService.isScrappedByMe(viewerId, p.getId()),
+                postLikeService.isLikedByMe(viewerId, p.getId())
         ));
     }
 
@@ -85,7 +89,8 @@ public class PostService {
         Page<Post> page = postRepository.findByBoardId(boardId, pageable);
         return page.map(p -> PostResDTO.from(
                 p,
-                scrapService.isScrappedByMe(viewerId, p.getId())
+                scrapService.isScrappedByMe(viewerId, p.getId()),
+                postLikeService.isLikedByMe(viewerId, p.getId())
         ));
     }
 
@@ -96,7 +101,8 @@ public class PostService {
 
         post.update(req, post.getBoard());
         boolean scrappedByMe = scrapService.isScrappedByMe(viewerId, postId);
-        return PostResDTO.from(post, scrappedByMe);
+        boolean likedByMe = postLikeService.isLikedByMe(viewerId, postId);
+        return PostResDTO.from(post, scrappedByMe, likedByMe);
     }
 
     @Transactional

--- a/src/main/java/com/tavemakers/surf/domain/post/service/PostService.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/service/PostService.java
@@ -14,7 +14,6 @@ import com.tavemakers.surf.domain.post.exception.PostNotFoundException;
 import com.tavemakers.surf.domain.post.repository.PostRepository;
 import com.tavemakers.surf.domain.scrap.service.ScrapService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/tavemakers/surf/domain/post/service/PostService.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/service/PostService.java
@@ -16,6 +16,7 @@ import com.tavemakers.surf.domain.scrap.service.ScrapService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -57,12 +58,12 @@ public class PostService {
     }
 
     @Transactional(readOnly = true)
-    public Page<PostResDTO> getMyPosts(Long myId, Pageable pageable) {
+    public Slice<PostResDTO> getMyPosts(Long myId, Pageable pageable) {
         if (!memberRepository.existsById(myId))
             throw new MemberNotFoundException();
 
-        Page<Post> page = postRepository.findByMemberId(myId, pageable);
-        return page.map(p -> PostResDTO.from(
+        Slice<Post> slice = postRepository.findByMemberId(myId, pageable);
+        return slice.map(p -> PostResDTO.from(
                 p,
                 scrapService.isScrappedByMe(myId, p.getId()),
                 postLikeService.isLikedByMe(myId, p.getId())
@@ -70,11 +71,11 @@ public class PostService {
     }
 
     @Transactional(readOnly = true)
-    public Page<PostResDTO> getPostsByMember(Long authorId, Long viewerId, Pageable pageable) {
+    public Slice<PostResDTO> getPostsByMember(Long authorId, Long viewerId, Pageable pageable) {
         if (!memberRepository.existsById(authorId)) throw new MemberNotFoundException();
 
-        Page<Post> page = postRepository.findByMemberId(authorId, pageable);
-        return page.map(p -> PostResDTO.from(
+        Slice<Post> slice = postRepository.findByMemberId(authorId, pageable);
+        return slice.map(p -> PostResDTO.from(
                 p,
                 scrapService.isScrappedByMe(viewerId, p.getId()),
                 postLikeService.isLikedByMe(viewerId, p.getId())
@@ -82,12 +83,12 @@ public class PostService {
     }
 
     @Transactional(readOnly = true)
-    public Page<PostResDTO> getPostsByBoard(Long boardId, Long viewerId, Pageable pageable) {
+    public Slice<PostResDTO> getPostsByBoard(Long boardId, Long viewerId, Pageable pageable) {
         if (!boardRepository.existsById(boardId)) {
             throw new BoardNotFoundException();
         }
-        Page<Post> page = postRepository.findByBoardId(boardId, pageable);
-        return page.map(p -> PostResDTO.from(
+        Slice<Post> slice = postRepository.findByBoardId(boardId, pageable);
+        return slice.map(p -> PostResDTO.from(
                 p,
                 scrapService.isScrappedByMe(viewerId, p.getId()),
                 postLikeService.isLikedByMe(viewerId, p.getId())

--- a/src/main/java/com/tavemakers/surf/domain/scrap/controller/ScrapController.java
+++ b/src/main/java/com/tavemakers/surf/domain/scrap/controller/ScrapController.java
@@ -47,7 +47,7 @@ public class ScrapController {
     @Operation(summary = "내가 스크랩한 게시글 목록", description = "본인이 스크랩한 게시글 목록을 조회합니다.")
     @GetMapping("/v1/user/scraps/me")
     public ApiResponse<Page<PostResDTO>> myScraps(
-            @PageableDefault(size = 12, sort = "postedAt", direction = Sort.Direction.DESC)
+            @PageableDefault(size = 12, sort = "createdAt", direction = Sort.Direction.DESC)
             Pageable pageable
     ) {
         Long me = SecurityUtils.getCurrentMemberId();

--- a/src/main/java/com/tavemakers/surf/domain/scrap/controller/ScrapController.java
+++ b/src/main/java/com/tavemakers/surf/domain/scrap/controller/ScrapController.java
@@ -7,12 +7,11 @@ import com.tavemakers.surf.global.util.SecurityUtils;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import static com.tavemakers.surf.domain.scrap.controller.ResponseMessage.*;
@@ -46,12 +45,12 @@ public class ScrapController {
     /** 내가 스크랩한 게시글 목록 */
     @Operation(summary = "내가 스크랩한 게시글 목록", description = "본인이 스크랩한 게시글 목록을 조회합니다.")
     @GetMapping("/v1/user/scraps/me")
-    public ApiResponse<Page<PostResDTO>> myScraps(
+    public ApiResponse<Slice<PostResDTO>> myScraps(
             @PageableDefault(size = 12, sort = "createdAt", direction = Sort.Direction.DESC)
             Pageable pageable
     ) {
         Long me = SecurityUtils.getCurrentMemberId();
-        Page<PostResDTO> response = scrapService.getMyScraps(me, pageable);
+        Slice<PostResDTO> response = scrapService.getMyScraps(me, pageable);
         return ApiResponse.response(HttpStatus.OK, MY_SCRAP_LIST_READ.getMessage(), response);
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/scrap/repository/ScrapRepository.java
+++ b/src/main/java/com/tavemakers/surf/domain/scrap/repository/ScrapRepository.java
@@ -2,8 +2,8 @@ package com.tavemakers.surf.domain.scrap.repository;
 
 import com.tavemakers.surf.domain.post.entity.Post;
 import com.tavemakers.surf.domain.scrap.entity.Scrap;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -21,12 +21,7 @@ public interface ScrapRepository extends JpaRepository<Scrap, Long> {
             from Scrap s
             where s.member.id = :memberId
             order by s.createdAt desc
-            """,
-            countQuery = """
-            select count(s)
-            from Scrap s
-            where s.member.id = :memberId
             """
     )
-    Page<Post> findPostsByMemberId(Long memberId, Pageable pageable);
+    Slice<Post> findPostsByMemberId(Long memberId, Pageable pageable);
 }

--- a/src/main/java/com/tavemakers/surf/domain/scrap/repository/ScrapRepository.java
+++ b/src/main/java/com/tavemakers/surf/domain/scrap/repository/ScrapRepository.java
@@ -20,6 +20,7 @@ public interface ScrapRepository extends JpaRepository<Scrap, Long> {
             select s.post
             from Scrap s
             where s.member.id = :memberId
+            order by s.createdAt desc
             """,
             countQuery = """
             select count(s)

--- a/src/main/java/com/tavemakers/surf/domain/scrap/service/ScrapService.java
+++ b/src/main/java/com/tavemakers/surf/domain/scrap/service/ScrapService.java
@@ -8,14 +8,13 @@ import com.tavemakers.surf.domain.post.entity.Post;
 import com.tavemakers.surf.domain.post.exception.PostNotFoundException;
 import com.tavemakers.surf.domain.post.repository.PostLikeRepository;
 import com.tavemakers.surf.domain.post.repository.PostRepository;
-import com.tavemakers.surf.domain.post.service.PostLikeService;
 import com.tavemakers.surf.domain.scrap.entity.Scrap;
 import com.tavemakers.surf.domain.scrap.repository.ScrapRepository;
 import jakarta.persistence.OptimisticLockException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -66,16 +65,16 @@ public class ScrapService {
         }
     }
 
-    public Page<PostResDTO> getMyScraps(Long memberId, Pageable pageable) {
-        Page<Post> page = scrapRepository.findPostsByMemberId(memberId, pageable);
+    public Slice<PostResDTO> getMyScraps(Long memberId, Pageable pageable) {
+        Slice<Post> slice = scrapRepository.findPostsByMemberId(memberId, pageable);
 
-        List<Long> postIds = page.getContent().stream()
+        List<Long> postIds = slice.getContent().stream()
                 .map(Post::getId)
                 .toList();
 
         Set<Long> likedIds = new HashSet<>(postLikeRepository.findLikedPostIdsByMemberAndPostIds(memberId, postIds));
 
-        return page.map(post ->
+        return slice.map(post ->
                 PostResDTO.from(post, true, likedIds.contains(post.getId()))
         );
     }


### PR DESCRIPTION
## 📄 작업 내용 요약

게시글 조회 시 작성자 이름, 좋아요 수, 댓글 수를 함께 반환합니다.

좋아요 수, 댓글 수를 반환하기 위해 좋아요 관련 api, 댓글 관련 api를 구현하였습니다.

대댓글의 깊이는 최대 2 (대댓글 1회 가능) 으로 설정하였습니다.

마찬가지로 아직 FACADE는 구현하지 않았습니다.

## 📎 Issue 번호
<!-- closed #98 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **뉴 기능**
  * 댓글 기능 추가: 작성/조회(페이징 → Slice)/수정/삭제, 1단계 대댓글, 권한·예외 처리.
  * 게시글 좋아요 추가: 좋아요/해제 API 및 응답에 내 좋아요 여부 반영.
  * 게시판 목록 조회 API 추가.

* **변경**
  * 목록 페이징 방식 Page → Slice로 통일(페이징 동작 변경).
  * 게시글 응답에 likeCount, commentCount, likedByMe, 작성자 닉네임 포함.
  * 게시글 생성 요청에서 postedAt 제거; 게시판 업데이트 시 이름 필수화.

* **문서**
  * Swagger 문서 강화 및 입력 검증(밸리데이션) 보강.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->