### PR TITLE
[Hotfix] 토큰 발급 시 Role Prefix 추가

### DIFF
--- a/src/main/java/com/tavemakers/surf/global/jwt/JwtServiceImpl.java
+++ b/src/main/java/com/tavemakers/surf/global/jwt/JwtServiceImpl.java
@@ -25,6 +25,7 @@ public class JwtServiceImpl implements JwtService {
     private static final String AUTH_HEADER = "Authorization";
     private static final String BEARER_PREFIX = "Bearer ";
     private static final String REFRESH_COOKIE_NAME = "refreshToken";
+    private static final String ROLE_PREFIX = "ROLE_";
 
     @Value("${jwt.secret}")
     private String jwtSecret;
@@ -50,7 +51,7 @@ public class JwtServiceImpl implements JwtService {
         Date now = new Date();
         return Jwts.builder()
                 .setSubject(String.valueOf(memberId))
-                .claim("role", role)
+                .claim("role", ROLE_PREFIX+role)
                 .setIssuedAt(now)
                 .setExpiration(new Date(now.getTime() + accessTokenExpireMs))
                 .signWith(secretKey, SignatureAlgorithm.HS256)


### PR DESCRIPTION
## 📄 작업 내용 요약
토큰 ROle PREFIX 설정 추가

## 설명
securityConfig에서 hasAnyRole을 사용해서 엔드포인트에따른 인가 작업을 수행하고 있습니다.
hasAnyRole은 `ROLE_` 접두사가 자동으로 추가되어 검증하므로 토큰 발급 시 권한에 `ROLE_`을 추가해주도록 변경했습니다.

## 📎 Issue #108
<!-- closed #108 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 버그 수정
  * 액세스 토큰의 역할 정보에 표준 접두사를 적용하여 권한 인식 불일치로 인한 오류를 방지했습니다. 인증/인가 시스템과의 호환성이 개선되고, 로그인 및 권한 기반 화면/기능 접근의 안정성이 향상됩니다. 기존 토큰은 계속 유효하나, 새로 발급되는 토큰에서 일관된 역할 형식을 보장합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->