### PR TITLE
[Feat] 게시글 예약 기능 구현

### DIFF
--- a/src/main/java/com/tavemakers/surf/domain/post/dto/req/PostCreateReqDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/dto/req/PostCreateReqDTO.java
@@ -2,6 +2,7 @@ package com.tavemakers.surf.domain.post.dto.req;
 
 import com.tavemakers.surf.global.logging.LogPropsProvider;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Future;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
@@ -24,6 +25,7 @@ public record PostCreateReqDTO(
         Boolean pinned,
 
         @Schema(description = "예약 시간", example = "2025-10-29T00:00:00")
+        @Future(message = "예약 시간은 현재 이후여야 합니다")
         LocalDateTime reservedAt
 
 ) implements LogPropsProvider {

--- a/src/main/java/com/tavemakers/surf/domain/post/dto/req/PostCreateReqDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/dto/req/PostCreateReqDTO.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
+import java.time.LocalDateTime;
 import java.util.Map;
 
 @Schema(description = "게시글 생성 요청 DTO")
@@ -20,7 +21,11 @@ public record PostCreateReqDTO(
         @NotBlank String content,
 
         @Schema(description = "게시글 상단 고정 여부", example = "true")
-        Boolean pinned
+        Boolean pinned,
+
+        @Schema(description = "예약 시간", example = "2025-10-29T00:00:00")
+        LocalDateTime reservedAt
+
 ) implements LogPropsProvider {
 
         @Override
@@ -30,4 +35,9 @@ public record PostCreateReqDTO(
                         "title_length", title != null ? title.length() : 0
                 );
         }
+
+        public boolean isReserved() {
+                return reservedAt != null;
+        }
+
 }

--- a/src/main/java/com/tavemakers/surf/domain/post/entity/Post.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/entity/Post.java
@@ -8,14 +8,15 @@ import com.tavemakers.surf.global.common.entity.BaseEntity;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AccessLevel;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 import java.time.LocalDateTime;
 
 @Entity
 @Getter
