### PR TITLE
[CHORE] 로그인 및 회원가입 Swagger 수정

### DIFF
--- a/src/main/java/com/tavemakers/surf/domain/login/LoginResDto.java
+++ b/src/main/java/com/tavemakers/surf/domain/login/LoginResDto.java
@@ -1,17 +1,28 @@
 package com.tavemakers.surf.domain.login;
 
 import lombok.Builder;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 /**
  * 로그인 성공 시 프론트엔드로 내려주는 응답 DTO
  * - accessToken + 최소한의 사용자 정보만 포함
  * - refreshToken, expiresIn 은 제외 (보안 및 불필요 데이터 제거)
  */
+
+@Schema(description = "인가 코드(code)를 받아 JWT AccessToken과 사용자 정보를 반환합니다.")
 @Builder
 public record LoginResDto(
+
+        @Schema(description = "JWT Access Token", example = "abcdefg...jwt")
         String accessToken,
+
+        @Schema(description = "사용자 닉네임", example = "홍길동")
         String nickname,
+
+        @Schema(description = "사용자 이메일", example = "hong@example.com")
         String email,
+
+        @Schema(description = "프로필 이미지 URL", example = "https://k.kakaocdn.net/.../img_640x640.jpg")
         String profileImageUrl
 ) {
     /**

--- a/src/main/java/com/tavemakers/surf/domain/member/controller/AuthController.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/controller/AuthController.java
@@ -51,7 +51,9 @@ public class AuthController {
      *    - authCode → accessToken → userInfo 처리
      *    - refreshToken은 HttpOnly 쿠키로 전달
      */
-    @Operation(summary = "카카오 콜백")
+    @Operation(
+            summary = "카카오 로그인 콜백",
+            description = "인가 코드(code)를 받아 JWT AccessToken과 사용자 정보를 반환합니다.")
     @GetMapping("/login/oauth2/code/kakao")
     public Mono<ApiResponse<LoginResDto>> kakaoCallback(
             @RequestParam("code") String code,

--- a/src/main/java/com/tavemakers/surf/domain/member/controller/MemberController.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/controller/MemberController.java
@@ -16,14 +16,15 @@ import jakarta.validation.Valid;
 @RestController
 @RequestMapping
 @RequiredArgsConstructor
-@Tag(name = "서비스 내 자체 회원가입 관련")
+@Tag(name = "자체 회원가입 및 관리자 승인/거절")
 public class MemberController {
-
 
     private final MemberService memberService;
     private final MemberUsecase memberUsecase;
 
-    @Operation(summary = "자체 회원가입 온보딩")
+    @Operation(
+            summary = "자체 회원가입 온보딩",
+            description = "카카오 로그인 후 추가 정보를 입력하여 회원가입을 완료합니다.")
     @PostMapping("/v1/user/members/signup")
     public ApiResponse<MemberSignupResDTO> signup(@Valid @RequestBody MemberSignupReqDTO request) {
         return ApiResponse.response(
@@ -33,7 +34,9 @@ public class MemberController {
             );
     }
 
-    @Operation(summary = "온보딩(추가 정보 입력) 필요 여부 확인", description = "카카오 ID로 회원을 조회하여 추가 정보 입력이 필요한 상태인지 확인합니다.")
+    @Operation(
+            summary = "온보딩(추가 정보 입력) 필요 여부 확인",
+            description = "카카오 ID로 회원을 조회하여 추가 정보 입력이 필요한 상태인지 확인합니다.")
     @GetMapping("/v1/user/members/valid-status")
     public ApiResponse<Boolean> checkOnboardingStatus(
             ) {
@@ -44,7 +47,9 @@ public class MemberController {
         );
     }
 
-    @Operation(summary = "회원 가입 승인")
+    @Operation(
+            summary = "회원가입 승인",
+            description = "관리자가 회원의 회원가입을 승인합니다.")
     @PatchMapping("/v1/admin/members/{memberId}/approve")
     public ApiResponse<Void> approveMember(@PathVariable Long memberId) {
         memberService.approveMember(memberId);
@@ -55,7 +60,9 @@ public class MemberController {
         );
     }
 
-    @Operation(summary = "회원 가입 거절")
+    @Operation(
+            summary = "회원가입 거절",
+            description = "관리자가 회원의 회원가입을 거절합니다.")
     @PatchMapping("/v1/admin/members/{memberId}/reject")
     public ApiResponse<Void> rejectMember(@PathVariable Long memberId) {
         memberService.rejectMember(memberId);

--- a/src/main/java/com/tavemakers/surf/domain/member/controller/MemberController.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/controller/MemberController.java
@@ -14,7 +14,6 @@ import org.springframework.web.bind.annotation.*;
 import jakarta.validation.Valid;
 
 @RestController
-@RequestMapping
 @RequiredArgsConstructor
 @Tag(name = "자체 회원가입 및 관리자 승인/거절")
 public class MemberController {

--- a/src/main/java/com/tavemakers/surf/domain/member/dto/request/MemberSignupReqDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/dto/request/MemberSignupReqDTO.java
@@ -1,5 +1,6 @@
 package com.tavemakers.surf.domain.member.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import lombok.Getter;
 import jakarta.validation.constraints.*;
@@ -10,14 +11,18 @@ import lombok.Setter;
 
 @Getter
 @Valid
+@Schema(description = "회원가입 요청 DTO")
 public class MemberSignupReqDTO {
 
+    @Schema(description = "프로필 이미지 URL", example = "https://example.com/profile.jpg")
     private String profileImageUrl;
 
+    @Schema(description = "이름", example = "홍길동")
     @NotBlank(message = "이름은 필수 입력값입니다.")
     private String name;
 
     // ==== 트랙 정보 (기수 + 파트) ====
+    @Schema(description = "트랙 정보 리스트 (기수 + 파트)")
     @NotEmpty(message = "트랙 정보는 최소 1개 이상 필요합니다.")
     @jakarta.validation.Valid
     private List<TrackInfo> tracks;
@@ -25,24 +30,32 @@ public class MemberSignupReqDTO {
     @Getter
     @Setter
     @NoArgsConstructor
+    @Schema(description = "트랙 정보 DTO")
     public static class TrackInfo {
+
+        @Schema(description = "기수", example = "15")
         @NotNull(message = "기수는 필수 입력값입니다.")
         private Integer generation;
 
+        @Schema(description = "파트", example = "BACKEND")
         @NotNull(message = "파트는 필수 입력값입니다.")
         private Part part;
     }
 
+    @Schema(description = "대학교", example = "서울과학기술대학교")
     @NotBlank(message = "대학교는 필수 입력값입니다.")
     private String university;
 
+    @Schema(description = "대학원 (선택)", example = "서울과학기술대학교 대학원")
     private String graduateSchool; // 선택(대학원)
 
+    @Schema(description = "이메일", example = "honggildong@example.com")
     @Email(message = "올바른 이메일 형식을 입력하세요.")
     @NotBlank(message = "이메일은 필수 입력값입니다.")
     private String email;
 
+    @Schema(description = "전화번호", example = "01012345678")
     @NotBlank(message = "전화번호는 필수 입력값입니다.")
     @Pattern(regexp = "^[0-9]{10,11}$", message = "전화번호 형식이 올바르지 않습니다.")
-    private String phoneNumber; // 전화번호를 하이픈 써서 받을지 안 써서 받을지?
+    private String phoneNumber;
 }

--- a/src/main/java/com/tavemakers/surf/domain/member/dto/response/MemberSignupResDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/dto/response/MemberSignupResDTO.java
@@ -1,5 +1,6 @@
 package com.tavemakers.surf.domain.member.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import com.tavemakers.surf.domain.member.entity.Member;
@@ -9,17 +10,29 @@ import java.util.List;
 @Getter
 @AllArgsConstructor
 public class MemberSignupResDTO {
+
+    @Schema(description = "회원 ID", example = "1")
     private Long memberId;
 
+    @Schema(description = "프로필 이미지 URL", example = "https://example.com/profile.jpg")
     private String profileImageUrl;
+
+    @Schema(description = "이름", example = "홍길동")
     private String name;
 
+    @Schema(description = "트랙 정보 리스트")
     private List<TrackResDTO> tracks;
 
+    @Schema(description = "대학교", example = "서울과학기술대학교")
     private String university;
+
+    @Schema(description = "대학원", example = "서울과학기술대학교 대학원")
     private String graduateSchool;
 
+    @Schema(description = "이메일", example = "honggildong@example.com")
     private String email;
+
+    @Schema(description = "전화번호", example = "01012345678")
     private String phoneNumber;
 
     // 정적 팩토리 메서드

--- a/src/main/java/com/tavemakers/surf/domain/member/dto/response/TrackResDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/dto/response/TrackResDTO.java
@@ -2,10 +2,15 @@ package com.tavemakers.surf.domain.member.dto.response;
 
 import com.tavemakers.surf.domain.member.entity.Track;
 import lombok.Builder;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 @Builder
 public record TrackResDTO(
+
+        @Schema(description = "기수", example = "15")
         Integer generation,
+
+        @Schema(description = "파트 이름", example = "BACKEND")
         String part
 ) {
     public static TrackResDTO from(Track track) {


### PR DESCRIPTION
## 📄 작업 내용 요약
- LoginResDto, MemberSignupReqDTO, MemberSignupResDTO, TrackResDTO에 Swagger @Schema 어노테이션 추가 (설명과 예시 값 명시)
- AuthController에 Swagger 설명 추가
- MemberController에 Tag 및 Swagger 설명 수정

## 📎 Issue 번호
closed #99

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* 문서화
  * API 문서 보강: 요청/응답 스키마에 필드별 설명·예시 추가로 Swagger/OpenAPI 문서 가독성 향상.
  * 엔드포인트 설명 보완: 카카오 로그인 콜백, 회원가입·상태 확인·관리자 승인·거절 관련 설명과 태그를 명확화.
  * Swagger UI 및 개발자 포털에서 탐색성과 이해도 개선. 런타임 동작에는 영향 없음.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->