### PR TITLE
[FEAT] 게시판별 전체 조회와 카테고리별 조회 api 통일

### DIFF
--- a/src/main/java/com/tavemakers/surf/domain/board/entity/BoardCategory.java
+++ b/src/main/java/com/tavemakers/surf/domain/board/entity/BoardCategory.java
@@ -4,7 +4,6 @@ import com.tavemakers.surf.global.common.entity.BaseEntity;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AccessLevel;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
@@ -13,23 +12,27 @@ import lombok.experimental.SuperBuilder;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SuperBuilder
+@Table(
+        name = "board_category",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"board_id", "slug"}),
+        indexes = {
+                @Index(name = "idx_boardcategory_board", columnList = "board_id"),
+                @Index(name = "idx_boardcategory_slug", columnList = "slug")
+        }
+)
 public class BoardCategory extends BaseEntity {
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY) // nullable=false 유지
     @JoinColumn(name = "board_id", nullable = false)
     private Board board;
 
-    @Column(nullable = false)
-    @NotBlank
+    @Column(nullable = false) @NotBlank
     private String name;
 
-    @Column(nullable = false, unique = true)
-    @NotBlank
-    private String slug;
+    @Column(nullable = false) @NotBlank
+    private String slug; // 전역 unique 제거(중요)
 
     public void update(String name, String slug) {
         if (name != null) this.name = name;

--- a/src/main/java/com/tavemakers/surf/domain/post/controller/PostController.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/controller/PostController.java
@@ -75,30 +75,29 @@ public class PostController {
         return ApiResponse.response(HttpStatus.OK, POSTS_BY_MEMBER_READ.getMessage(), response);
     }
 
-    /** 게시판별 게시글 목록 (뷰어 = 현재 로그인 사용자) */
-    @Operation(summary = "게시판별 게시글 목록", description = "특정 게시판에 속한 게시글 목록을 조회합니다.")
-    @GetMapping("/v1/user/posts/board/{boardId}")
-    public ApiResponse<Slice<PostResDTO>> getPostsByBoard(
-            @PathVariable(name = "boardId") Long boardId,
-            @PageableDefault(size = 12, sort = "postedAt", direction = Sort.Direction.DESC)
-            Pageable pageable
-    ) {
-        Long viewerId = SecurityUtils.getCurrentMemberId();
-        Slice<PostResDTO> response = postService.getPostsByBoard(boardId, viewerId, pageable);
-        return ApiResponse.response(HttpStatus.OK, POSTS_BY_BOARD_READ.getMessage(), response);
-    }
+//    /** 게시판별 게시글 목록 (뷰어 = 현재 로그인 사용자) */
+//    @Operation(summary = "게시판별 게시글 목록", description = "특정 게시판에 속한 게시글 목록을 조회합니다.")
+//    @GetMapping("/v1/user/posts/board/{boardId}")
+//    public ApiResponse<Slice<PostResDTO>> getPostsByBoard(
+//            @PathVariable(name = "boardId") Long boardId,
+//            @PageableDefault(size = 12, sort = "postedAt", direction = Sort.Direction.DESC)
+//            Pageable pageable
+//    ) {
+//        Long viewerId = SecurityUtils.getCurrentMemberId();
+//        Slice<PostResDTO> response = postService.getPostsByBoard(boardId, viewerId, pageable);
+//        return ApiResponse.response(HttpStatus.OK, POSTS_BY_BOARD_READ.getMessage(), response);
+//    }
 
-    /** 보드+카테고리별 게시글 목록 (뷰어 = 현재 로그인 사용자) */
-    @Operation(summary = "카테고리별 게시글 목록", description = "특정 보드의 특정 카테고리에 속한 게시글 목록을 조회합니다.")
-    @GetMapping("/v1/user/posts/board/{boardId}/category/{categoryId}")
+    @Operation(summary = "보드 게시글 목록", description = "category 미지정 또는 'all'이면 보드 전체")
+    @GetMapping("/v1/user/posts/board/{boardId}")
     public ApiResponse<Slice<PostResDTO>> getPostsByBoardAndCategory(
             @PathVariable Long boardId,
-            @PathVariable Long categoryId,
+            @RequestParam(required = false) String category,
             @PageableDefault(size = 12, sort = "postedAt", direction = Sort.Direction.DESC)
             Pageable pageable
     ) {
         Long viewerId = SecurityUtils.getCurrentMemberId();
-        Slice<PostResDTO> response = postService.getPostsByBoardAndCategory(boardId, categoryId, viewerId, pageable);
+        Slice<PostResDTO> response = postService.getPostsByBoardAndCategory(boardId, category, viewerId, pageable);
         return ApiResponse.response(HttpStatus.OK, POSTS_BY_BOARD_READ.getMessage(), response);
     }
 

--- a/src/main/java/com/tavemakers/surf/domain/post/service/PostService.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/service/PostService.java
@@ -114,22 +114,38 @@ public class PostService {
         return slice.map(p -> toRes(p, flags.scrappedIds, flags.likedIds));
     }
 
-    @Transactional(readOnly = true)
-    public Slice<PostResDTO> getPostsByBoard(Long boardId, Long viewerId, Pageable pageable) {
-        if (!boardRepository.existsById(boardId))
-            throw new BoardNotFoundException();
-        Slice<Post> slice = postRepository.findByBoardId(boardId, pageable);
-        Flags flags = resolveFlags(viewerId, slice);
-        return slice.map(p -> toRes(p, flags.scrappedIds, flags.likedIds));
-    }
+//    @Transactional(readOnly = true)
+//    public Slice<PostResDTO> getPostsByBoard(Long boardId, Long viewerId, Pageable pageable) {
+//        if (!boardRepository.existsById(boardId))
+//            throw new BoardNotFoundException();
+//        Slice<Post> slice = postRepository.findByBoardId(boardId, pageable);
+//        Flags flags = resolveFlags(viewerId, slice);
+//        return slice.map(p -> toRes(p, flags.scrappedIds, flags.likedIds));
+//    }
 
     @Transactional(readOnly = true)
-    public Slice<PostResDTO> getPostsByBoardAndCategory(Long boardId, Long categoryId, Long viewerId, Pageable pageable) {
-        Board board = boardRepository.findById(boardId).orElseThrow(BoardNotFoundException::new);
-        resolveCategory(board, categoryId);
-        Slice<Post> slice = postRepository.findByBoardIdAndCategoryId(boardId, categoryId, pageable);
-        Flags f = resolveFlags(viewerId, slice);
-        return slice.map(p -> toRes(p, f.scrappedIds, f.likedIds));
+    public Slice<PostResDTO> getPostsByBoardAndCategory(
+            Long boardId, String categorySlug, Long viewerId, Pageable pageable) {
+
+        Board board = boardRepository.findById(boardId)
+                .orElseThrow(BoardNotFoundException::new);
+
+        final boolean all = (categorySlug == null || categorySlug.isBlank() || "all".equalsIgnoreCase(categorySlug));
+
+        Slice<Post> slice;
+        if (all) {
+            slice = postRepository.findByBoardId(boardId, pageable);
+        } else {
+            // 보드-카테고리 소속 검증 (slug 기준)
+            BoardCategory category = boardCategoryRepository.findByBoardIdAndSlug(boardId, categorySlug)
+                    .orElseThrow(CategoryNotFoundException::new);
+
+            resolveCategory(board, category.getId());
+            slice = postRepository.findByBoardIdAndCategoryId(boardId, category.getId(), pageable);
+        }
+
+        Flags flags = resolveFlags(viewerId, slice);
+        return slice.map(p -> toRes(p, flags.scrappedIds, flags.likedIds));
     }
 
     @Transactional


### PR DESCRIPTION
## 📄 작업 내용 요약
기존의 분리되어 있던 '게시판별 게시글 조회' api 와 '카테고리별 게시글 조회' api를 통일하였습니다.

```
public ApiResponse<Slice<PostResDTO>> getPostsByBoardAndCategory(
            @PathVariable Long boardId,
            @RequestParam(required = false) String category,
            @PageableDefault(size = 12, sort = "postedAt", direction = Sort.Direction.DESC)
            Pageable pageable
    )
```
slug를 최대한 활용해보기 위해 category는 String으로 입력받아 slug를 통해 조회할 것입니다.
required=false 로 설정하여 category를 입력하지 않거나 ?category=all 로 접근했을 때 해당 boardId에 대한 모든 게시글을 조회하도록 하였습니다.

## 📎 Issue 번호
<!-- closed #139  -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **API 변경**
  * 게시물 검색 엔드포인트 경로 변경: 카테고리를 경로 매개변수에서 선택 사항 쿼리 매개변수로 수정
  * 보드별 게시물 조회 엔드포인트 제거
  * 게시물 필터링 옵션 유연성 향상 - 카테고리 필터는 이제 선택 사항

<!-- end of auto-generated comment: release notes by coderabbit.ai -->