+@SuperBuilder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Post extends BaseEntity {
 
@@ -42,9 +43,9 @@ public class Post extends BaseEntity {
     private long commentCount = 0L;
 
     @Version
-    private Long version;
+    private long version;
 
-    private LocalDateTime reservation;
+    private boolean isReserved;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "board_id", nullable = false)
@@ -53,19 +54,6 @@ public class Post extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
-
-    @Builder
-    private Post(String title, String content, boolean pinned, long scrapCount, long likeCount, long commentCount, LocalDateTime postedAt, Board board, Member member) {
-        this.title = title;
-        this.content = content;
-        this.pinned = pinned;
-        this.scrapCount = scrapCount;
-        this.likeCount = likeCount;
-        this.commentCount = commentCount;
-        this.postedAt = postedAt;
-        this.board = board;
-        this.member = member;
-    }
 
     public static Post of(PostCreateReqDTO req, Board board, Member member) {
         return Post.builder()
@@ -78,6 +66,7 @@ public class Post extends BaseEntity {
                 .scrapCount(0L)
                 .likeCount(0L)
                 .commentCount(0L)
+                .isReserved(req.isReserved())
                 .build();
     }
 
@@ -88,6 +77,16 @@ public class Post extends BaseEntity {
         this.board = board;
     }
 
-    public void increaseCommentCount() { this.commentCount++; }
-    public void decreaseCommentCount() { if (this.commentCount > 0) this.commentCount--; }
+    public void increaseCommentCount() {
+        this.commentCount++;
+    }
+
+    public void decreaseCommentCount() {
+        if (this.commentCount > 0) this.commentCount--;
+    }
+
+    public void publish() {
+        this.isReserved = false;
+    }
+
 }

--- a/src/main/java/com/tavemakers/surf/domain/post/exception/ErrorMessage.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/exception/ErrorMessage.java
@@ -7,7 +7,9 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum ErrorMessage {
-    POST_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 [게시글]입니다.");
+    POST_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 [게시글]입니다."),
+    POST_ALREADY_DELETED(HttpStatus.NOT_FOUND, "이미 삭제된 [게시글]입니다."),
+    ;
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/tavemakers/surf/domain/post/exception/PostAlreadyDeleteException.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/exception/PostAlreadyDeleteException.java
@@ -1,0 +1,11 @@
+package com.tavemakers.surf.domain.post.exception;
+
+import com.tavemakers.surf.global.common.exception.BaseException;
+
+import static com.tavemakers.surf.domain.post.exception.ErrorMessage.POST_ALREADY_DELETED;
+
+public class PostAlreadyDeleteException extends BaseException {
+    public PostAlreadyDeleteException() {
+        super(POST_ALREADY_DELETED.getStatus(), POST_ALREADY_DELETED.getMessage());
+    }
+}

--- a/src/main/java/com/tavemakers/surf/domain/post/exception/PostAlreadyDeletedException.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/exception/PostAlreadyDeletedException.java
@@ -4,8 +4,8 @@ import com.tavemakers.surf.global.common.exception.BaseException;
 
 import static com.tavemakers.surf.domain.post.exception.ErrorMessage.POST_ALREADY_DELETED;
 
-public class PostAlreadyDeleteException extends BaseException {
-    public PostAlreadyDeleteException() {
+public class PostAlreadyDeletedException extends BaseException {
+    public PostAlreadyDeletedException() {
         super(POST_ALREADY_DELETED.getStatus(), POST_ALREADY_DELETED.getMessage());
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/post/service/PostGetService.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/service/PostGetService.java
@@ -1,0 +1,33 @@
+package com.tavemakers.surf.domain.post.service;
+
+import com.tavemakers.surf.domain.post.entity.Post;
+import com.tavemakers.surf.domain.post.exception.PostNotFoundException;
+import com.tavemakers.surf.domain.post.repository.PostRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PostGetService {
+
+    private final PostRepository postRepository;
+
+    @Transactional
+    public Post getPost(Long id) {
+        return  postRepository.findById(id)
+                .orElseThrow(PostNotFoundException::new);
+    }
+
+    public Post getPostOrNull(Long id) {
+        return postRepository.findById(id)
+                .orElse(null);
+    }
+
+    @Transactional(readOnly = true)
+    public Post readPost(Long id) {
+        return  postRepository.findById(id)
+                .orElseThrow(PostNotFoundException::new);
+    }
+
+}

--- a/src/main/java/com/tavemakers/surf/domain/post/service/PostService.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/service/PostService.java
@@ -12,6 +12,7 @@ import com.tavemakers.surf.domain.post.dto.res.PostResDTO;
 import com.tavemakers.surf.domain.post.entity.Post;
 import com.tavemakers.surf.domain.post.exception.PostNotFoundException;
 import com.tavemakers.surf.domain.post.repository.PostRepository;
+import com.tavemakers.surf.domain.reservation.usecase.ReservationUsecase;
 import com.tavemakers.surf.domain.scrap.service.ScrapService;
 import com.tavemakers.surf.global.logging.LogEvent;
 import com.tavemakers.surf.global.logging.LogParam;
@@ -30,9 +31,9 @@ public class PostService {
     private final BoardRepository boardRepository;
     private final PostRepository postRepository;
     private final MemberRepository memberRepository;
-
     private final ScrapService scrapService;
     private final PostLikeService postLikeService;
+    private final ReservationUsecase reservationUsecase;
 
     @Transactional
     @LogEvent(value= "post.create", message= "게시글 생성 성공")
@@ -43,6 +44,11 @@ public class PostService {
                 .orElseThrow(MemberNotFoundException::new);
         Post post = Post.of(req, board, member);
         Post saved = postRepository.save(post);
+
+        if (req.isReserved()) {
+            reservationUsecase.reservePost(saved.getId(), req.reservedAt());
+        }
+
         return PostResDTO.from(saved, false, false);
     }
 

--- a/src/main/java/com/tavemakers/surf/domain/reservation/entity/Reservation.java
+++ b/src/main/java/com/tavemakers/surf/domain/reservation/entity/Reservation.java
@@ -1,0 +1,47 @@
+package com.tavemakers.surf.domain.reservation.entity;
+
+import com.tavemakers.surf.global.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+import java.time.Instant;
+
+@Getter
+@Entity
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Reservation extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "reservation_id")
+    private Long id;
+
+    @Column(name = "post_id")
+    private Long postId;
+
+    @Enumerated(EnumType.STRING)
+    private ReservationStatus status;
+
+    private Instant reservedAt;
+
+    public static Reservation of(Long postId, Instant reservedAt) {
+        return Reservation.builder()
+                .postId(postId)
+                .reservedAt(reservedAt)
+                .status(ReservationStatus.RESERVED)
+                .build();
+    }
+
+    public void publish() {
+        status = ReservationStatus.PUBLISHED;
+    }
+
+    public void cancel() {
+        status = ReservationStatus.CANCELLED;
+    }
+
+}

--- a/src/main/java/com/tavemakers/surf/domain/reservation/entity/ReservationStatus.java
+++ b/src/main/java/com/tavemakers/surf/domain/reservation/entity/ReservationStatus.java
@@ -1,0 +1,7 @@
+package com.tavemakers.surf.domain.reservation.entity;
+
+public enum ReservationStatus {
+    RESERVED,
+    PUBLISHED,
+    CANCELLED,
+}

--- a/src/main/java/com/tavemakers/surf/domain/reservation/exception/ErrorMessage.java
+++ b/src/main/java/com/tavemakers/surf/domain/reservation/exception/ErrorMessage.java
@@ -1,0 +1,18 @@
+package com.tavemakers.surf.domain.reservation.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorMessage {
+
+    RESERVATION_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 [예약정보]입니다."),
+    RESERVATION_CANCELED_EXCEPTION(HttpStatus.BAD_REQUEST, "취소된 [예약정보]입니다."),
+    ;
+
+    private final HttpStatus status;
+    private final String message;
+
+}

--- a/src/main/java/com/tavemakers/surf/domain/reservation/exception/ReservationCanceledException.java
+++ b/src/main/java/com/tavemakers/surf/domain/reservation/exception/ReservationCanceledException.java
@@ -1,0 +1,11 @@
+package com.tavemakers.surf.domain.reservation.exception;
+
+import com.tavemakers.surf.global.common.exception.BaseException;
+
+import static com.tavemakers.surf.domain.reservation.exception.ErrorMessage.RESERVATION_CANCELED_EXCEPTION;
+
+public class ReservationCanceledException extends BaseException {
+    public ReservationCanceledException() {
+        super(RESERVATION_CANCELED_EXCEPTION.getStatus(), RESERVATION_CANCELED_EXCEPTION.getMessage());
+    }
+}

--- a/src/main/java/com/tavemakers/surf/domain/reservation/exception/ReservationNotFoundException.java
+++ b/src/main/java/com/tavemakers/surf/domain/reservation/exception/ReservationNotFoundException.java
@@ -1,0 +1,11 @@
+package com.tavemakers.surf.domain.reservation.exception;
+
+import com.tavemakers.surf.global.common.exception.BaseException;
+
+import static com.tavemakers.surf.domain.reservation.exception.ErrorMessage.RESERVATION_NOT_FOUND;
+
+public class ReservationNotFoundException extends BaseException {
+    public ReservationNotFoundException() {
+        super(RESERVATION_NOT_FOUND.getStatus(), RESERVATION_NOT_FOUND.getMessage());
+    }
+}

--- a/src/main/java/com/tavemakers/surf/domain/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/tavemakers/surf/domain/reservation/repository/ReservationRepository.java
@@ -1,0 +1,18 @@
+package com.tavemakers.surf.domain.reservation.repository;
+
+import com.tavemakers.surf.domain.reservation.entity.Reservation;
+import com.tavemakers.surf.domain.reservation.entity.ReservationStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface ReservationRepository extends JpaRepository<Reservation, Long> {
+
+    Optional<Reservation> findByIdAndStatus(Long id, ReservationStatus status);
+
+    List<Reservation> findByStatus(ReservationStatus status);
+
+}

--- a/src/main/java/com/tavemakers/surf/domain/reservation/service/ReservationGetService.java
+++ b/src/main/java/com/tavemakers/surf/domain/reservation/service/ReservationGetService.java
@@ -1,0 +1,27 @@
+package com.tavemakers.surf.domain.reservation.service;
+
+import com.tavemakers.surf.domain.reservation.entity.Reservation;
+import com.tavemakers.surf.domain.reservation.entity.ReservationStatus;
+import com.tavemakers.surf.domain.reservation.exception.ReservationNotFoundException;
+import com.tavemakers.surf.domain.reservation.repository.ReservationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ReservationGetService {
+
+    private final ReservationRepository reservationRepository;
+
+    public Reservation getReservationById(Long id) {
+        return reservationRepository.findByIdAndStatus(id, ReservationStatus.RESERVED)
+                .orElseThrow(ReservationNotFoundException::new);
+    }
+
+    public List<Reservation> getAllReservation() {
+        return reservationRepository.findByStatus(ReservationStatus.RESERVED);
+    }
+
+}

--- a/src/main/java/com/tavemakers/surf/domain/reservation/service/ReservationSaveService.java
+++ b/src/main/java/com/tavemakers/surf/domain/reservation/service/ReservationSaveService.java
@@ -1,0 +1,18 @@
+package com.tavemakers.surf.domain.reservation.service;
+
+import com.tavemakers.surf.domain.reservation.entity.Reservation;
+import com.tavemakers.surf.domain.reservation.repository.ReservationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ReservationSaveService {
+
+    private final ReservationRepository reservationRepository;
+
+    public Reservation save(Reservation reservation) {
+        return reservationRepository.save(reservation);
+    }
+
+}

--- a/src/main/java/com/tavemakers/surf/domain/reservation/service/ReservationScheduleService.java
+++ b/src/main/java/com/tavemakers/surf/domain/reservation/service/ReservationScheduleService.java
@@ -1,0 +1,25 @@
+package com.tavemakers.surf.domain.reservation.service;
+
+import com.tavemakers.surf.domain.reservation.task.PostPublishRunner;
+import com.tavemakers.surf.domain.reservation.task.PostPublishTask;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ReservationScheduleService {
+
+    private final PostPublishRunner taskRunner;
+    private final TaskScheduler taskScheduler;
+
+    public void schedule(Long reservationId, Instant publishAt) {
+        PostPublishTask task = PostPublishTask.of(reservationId, taskRunner);
+        taskScheduler.schedule(task, publishAt);
+    }
+
+}

--- a/src/main/java/com/tavemakers/surf/domain/reservation/task/PostPublishRunner.java
+++ b/src/main/java/com/tavemakers/surf/domain/reservation/task/PostPublishRunner.java
@@ -1,0 +1,49 @@
+package com.tavemakers.surf.domain.reservation.task;
+
+import com.tavemakers.surf.domain.post.entity.Post;
+import com.tavemakers.surf.domain.post.exception.PostAlreadyDeleteException;
+import com.tavemakers.surf.domain.post.exception.PostNotFoundException;
+import com.tavemakers.surf.domain.post.service.PostGetService;
+import com.tavemakers.surf.domain.reservation.entity.Reservation;
+import com.tavemakers.surf.domain.reservation.exception.ReservationCanceledException;
+import com.tavemakers.surf.domain.reservation.service.ReservationGetService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PostPublishRunner {
+
+    private final ReservationGetService reservationGetService;
+    private final PostGetService postGetService;
+
+    @Transactional(noRollbackFor = PostAlreadyDeleteException.class)
+    public void publishPost(Long reservationId) {
+        Reservation reservation = reservationGetService.getReservationById(reservationId);
+        validateReservation(reservation);
+
+        Post post = postGetService.getPostOrNull(reservation.getPostId());
+        cancelReservationIfPostDeleted(post, reservation);
+
+        log.info("예약 번호 {}번 예약 작업 수행", reservationId);
+        post.publish();
+        reservation.publish();
+    }
+
+    private void cancelReservationIfPostDeleted(Post post, Reservation reservation) {
+        if(post == null) {
+            reservation.cancel();
+            throw new PostAlreadyDeleteException();
+        }
+    }
+
+    private void validateReservation(Reservation reservation) {
+        if(reservation == null) {
+            throw new ReservationCanceledException();
+        }
+    }
+
+}

--- a/src/main/java/com/tavemakers/surf/domain/reservation/task/PostPublishRunner.java
+++ b/src/main/java/com/tavemakers/surf/domain/reservation/task/PostPublishRunner.java
@@ -1,8 +1,7 @@
 package com.tavemakers.surf.domain.reservation.task;
 
 import com.tavemakers.surf.domain.post.entity.Post;
-import com.tavemakers.surf.domain.post.exception.PostAlreadyDeleteException;
-import com.tavemakers.surf.domain.post.exception.PostNotFoundException;
+import com.tavemakers.surf.domain.post.exception.PostAlreadyDeletedException;
 import com.tavemakers.surf.domain.post.service.PostGetService;
 import com.tavemakers.surf.domain.reservation.entity.Reservation;
 import com.tavemakers.surf.domain.reservation.exception.ReservationCanceledException;
@@ -20,7 +19,7 @@ public class PostPublishRunner {
     private final ReservationGetService reservationGetService;
     private final PostGetService postGetService;
 
-    @Transactional(noRollbackFor = PostAlreadyDeleteException.class)
+    @Transactional(noRollbackFor = PostAlreadyDeletedException.class)
     public void publishPost(Long reservationId) {
         Reservation reservation = reservationGetService.getReservationById(reservationId);
         validateReservation(reservation);
@@ -36,7 +35,7 @@ public class PostPublishRunner {
     private void cancelReservationIfPostDeleted(Post post, Reservation reservation) {
         if(post == null) {
             reservation.cancel();
-            throw new PostAlreadyDeleteException();
+            throw new PostAlreadyDeletedException();
         }
     }
 

--- a/src/main/java/com/tavemakers/surf/domain/reservation/task/PostPublishTask.java
+++ b/src/main/java/com/tavemakers/surf/domain/reservation/task/PostPublishTask.java
@@ -1,0 +1,22 @@
+package com.tavemakers.surf.domain.reservation.task;
+
+public class PostPublishTask implements Runnable {
+
+    private final Long reservationId;
+    private final PostPublishRunner publishRunner;
+
+    private PostPublishTask(final Long reservationId, final PostPublishRunner publishRunner) {
+        this.reservationId = reservationId;
+        this.publishRunner = publishRunner;
+    }
+
+    public static PostPublishTask of(final Long reservationId, final PostPublishRunner publishRunner) {
+        return new PostPublishTask(reservationId, publishRunner);
+    }
+
+    @Override
+    public void run() {
+        publishRunner.publishPost(reservationId);
+    }
+
+}

--- a/src/main/java/com/tavemakers/surf/domain/reservation/usecase/ReservationUsecase.java
+++ b/src/main/java/com/tavemakers/surf/domain/reservation/usecase/ReservationUsecase.java
@@ -1,0 +1,34 @@
+package com.tavemakers.surf.domain.reservation.usecase;
+
+import com.tavemakers.surf.domain.reservation.entity.Reservation;
+import com.tavemakers.surf.domain.reservation.service.ReservationSaveService;
+import com.tavemakers.surf.domain.reservation.service.ReservationScheduleService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ReservationUsecase {
+
+    private final ReservationSaveService reservationSaveService;
+    private final ReservationScheduleService scheduleService;
+
+    public void reservePost(Long postId, LocalDateTime reservedAt) {
+        Instant publishAt = toInstant(reservedAt);
+        Reservation reservation = Reservation.of(postId, publishAt);
+        Reservation savedReservation = reservationSaveService.save(reservation);
+
+        scheduleService.schedule(savedReservation.getId(), publishAt);
+    }
+
+    private Instant toInstant(LocalDateTime localDateTime) {
+        return localDateTime.atZone(ZoneId.of("Asia/Seoul")).toInstant();
+    }
+
+}

--- a/src/main/java/com/tavemakers/surf/global/common/loader/ReservationStartupLoader.java
+++ b/src/main/java/com/tavemakers/surf/global/common/loader/ReservationStartupLoader.java
@@ -1,0 +1,35 @@
+package com.tavemakers.surf.global.common.loader;
+
+import com.tavemakers.surf.domain.reservation.entity.Reservation;
+import com.tavemakers.surf.domain.reservation.service.ReservationGetService;
+import com.tavemakers.surf.domain.reservation.service.ReservationScheduleService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.ApplicationListener;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ReservationStartupLoader implements ApplicationListener<ApplicationReadyEvent> {
+
+    private final ReservationScheduleService scheduleService;
+    private final ReservationGetService reservationGetService;
+
+    @Override
+    public void onApplicationEvent(ApplicationReadyEvent event) {
+        List<Reservation> reservedInformation = reservationGetService.getAllReservation();
+        if (reservedInformation.isEmpty()) {
+            log.info("복구할 예약 작업이 없습니다.");
+            return;
+        }
+
+        for(Reservation reservation : reservedInformation) {
+            scheduleService.schedule(reservation.getId(), reservation.getReservedAt());
+        }
+    }
+
+}

--- a/src/main/java/com/tavemakers/surf/global/config/SchedulerConfig.java
+++ b/src/main/java/com/tavemakers/surf/global/config/SchedulerConfig.java
@@ -1,0 +1,26 @@
+package com.tavemakers.surf.global.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class SchedulerConfig {
+
+    @Bean(name = "postTaskScheduler")
+    public TaskScheduler postTaskScheduler() {
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        scheduler.setPoolSize(3); // 조정합시다!
+        scheduler.setThreadNamePrefix("reservation-task-");
+        scheduler.setWaitForTasksToCompleteOnShutdown(true);
+        scheduler.setAwaitTerminationSeconds(60);
+        scheduler.setErrorHandler(t -> log.error("게시글 예약 실패", t));
+        scheduler.initialize();
+        return scheduler;
+    }
+
+}


### PR DESCRIPTION
## 📄 작업 내용 요약

추후 수정 예정

## 동적 스케줄링 사용 이유

초기에는 @Scheduled + cron으로 구현하려고 했습니다.
1시간 기준, 아무런 예약이 없어도 24번의 스케줄링 작업 시작
30분 기준, 아무런 예약이 없어도 48번의 스케줄링 작업 시작
원래 요구사항인 1분 기준은 60 * 24번의 스케줄링 작업을 시작합니다.

이는 비효율적이며, 리소스 낭비라고 생각합니다.
따라서 이러한 정적 스케줄링 방식 대신, 동적 스케줄링 방식을 택했습니다.

## 동적 스케줄링

TaskScheduler를 사용해 구현했습니다.
정확히는 TaskScheduler의 다음 메서드를 사용합니다.

```java
ScheduledFuture<?> schedule(Runnable task, Instant startTime);
```

첫번째 매개인자로는 실제 수행 작업을,
두번째 매개인자로는 예약 시간을 넘겨줍니다.
이렇게 되면 해당 스레드가 예약 시간까지 Waiting하게 되며, 예약시간이 되면 해당 스레드가 다시 깨어나서 작업을 수행합니다.

## 위 방식의 한계

TaskScheduler는 외부 DB가 아닌 Spring Application 내부 인 메모리에 Task를 저장합니다.
따라서 서버가 꺼지면 Task 정보가 사라지는 비휘발적인 특징을 가지고있습니다.

## 극복

위 한계를 극복하기 위해서는 어플리케이션이 재시작 될 때마다, 사라진 Task를 복원해줘야합니다.
이를 위해 MySQL DB를 사용합니다.


### 정상적인 Task 수행

1. Post가 예약 글
2. Reservation 테이블에 예약 정보를 저장 + TaskScheduler에 Task 등록
3. 예약시간이 되면 등록된 Task가 수행
4. Task가 수행될 때, Reservation 테이블에 저장된 예약정보를 상태 변경 (`RESERVED `-> `PUBLISHED`)

### 어플리케이션이 종료된 경우 Task 복원 로직

1. Post가 예약 글
2. Reservation 테이블에 예약 정보를 저장 + TaskScheduler에 Task 등록
3. 어플리케이션이 종료됨.
4. 어플리케이션이 시작될 때, Reservation 테이블에서 예약상태가 `RESERVED`인 예약 정보를 모두 조회
5. 조회한 모든 예약 정보를 TaskScheduler에 다시 등록

## 객체 설명

- `PostPublishTask`: TaskScheduler에 실제로 등록되는 Runnable 구현체
- `PostPublishRunner`: PostPublishTask의 작업을 실제로 수행하는 객체
- `ReservationStartupLoader`: 어플리케이션 시작 시, 사라진 예약 정보를 TaskScheduler에 재등록하는 객체

## SchedulerConfig

실제 예약은 많이 이루어지는 작업은 아니므로 스레드풀 사이즈는 3으로 설정했습니다.



## 📎 Issue #123
<!-- closed #123-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 게시글 예약 기능 추가: 미래 날짜에 게시글을 게시하도록 예약할 수 있습니다.
  * 예약된 게시글은 지정된 시간에 자동으로 게시됩니다.
  * 애플리케이션 시작 시 예약된 게시글이 자동으로 복구됩니다.

* **버그 수정**
  * 삭제된 게시글에 대한 예약 처리 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->