### PR TITLE
[Feat] 게시글과 매핑된 일정 단건 조회

### DIFF
--- a/src/main/java/com/tavemakers/surf/domain/post/controller/ResponseMessage.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/controller/ResponseMessage.java
@@ -22,7 +22,8 @@ public enum ResponseMessage {
     SCHEDULE_CREATED("[일정]이 성공적으로 생성되었습니다"),
     SCHEDULE_UPDATED("[일정]이 성공적으로 수정되었습니다."),
     SCHEDULE_CALENDAR_READ("[일정]이 성공적으로 월별 조회되었습니다."),
-    SCHEDULE_DELETED("[일정]이 성공적으로 삭제되었습니다.");
+    SCHEDULE_DELETED("[일정]이 성공적으로 삭제되었습니다."),
+    SCHEDULE_POST_READ("[게시글]과 매핑된 [일정]이 성공적으로 조회되었습니다.");
 
     private final String message;
 

--- a/src/main/java/com/tavemakers/surf/domain/post/controller/ScheduleGetController.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/controller/ScheduleGetController.java
@@ -2,10 +2,13 @@ package com.tavemakers.surf.domain.post.controller;
 
 import static com.tavemakers.surf.domain.post.controller.ResponseMessage.SCHEDULE_CALENDAR_READ;
 import static com.tavemakers.surf.domain.post.controller.ResponseMessage.SCHEDULE_CREATED;
+import static com.tavemakers.surf.domain.post.controller.ResponseMessage.SCHEDULE_POST_READ;
 
 import com.tavemakers.surf.domain.post.dto.req.ScheduleCreateReqDTO;
 import com.tavemakers.surf.domain.post.dto.res.ScheduleMonthlyResDTO;
+import com.tavemakers.surf.domain.post.dto.res.ScheduleResDTO;
 import com.tavemakers.surf.domain.post.service.ScheduleGetService;
+import com.tavemakers.surf.domain.post.service.ScheduleUseCase;
 import com.tavemakers.surf.global.common.response.ApiResponse;
 import com.tavemakers.surf.global.util.SecurityUtils;
 import io.swagger.v3.oas.annotations.Operation;
@@ -29,6 +32,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class ScheduleGetController {
 
     private final ScheduleGetService scheduleGetService;
+    private final ScheduleUseCase scheduleUseCase;
 
     @Operation(summary = "캘린더에 월별 일정 목록 조회", description = "캘린더 페이지에서 월별 일정을 조회합니다.")
     @GetMapping("/v1/user/calendar/schedules")
@@ -37,5 +41,12 @@ public class ScheduleGetController {
         String memberRole = SecurityUtils.getCurrentMemberRole();
         ScheduleMonthlyResDTO dto = scheduleGetService.getScheduleMonthly(memberRole,year, month);
         return ApiResponse.response(HttpStatus.OK, SCHEDULE_CALENDAR_READ.getMessage(),dto);
+    }
+
+    @Operation(summary = "특정 게시글 일정 조회", description = "특정 게시글에 매핑된 일정이 있을 경우 반환")
+    @GetMapping("/v1/user/post/{postId}/schedule")
+    public ApiResponse<ScheduleResDTO> getScheduleByPost(@PathVariable Long postId) {
+        ScheduleResDTO dto = scheduleUseCase.getScheduleByPost(postId);
+        return ApiResponse.response(HttpStatus.OK, SCHEDULE_POST_READ.getMessage(),dto);
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/post/dto/req/PostCreateReqDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/dto/req/PostCreateReqDTO.java
@@ -36,7 +36,7 @@ public record PostCreateReqDTO(
         List<PostImageCreateReqDTO> imageUrlList,
 
         @Schema(description = "일정 매핑 유무", example = "true")
-        boolean isScheduleExist
+        Boolean hasSchedule
 
 ) implements LogPropsProvider {
 

--- a/src/main/java/com/tavemakers/surf/domain/post/dto/req/PostCreateReqDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/dto/req/PostCreateReqDTO.java
@@ -33,7 +33,10 @@ public record PostCreateReqDTO(
         LocalDateTime reservedAt,
 
         @Schema(description = "게시글 이미지 목록")
-        List<PostImageCreateReqDTO> imageUrlList
+        List<PostImageCreateReqDTO> imageUrlList,
+
+        @Schema(description = "일정 매핑 유무", example = "true")
+        boolean isScheduleExist
 
 ) implements LogPropsProvider {
 

--- a/src/main/java/com/tavemakers/surf/domain/post/dto/req/PostUpdateReqDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/dto/req/PostUpdateReqDTO.java
@@ -34,7 +34,10 @@ public record PostUpdateReqDTO(
         Boolean isImageChanged,
 
         @Schema(description = "게시글 이미지")
-        List<PostImageCreateReqDTO> imageUrlList
+        List<PostImageCreateReqDTO> imageUrlList,
+
+        @Schema(description = "일정 매핑 유무", example = "true")
+        Boolean hasSchedule
 
 ) implements LogPropsProvider {
 

--- a/src/main/java/com/tavemakers/surf/domain/post/dto/res/PostDetailResDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/dto/res/PostDetailResDTO.java
@@ -46,7 +46,10 @@ public record PostDetailResDTO(
         String nickname,
 
         @Schema(description = "게시글 이미지 링크")
-        List<PostImageResDTO> imageUrlList
+        List<PostImageResDTO> imageUrlList,
+
+        @Schema(description = "일정 매핑 유무", example = "true")
+        Boolean hasSchedule
 ) {
     public static PostDetailResDTO of(Post post, boolean scrappedByMe, boolean likedByMe, List<PostImageResDTO> imageUrlList) {
         return PostDetailResDTO.builder()
@@ -63,6 +66,7 @@ public record PostDetailResDTO(
                 .commentCount(post.getCommentCount())
                 .nickname(post.getMember().getName())
                 .imageUrlList(imageUrlList)
+                .hasSchedule(post.getHasSchedule())
                 .build();
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/post/entity/Post.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/entity/Post.java
@@ -65,6 +65,8 @@ public class Post extends BaseEntity {
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
+    private boolean isScheduleExist;
+
     public static Post of(PostCreateReqDTO req, Board board, BoardCategory category, Member member) {
         return Post.builder()
                 .title(req.title())
@@ -80,6 +82,7 @@ public class Post extends BaseEntity {
                 .likeCount(0L)
                 .commentCount(0L)
                 .isReserved(req.isReserved())
+                .isScheduleExist(req.isScheduleExist())
                 .build();
     }
 

--- a/src/main/java/com/tavemakers/surf/domain/post/entity/Post.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/entity/Post.java
@@ -65,7 +65,7 @@ public class Post extends BaseEntity {
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
-    private boolean isScheduleExist;
+    private Boolean hasSchedule;
 
     public static Post of(PostCreateReqDTO req, Board board, BoardCategory category, Member member) {
         return Post.builder()
@@ -82,7 +82,7 @@ public class Post extends BaseEntity {
                 .likeCount(0L)
                 .commentCount(0L)
                 .isReserved(req.isReserved())
-                .isScheduleExist(req.isScheduleExist())
+                .hasSchedule(req.hasSchedule())
                 .build();
     }
 

--- a/src/main/java/com/tavemakers/surf/domain/post/entity/Post.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/entity/Post.java
@@ -94,6 +94,7 @@ public class Post extends BaseEntity {
         this.boardName = board.getName();
         this.category = category;
         this.categoryName = category.getName();
+        this.hasSchedule = req.hasSchedule();
     }
 
     @PrePersist

--- a/src/main/java/com/tavemakers/surf/domain/post/entity/Schedule.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/entity/Schedule.java
@@ -71,11 +71,15 @@ public class Schedule extends BaseEntity {
     public void updateSchedule(ScheduleUpdateReqDTO dto){
         if(dto.startAt()!=null && dto.endAt()!=null){
             validateScheduleTime(dto.startAt(), dto.endAt());
+            this.startAt = dto.startAt();
+            this.endAt = dto.endAt();
         }
         else if(dto.startAt() != null) {
             validateScheduleTime(dto.startAt(), this.endAt);
+            this.startAt = dto.startAt();
         } else if (dto.endAt() != null) {
             validateScheduleTime(this.startAt, dto.endAt());
+            this.endAt = dto.endAt();
         }
 
         if(dto.category() != null) {

--- a/src/main/java/com/tavemakers/surf/domain/post/repository/ScheduleRepository.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/repository/ScheduleRepository.java
@@ -3,6 +3,7 @@ package com.tavemakers.surf.domain.post.repository;
 import com.tavemakers.surf.domain.post.entity.Schedule;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -15,4 +16,6 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
             LocalDateTime endOfMonth,
             List<String> categories
     );
+
+    Optional<Schedule> findByPostId(Long postId);
 }

--- a/src/main/java/com/tavemakers/surf/domain/post/service/PostGetService.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/service/PostGetService.java
@@ -39,6 +39,6 @@ public class PostGetService {
     //해당 게시글이 일정과 매핑 되어있는지 판단
     @Transactional(readOnly = true)
     public boolean existsSchedule(Post post){
-        return post.isScheduleExist();
+        return post.getHasSchedule();
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/post/service/PostGetService.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/service/PostGetService.java
@@ -36,4 +36,9 @@ public class PostGetService {
                 .orElseThrow(PostNotFoundException::new);
     }
 
+    //해당 게시글이 일정과 매핑 되어있는지 판단
+    @Transactional(readOnly = true)
+    public boolean existsSchedule(Post post){
+        return post.isScheduleExist();
+    }
 }

--- a/src/main/java/com/tavemakers/surf/domain/post/service/ScheduleCreateService.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/service/ScheduleCreateService.java
@@ -14,14 +14,14 @@ public class ScheduleCreateService {
     private final ScheduleRepository scheduleRepository;
 
     @Transactional
-    public Schedule createScheduleAtPost(ScheduleCreateReqDTO dto, Post post) {
+    public void createScheduleAtPost(ScheduleCreateReqDTO dto, Post post) {
         Schedule schedule = Schedule.of(dto, post);
-        return scheduleRepository.save(schedule);
+        scheduleRepository.save(schedule);
     }
 
     @Transactional
-    public Schedule createScheduleSingle(ScheduleCreateReqDTO dto) {
+    public void createScheduleSingle(ScheduleCreateReqDTO dto) {
         Schedule schedule = Schedule.from(dto);
-        return scheduleRepository.save(schedule);
+        scheduleRepository.save(schedule);
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/post/service/ScheduleGetService.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/service/ScheduleGetService.java
@@ -62,4 +62,11 @@ public class ScheduleGetService {
         return scheduleRepository.findById(scheduleId)
                 .orElseThrow(ScheduleNotFoundException::new);
     }
+
+    //특정 일정 개별 조회 - 게시글
+    @Transactional(readOnly = true)
+    public void getScheduleSingleDTO(Long postId) {
+        Schedule schedule = scheduleRepository.findByPostId(postId)
+                .orElseThrow(ScheduleNotFoundException::new);
+    }
 }

--- a/src/main/java/com/tavemakers/surf/domain/post/service/ScheduleGetService.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/service/ScheduleGetService.java
@@ -65,8 +65,9 @@ public class ScheduleGetService {
 
     //특정 일정 개별 조회 - 게시글
     @Transactional(readOnly = true)
-    public void getScheduleSingleDTO(Long postId) {
+    public ScheduleResDTO getScheduleSingleDTO(Long postId) {
         Schedule schedule = scheduleRepository.findByPostId(postId)
                 .orElseThrow(ScheduleNotFoundException::new);
+        return ScheduleResDTO.fromEntity(schedule);
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/post/service/ScheduleUseCase.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/service/ScheduleUseCase.java
@@ -2,6 +2,7 @@ package com.tavemakers.surf.domain.post.service;
 
 import com.tavemakers.surf.domain.post.dto.req.ScheduleCreateReqDTO;
 import com.tavemakers.surf.domain.post.dto.req.ScheduleUpdateReqDTO;
+import com.tavemakers.surf.domain.post.dto.res.ScheduleResDTO;
 import com.tavemakers.surf.domain.post.entity.Post;
 import com.tavemakers.surf.domain.post.entity.Schedule;
 import lombok.RequiredArgsConstructor;
@@ -17,6 +18,7 @@ public class ScheduleUseCase {
     private final SchedulePatchService schedulePatchService;
     private final ScheduleDeleteService scheduleDeleteService;
     private final PostService postService;
+    private final PostGetService postGetService;
 
     //게시글 생성 시 일정 생성
     @Transactional
@@ -43,5 +45,16 @@ public class ScheduleUseCase {
     public void deleteSchedule(Long id) {
         Schedule schedule = scheduleGetService.getScheduleById(id);
         scheduleDeleteService.deleteSchedule(schedule);
+    }
+
+    //게시글별 일정 조회
+    @Transactional(readOnly = true)
+    public ScheduleResDTO getScheduleByPost(Long postId) {
+       Post post = postGetService.getPost(postId);
+       boolean hasSchedule = postGetService.existsSchedule(post);
+
+       if(hasSchedule) {
+           return scheduleGetService.getScheduleSingleDTO(postId);
+       }else return null;
     }
 }


### PR DESCRIPTION
## 📄 작업 내용 요약

- [ ] 게시글과 매핑된 일정 단건 조회
- [ ] 게시글 생성/ 수정 필드 수정
- [ ] 게시글 필드 수정

## 게시글 필드 수정
``` java
private Boolean hasSchedule;
```
Boolean 형태로 일정과 매핑되어있는지 유무를 나타내는 필드를 추가하였습니다.
처음에는 boolean 형태로 선언하였는데,
이렇게 하니까 PostDetailResDTO의 팩토리 메소드에서 get()으로 불러와지지 않았습니다. 

이유는 DB에서 해당 컬럼이 NULL일 경우,
JPA가 boolean(기본형) 으로 매핑하려다 NPE 또는 변환 오류 발생 가능하기 때문이라고 하네요...


## 게시글 생성 및 수정 dto및 메소드에 hasSchedule 추가
``` java
        @Schema(description = "일정 매핑 유무", example = "true")
        Boolean hasSchedule
```


## 추가 이유
hasSchedule이 없으면,
특정 게시글 조회시
1. 게시글 id 값을 가져와서
2. schedule 테이블에서 해당 id와 매핑되어있는지 매번 확인해야함

근데 만약 hasSchedule로 매핑 유무를 먼저 판단할 수 있다면,
true경우에만 schedule 테이블에 접근하여 가져오면 됨!!



## 📎 Issue 번호 146
<!-- closed #146 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 게시글에 일정 매핑 기능 추가
  * 게시글에 연결된 일정 조회 기능 추가
  * 일정 시간 업데이트 시 검증 로직 강화

* **개선 사항**
  * 게시글 생성 및 수정 시 일정 매핑 여부 설정 가능
  * 게시글 상세 정보에 일정 포함 여부 표시

<!-- end of auto-generated comment: release notes by coderabbit.ai -->