### PR TITLE
[Feat] 상태 체크 필드 추가

### DIFF
--- a/src/main/java/com/tavemakers/surf/domain/member/controller/MemberController.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/controller/MemberController.java
@@ -2,6 +2,7 @@ package com.tavemakers.surf.domain.member.controller;
 
 import com.tavemakers.surf.domain.member.dto.request.MemberSignupReqDTO;
 import com.tavemakers.surf.domain.member.dto.response.MemberSignupResDTO;
+import com.tavemakers.surf.domain.member.dto.response.OnboardingCheckResDTO;
 import com.tavemakers.surf.domain.member.usecase.MemberAdminUsecase;
 import com.tavemakers.surf.domain.member.usecase.MemberUsecase;
 import com.tavemakers.surf.global.common.response.ApiResponse;
@@ -19,7 +20,6 @@ import jakarta.validation.Valid;
 @Tag(name = "자체 회원가입 및 관리자 승인/거절")
 public class MemberController {
 
-    private final MemberService memberService;
     private final MemberUsecase memberUsecase;
     private final MemberAdminUsecase memberAdminUsecase;
 
@@ -39,7 +39,7 @@ public class MemberController {
             summary = "온보딩(추가 정보 입력) 필요 여부 확인",
             description = "카카오 ID로 회원을 조회하여 추가 정보 입력이 필요한 상태인지 확인합니다.")
     @GetMapping("/v1/user/members/valid-status")
-    public ApiResponse<Boolean> checkOnboardingStatus(
+    public ApiResponse<OnboardingCheckResDTO> checkOnboardingStatus(
             ) {
         return ApiResponse.response(
                 HttpStatus.OK,

--- a/src/main/java/com/tavemakers/surf/domain/member/dto/response/OnboardingCheckResDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/dto/response/OnboardingCheckResDTO.java
@@ -1,0 +1,18 @@
+package com.tavemakers.surf.domain.member.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public class OnboardingCheckResDTO {
+
+    public Long memberId;
+    public Boolean needOnboarding;
+    public Boolean isApproved;
+
+    public static OnboardingCheckResDTO of(Long memberId, Boolean needOnboarding, Boolean isApproved) {
+        return OnboardingCheckResDTO.builder()
+                .memberId(memberId)
+                .needOnboarding(needOnboarding)
+                .isApproved(isApproved).build();
+    }
+}

--- a/src/main/java/com/tavemakers/surf/domain/member/dto/response/OnboardingCheckResDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/dto/response/OnboardingCheckResDTO.java
@@ -1,5 +1,6 @@
 package com.tavemakers.surf.domain.member.dto.response;
 
+import com.tavemakers.surf.domain.member.entity.enums.MemberStatus;
 import lombok.Builder;
 
 @Builder
@@ -7,12 +8,12 @@ public class OnboardingCheckResDTO {
 
     public Long memberId;
     public Boolean needOnboarding;
-    public Boolean isApproved;
+    public MemberStatus memberStatus;
 
-    public static OnboardingCheckResDTO of(Long memberId, Boolean needOnboarding, Boolean isApproved) {
+    public static OnboardingCheckResDTO of(Long memberId, Boolean needOnboarding, MemberStatus memberStatus) {
         return OnboardingCheckResDTO.builder()
                 .memberId(memberId)
                 .needOnboarding(needOnboarding)
-                .isApproved(isApproved).build();
+                .memberStatus(memberStatus).build();
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/service/MemberServiceImpl.java
@@ -17,9 +17,6 @@ import java.util.Locale;
 @RequiredArgsConstructor
 public class MemberServiceImpl implements MemberService {
 
-    private final MemberGetService memberGetService;
-    private final MemberRepository memberRepository;
-
     //추가 정보 입력 회원가입
     @Transactional
     public MemberSignupResDTO signup(Member member, MemberSignupReqDTO request) {
@@ -51,9 +48,12 @@ public class MemberServiceImpl implements MemberService {
     //추가 정보 회원가입 온보딩 필요 여부 확인
     @Transactional
     public Boolean needsOnboarding(Member member) {
-        if(member.getStatus().equals(MemberStatus.REGISTERING)) {
-            return true;
-        }else
-            return false;
+        return member.getStatus().equals(MemberStatus.REGISTERING);
+    }
+
+    //회원 승인 여부 체크
+    @Transactional
+    public MemberStatus memberStatusCheck(Member member) {
+        return member.getStatus();
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/member/usecase/MemberUsecase.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/usecase/MemberUsecase.java
@@ -123,9 +123,11 @@ public class MemberUsecase {
 
     //온보딩 필요 여부 확인
     @Transactional
-    public Boolean needsOnboarding(Long memberId) {
+    public OnboardingCheckResDTO needsOnboarding(Long memberId) {
         Member member = memberGetService.getMember(memberId);
-        return memberServiceImpl.needsOnboarding(member);
+        Boolean needsOnboarding = memberServiceImpl.needsOnboarding(member);
+        MemberStatus memberStatus = memberServiceImpl.memberStatusCheck(member);
+        return OnboardingCheckResDTO.of(memberId, needsOnboarding, memberStatus);
     }
 
     //회원가입


### PR DESCRIPTION
## 📄 작업 내용 요약
기존 : 카카오 로그인 후 온보딩 필요여부에 대해서만 값을 반환
수정 : 온보딩 필요여부와 멤버 id, 멤버 상태까지 포함

```java
{
  "code": 200,
  "message": "[회원]의 추가 회원가입 정보 입력 필요 여부를 확인했습니다.",
  "data": {
    "memberId": 1,
    "needOnboarding": false,
    "memberStatus": "APPROVED"
  }
}
```




## 📎 Issue 번호 110
closed #110 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 새 기능
  - 온보딩 상태 확인 API가 기존의 단순 불리언 대신 상세 정보 객체를 반환합니다. 반환값에 온보딩 필요 여부, 회원 ID, 현재 회원 상태가 포함되어 한 번의 호출로 필요한 정보를 모두 확인할 수 있습니다.
- 리팩터링
  - 내부 의존성을 정리하고 로직을 단순화하여 응답 구조를 일관되게 개선했습니다. 이를 통해 클라이언트 연동 시 해석과 처리 과정이 더 명확해집니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->