### PR TITLE
[FIX] Logevent의 로그 메시지가 반영되지 않는 문제 해결

### DIFF
--- a/src/main/java/com/tavemakers/surf/domain/board/service/BoardService.java
+++ b/src/main/java/com/tavemakers/surf/domain/board/service/BoardService.java
@@ -21,7 +21,7 @@ public class BoardService {
     private final BoardRepository boardRepository;
 
     @Transactional
-    @LogEvent("board.create")
+    @LogEvent(value = "board.create", message = "게시판 생성 성공")
     public BoardResDTO createBoard(BoardCreateReqDTO req) {
         Board board = Board.of(req);
         Board saved = boardRepository.save(board);
@@ -40,7 +40,7 @@ public class BoardService {
     }
 
     @Transactional
-    @LogEvent("board.update")
+    @LogEvent(value = "board.update", message = "게시판 수정 성공")
     public BoardResDTO updateBoard(
             @LogParam("board_id") Long id,
             BoardUpdateReqDTO req) {
@@ -51,7 +51,7 @@ public class BoardService {
     }
 
     @Transactional
-    @LogEvent("board.delete")
+    @LogEvent(value = "board.delete", message = "게시판 삭제 성공")
     public void deleteBoard(
             @LogParam("board_id") Long id) {
         if (!boardRepository.existsById(id)) throw new BoardNotFoundException();

--- a/src/main/java/com/tavemakers/surf/domain/comment/service/CommentService.java
+++ b/src/main/java/com/tavemakers/surf/domain/comment/service/CommentService.java
@@ -32,7 +32,7 @@ public class CommentService {
     private final MemberRepository memberRepository;
 
     @Transactional
-    @LogEvent("comment.create")
+    @LogEvent(value = "comment.create", message = "댓글 생성 성공")
     public CommentResDTO createComment(
             @LogParam("post_id") Long postId,
             Long memberId, CommentCreateReqDTO req) {
@@ -68,7 +68,7 @@ public class CommentService {
     }
 
     @Transactional
-    @LogEvent("comment.delete")
+    @LogEvent(value = "comment.delete", message = "댓글 삭제 성공")
     public void deleteComment(
             @LogParam("post_id")
             Long postId,

--- a/src/main/java/com/tavemakers/surf/domain/feedback/service/FeedbackService.java
+++ b/src/main/java/com/tavemakers/surf/domain/feedback/service/FeedbackService.java
@@ -25,7 +25,7 @@ public class FeedbackService {
     private static final int DAILY_LIMIT = 3; // 하루 최대 3회
 
     @Transactional
-    @LogEvent("feedback.create")
+    @LogEvent(value = "feedback.create", message = "피드백 생성 성공")
     public FeedbackResDTO createFeedback(FeedbackCreateReqDTO req, Long memberId) {
         String writerHash = writerHashService.hashDaily(memberId, LocalDate.now());
         long todayCount = feedbackRepository.countByWriterHash(writerHash);

--- a/src/main/java/com/tavemakers/surf/domain/post/service/PostLikeService.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/service/PostLikeService.java
@@ -25,7 +25,7 @@ public class PostLikeService {
     private final MemberRepository memberRepository;
 
     @Transactional
-    @LogEvent("post.like")
+    @LogEvent(value = "post.like", message = "게시물 좋아요 성공")
     public void like(
             @LogParam("post_id") Long postId,
             @LogParam("user_id") Long memberId) {
@@ -54,7 +54,7 @@ public class PostLikeService {
     }
 
     @Transactional
-    @LogEvent("post.unlike")
+    @LogEvent(value = "post.unlike", message = "게시물 좋아요 해제 성공")
     public void unlike(
             @LogParam("post_id")
             Long postId,

--- a/src/main/java/com/tavemakers/surf/domain/post/service/PostService.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/service/PostService.java
@@ -35,7 +35,7 @@ public class PostService {
     private final PostLikeService postLikeService;
 
     @Transactional
-    @LogEvent("post.create")
+    @LogEvent(value= "post.create", message= "게시글 생성 성공")
     public PostResDTO createPost(PostCreateReqDTO req, Long memberId) {
         Board board = boardRepository.findById(req.boardId())
                 .orElseThrow(BoardNotFoundException::new);
@@ -89,7 +89,7 @@ public class PostService {
     }
 
     @Transactional
-    @LogEvent("post.update")
+    @LogEvent(value = "post.update", message = "게시글 수정 성공")
     public PostResDTO updatePost(
             @LogParam("post_id") Long postId,
             PostUpdateReqDTO req, Long viewerId) {
@@ -102,7 +102,7 @@ public class PostService {
     }
 
     @Transactional
-    @LogEvent("post.delete")
+    @LogEvent(value = "post.delete", message = "게시글 삭제 성공")
     public void deletePost(
             @LogParam("post_id") Long postId) {
         if (!postRepository.existsById(postId)) throw new PostNotFoundException();

--- a/src/main/java/com/tavemakers/surf/domain/scrap/service/ScrapService.java
+++ b/src/main/java/com/tavemakers/surf/domain/scrap/service/ScrapService.java
@@ -35,7 +35,7 @@ public class ScrapService {
     private final PostLikeRepository postLikeRepository;
 
     @Transactional
-    @LogEvent("scrap.add")
+    @LogEvent(value = "scrap.add", message = "스크랩 추가 성공")
     public void addScrap(
             @LogParam("user_id") Long memberId,
             @LogParam("post_id") Long postId) {
@@ -58,7 +58,7 @@ public class ScrapService {
     }
 
     @Transactional
-    @LogEvent("scrap.remove")
+    @LogEvent(value = "scrap.remove", message = "스크랩 삭제 성공")
     public void removeScrap(
             @LogParam("user_id") Long memberId,
             @LogParam("post_id") Long postId) {

--- a/src/main/java/com/tavemakers/surf/global/logging/LogEventAspect.java
+++ b/src/main/java/com/tavemakers/surf/global/logging/LogEventAspect.java
@@ -55,9 +55,7 @@ public class LogEventAspect {
         } catch (Exception ex) {
             // ✅ 4. 실패 로그 emit
             Map<String, Object> fail = new HashMap<>(props);
-            fail.put("error_code", ex.getClass().getSimpleName());
-            fail.put("error_msg", ex.getMessage());
-            emitter.emitError(event, fail, msg != null ? msg : "AOP captured exception");
+            emitter.emitError(event, fail, msg != null ? ex.getMessage() : "AOP captured exception");
             throw ex;
         }
     }

--- a/src/main/java/com/tavemakers/surf/global/logging/LogEventAspect.java
+++ b/src/main/java/com/tavemakers/surf/global/logging/LogEventAspect.java
@@ -46,7 +46,11 @@ public class LogEventAspect {
             enrichWithReturn(props, ret);
 
             // ✅ 3. 성공 로그 emit
-            emitter.emit(event, props);
+            if (msg == null || msg.isBlank()) {
+                emitter.emit(event, props);
+            } else {
+                emitter.emit(event, props, msg);
+            }
             return ret;
         } catch (Exception ex) {
             // ✅ 4. 실패 로그 emit

--- a/src/main/java/com/tavemakers/surf/global/logging/LogEventEmitter.java
+++ b/src/main/java/com/tavemakers/surf/global/logging/LogEventEmitter.java
@@ -4,6 +4,11 @@ package com.tavemakers.surf.global.logging;
 import java.util.Map;
 
 public interface LogEventEmitter {
-    void emit(String event, Map<String, Object> props);                   // 성공 이벤트
+    void emit(String event, Map<String, Object> props, String message);
+
+    default void emit(String event, Map<String, Object> props) {
+        String defaultMsg = "이벤트명: " + event; // ✅ 기본 메시지 자동 포함
+        emit(event, props, defaultMsg);
+    }
     void emitError(String event, Map<String, Object> props, String msg);  // 실패 이벤트
 }

--- a/src/main/java/com/tavemakers/surf/global/logging/LogEventEmitterImpl.java
+++ b/src/main/java/com/tavemakers/surf/global/logging/LogEventEmitterImpl.java
@@ -22,13 +22,14 @@ public class LogEventEmitterImpl implements LogEventEmitter {
 
     /** 성공 이벤트 적재 (요청 컨텍스트에 쌓아두고, 출력은 필터에서 flush) */
     @Override
-    public void emit(String event, Map<String, Object> props) {
+    public void emit(String event, Map<String, Object> props, String message) {
         RequestLogContext ctx = RequestLogContext.get();
 
         Map<String, Object> e = new HashMap<>();
         e.put("event", event);
         e.put("event_type", "INFO");
-        // message는 성공 시 보통 없음 -> null이면 키 자체를 생략
+        if (message != null && !message.isBlank())
+            e.put("message", message);
         e.put("props", props != null ? props : Collections.emptyMap());
 
         ctx.events.add(e);


### PR DESCRIPTION
## 📄 작업 내용 요약
기존의 LogEmitter에는 메시지가 담기는 emit 가 구현되어 있지 않아서 api 호출 실패시에만 로그 메시지가 출력되었습니다.
처음 설계대로 @LogEvent의 파라미터를 사용해서 호출 성공 시에도 로그 메시지가 제대로 담길 수 있도록 emit 를 추가 구현하였습니다.

```
void emit(String event, Map<String, Object> props, String message);
default void emit(String event, Map<String, Object> props) {
    String defaultMsg = "이벤트명: " + event; // ✅ 기본 메시지 자동 포함
    emit(event, props, defaultMsg);
}
```
이제 @LogEvent 어노테이션 사용 시 value와 message를 작성하면 로그에 정상적으로 출력됩니다.
추가적으로 호출 실패시에도 코드 상 존재하는 커스텀 에러 메시지가 로그에 출력되도록 수정하였는데 이 부분은 우선 참고 후 추후 회의 시에 어떻게 출력할지 정하는게 좋을 것 같습니다.

## 📎 Issue 번호
<!-- closed #118  -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **운영 개선**
  * 로깅 시스템 인프라 강화 및 메시지 처리 최적화 수행.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->