### PR TITLE
[Feat] 프로필 조회 Dto에 활동여부 추가

### DIFF
--- a/src/main/java/com/tavemakers/surf/domain/member/dto/response/MyPageProfileResDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/dto/response/MyPageProfileResDTO.java
@@ -15,6 +15,7 @@ public record MyPageProfileResDTO(
         String graduateSchool,
         String role,
         BigDecimal activityScore,
+        boolean isActive,
         List<TrackResDTO> trackList,
         List<CareerResDTO> careerList
 ) {
@@ -28,6 +29,7 @@ public record MyPageProfileResDTO(
                 .graduateSchool(member.getGraduateSchool())
                 .role(member.getRole().name())
                 .activityScore(activityScore)
+                .isActive((member.isActivityStatus()))
                 .trackList(trackList)
                 .careerList(careerList)
                 .build();


### PR DESCRIPTION
## 📄 작업 내용 요약
프로필 조회 Dto에 활동여부 추가

## 응답 JSON 예시

```json
{
    "code": 200,
    "message": "본인 마이페이지에서 [프로필 정보]를 조회합니다.",
    "data": {
        "username": "홍길동",
        "phoneNumber": "010-1234-1234",
        "email": "test01@gmail.com",
        "university": "가천대학교",
        "graduateSchool": null,
        "role": "MANAGER",
        "activityScore": 135.0,
        "isActive": true,  // 추가
        "trackList": [
            {
                "generation": 13,
                "part": "백엔드"
            },
            {
                "generation": 16,
                "part": "디자인"
            }
        ],
        "careerList": [
            {
                "careerId": 3,
                "companyName": "KT Cloud 서류합격제발",
                "position": "사원",
                "startDate": "2025-01",
                "endDate": null,
                "isWorking": false
            },
            {
                "careerId": 4,
                "companyName": "KT Cloud 서류합격제발",
                "position": "사원",
                "startDate": "2025-01",
                "endDate": null,
                "isWorking": false
            }
        ]
    }
}
```

## 📎 Issue 번호
<!-- closed #번호 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 마이페이지 프로필에 활동 상태 표시가 추가되었습니다. 사용자는 프로필에서 활성/비활성 여부를 한눈에 확인할 수 있습니다.
  - 프로필 조회 시 활동 상태가 함께 제공되어, 자신의 현재 활동 상태를 더 명확하게 파악할 수 있습니다.
  - 해당 정보는 앱 전반의 프로필 표시 영역에서도 일관되게 반영됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->