### PR TITLE
[Feat] Logback 설정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@ application.properties
 .idea/libraries/
 .idea/*
 .idea
-
+logs/*
 *.iws
 *.iml
 *.ipr

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -58,9 +58,9 @@ dependencies {
 }
 
 // log4j2 사용을 위해 추가
-configurations.all {
-    exclude(group = "org.springframework.boot", module = "spring-boot-starter-logging")
-}
+//configurations.all {
+//    exclude(group = "org.springframework.boot", module = "spring-boot-starter-logging")
+//}
 
 tasks.test {
     useJUnitPlatform()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,6 +36,9 @@ dependencies {
     // .env 자동 로딩
     implementation("me.paulschwarz:spring-dotenv:3.0.0")
 
+    // Spring AOP
+    implementation("org.springframework.boot:spring-boot-starter-aop")
+
     compileOnly("org.projectlombok:lombok")
     annotationProcessor("org.projectlombok:lombok")
 
@@ -54,6 +57,10 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-redis")
 }
 
+// log4j2 사용을 위해 추가
+configurations.all {
+    exclude(group = "org.springframework.boot", module = "spring-boot-starter-logging")
+}
 
 tasks.test {
     useJUnitPlatform()

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,45 @@
+<configuration>
+
+    <property name="LOG_FILE" value="logs/application.log"/>
+    <springProperty name="ACTIVE_PROFILE_NAME" source="spring.profiles.active" defaultValue="default"/>
+    <property name="DEFAULT_PATTERN" value="%d{yyyy-MM-dd HH:mm:ss} [${ACTIVE_PROFILE_NAME}] %-5level [%thread] %logger{36} - %msg%n"/>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>${DEFAULT_PATTERN}</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOG_FILE}</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>logs/application.%d{yyyy-MM-dd}.log</fileNamePattern>
+            <maxHistory>30</maxHistory>
+        </rollingPolicy>
+        <encoder>
+            <pattern>${DEFAULT_PATTERN}</pattern>
+        </encoder>
+    </appender>
+
+    <springProfile name="local">
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
+            <appender-ref ref="FILE"/>
+        </root>
+    </springProfile>
+
+    <springProfile name="dev">
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
+            <appender-ref ref="FILE"/>
+        </root>
+    </springProfile>
+
+    <springProfile name="default">
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
+            <appender-ref ref="FILE"/>
+        </root>
+    </springProfile>
+
+</configuration>


### PR DESCRIPTION
## 📄 작업 내용 요약

## Logback 설정
로그 관리를 위해 Logback.xml 파일을 설정합니다.

## RollingFileAppender
RollingFileAppender를 사용하면 어떤 기준으로 로그 파일을 만들 수 있습니다.   
여기서 기준은 주로 `날짜`나 `시간`입니다.
- ex 하루마다, 6시간마다, 1시간마다

```xml
        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
            <fileNamePattern>logs/application.%d{yyyy-MM-dd}.log</fileNamePattern>
            <maxHistory>30</maxHistory>
        </rollingPolicy>
```

fileNamePattern에서 기준을 `yyyy-MM-dd`로 설정했기 때문에, `하루`를 기준으로 로그 파일이 생겨납니다.
```
// 오늘이 10월 4일이라면
application.2025-10-01.log
application.2025-10-02.log
application.2025-10-03.log
application.log // 당일
```


## 📎 Issue 번호
<!-- closed #번호 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 콘솔과 파일(logs/)로 출력되는 구조화된 로깅을 도입했습니다. 일별 롤링과 보존 기간을 적용하고, 실행 프로필에 따라 일관된 로그 형식을 제공합니다.
- Chores
  - 생성된 로그 파일이 버전 관리에 포함되지 않도록 무시 규칙을 추가했습니다.
  - 빌드 설정을 업데이트해 런타임 기능 확장의 기반을 마련했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->