### PR TITLE
[Refact] 댓글 로직 구조 개선

### DIFF
--- a/src/main/java/com/tavemakers/surf/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/tavemakers/surf/domain/comment/controller/CommentController.java
@@ -1,6 +1,7 @@
 package com.tavemakers.surf.domain.comment.controller;
 
 import com.tavemakers.surf.domain.comment.dto.req.CommentCreateReqDTO;
+import com.tavemakers.surf.domain.comment.dto.res.CommentListResDTO;
 import com.tavemakers.surf.domain.comment.dto.res.CommentResDTO;
 import com.tavemakers.surf.domain.comment.service.CommentService;
 import com.tavemakers.surf.global.common.response.ApiResponse;
@@ -11,7 +12,6 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
@@ -22,12 +22,12 @@ import static com.tavemakers.surf.domain.comment.controller.ResponseMessage.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping
-@Tag(name = "댓글", description = "댓글 CRUD 관련 API, 대댓글 1단계 가능")
+@Tag(name = "댓글", description = "댓글 및 대댓글 관련 CRUD API")
 public class CommentController {
 
     private final CommentService commentService;
 
-    @Operation(summary = "댓글 생성 (루트/대댓글)", description = "parentId가 null이면 루트")
+    @Operation(summary = "댓글 생성 (루트/대댓글)", description = "rootId가 null이면 루트 댓글")
     @PostMapping("/v1/user/posts/{postId}/comments")
     public ApiResponse<CommentResDTO> createComment(@PathVariable Long postId,
                                                     @Valid @RequestBody CommentCreateReqDTO req) {
@@ -38,21 +38,21 @@ public class CommentController {
 
     @Operation(summary = "댓글 목록 조회 (페이징)", description = "루트 댓글과 대댓글 모두 포함. 페이징 처리")
     @GetMapping("/v1/user/posts/{postId}/comments")
-    public ApiResponse<Slice<CommentResDTO>> getComments(
+    public ApiResponse<CommentListResDTO> getComments(
             @PathVariable Long postId,
             @ParameterObject
             @PageableDefault(page = 0, size = 10, sort = "createdAt", direction = Sort.Direction.DESC)
             Pageable pageable
     ){
         Long memberId = SecurityUtils.getCurrentMemberId();
-        Slice<CommentResDTO> response = commentService.getComments(postId, pageable, memberId);
-        return ApiResponse.response(HttpStatus.OK, COMMENT_READ.getMessage(), response);
+        CommentListResDTO data = commentService.getComments(postId, pageable, memberId);
+        return ApiResponse.response(HttpStatus.OK, COMMENT_READ.getMessage(), data);
     }
 
     @Operation(summary = "댓글 삭제 (내 댓글만)", description = "본인이 작성한 댓글만 삭제 가능, 대댓글 존재 시 내용만 삭제(삭제된 댓글입니다 처리)")
     @DeleteMapping("/v1/user/posts/{postId}/comments/{commentId}")
     public ApiResponse<Void> deleteComment(@PathVariable Long postId,
-                                    @PathVariable Long commentId) {
+                                           @PathVariable Long commentId) {
         Long memberId = SecurityUtils.getCurrentMemberId();
         commentService.deleteComment(postId, commentId, memberId);
         return ApiResponse.response(HttpStatus.NO_CONTENT, COMMENT_DELETED.getMessage());

--- a/src/main/java/com/tavemakers/surf/domain/comment/dto/req/CommentCreateReqDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/comment/dto/req/CommentCreateReqDTO.java
@@ -9,8 +9,14 @@ import java.util.List;
 @Schema(description = "댓글 생성 DTO")
 public record CommentCreateReqDTO(
 
-        @Schema(description = "부모 댓글 ID (루트면 null)", example = "null")
-        Long parentId,
+        @Schema(
+                description = """
+                루트 댓글을 생성할 때는 null,
+                대댓글을 생성할 때는 루트 댓글의 ID를 입력합니다.
+                """,
+                example = "null"
+        )
+        Long rootId, // 해당 값 null 이면 루트 댓글, 값 있으면 대댓글
 
         @Schema(description = "내용", example = "좋은 공지 감사합니다!")
         @NotBlank
@@ -18,5 +24,18 @@ public record CommentCreateReqDTO(
         String content,
 
         @Schema(description = "멘션할 회원 ID 목록", example = "[5]")
-        List<Long> mentionMemberIds
+        List<Long> mentionMemberIds,
+
+        @Schema(
+                description = """
+                자동 멘션 여부.
+                true: 원 댓글을 클릭하여 자동으로 멘션된 경우 (대댓글)
+                false: 사용자가 직접 @입력으로 멘션한 경우 (루트 댓글로 취급)
+                """,
+                example = "false"
+        )
+        Boolean isAutoMention
 ) {}
+
+
+

--- a/src/main/java/com/tavemakers/surf/domain/comment/dto/res/CommentListResDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/comment/dto/res/CommentListResDTO.java
@@ -1,0 +1,19 @@
+
+package com.tavemakers.surf.domain.comment.dto.res;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "댓글 목록 + 총 개수 응답 DTO")
+public record CommentListResDTO(
+
+        @Schema(description = "댓글 목록")
+        List<CommentResDTO> comments,
+
+        @Schema(description = "총 댓글 수", example = "37")
+        long totalCount,
+
+        @Schema(description = "다음 페이지 존재 여부", example = "true")
+        boolean hasNext
+) {}

--- a/src/main/java/com/tavemakers/surf/domain/comment/dto/res/CommentResDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/comment/dto/res/CommentResDTO.java
@@ -14,9 +14,6 @@ public record CommentResDTO(
         @Schema(description = "게시글 ID", example = "3")
         Long postId,
 
-        @Schema(description = "부모 댓글 ID (루트면 null)", example = "null")
-        Long parentId,
-
         @Schema(description = "루트 댓글 ID", example = "15")
         Long rootId,
 
@@ -32,6 +29,9 @@ public record CommentResDTO(
         @Schema(description = "작성자 닉네임", example = "민수")
         String nickname,
 
+        @Schema(description = "작성자 프로필 이미지 URL", example = "https://.../profile.png")
+        String profileImageUrl,
+
         @Schema(description = "좋아요 수", example = "0")
         Long likeCount,
 
@@ -41,11 +41,9 @@ public record CommentResDTO(
         @Schema(description = "작성일시")
         LocalDateTime createdAt,
 
-        @Schema(description = "수정일시")
-        LocalDateTime updatedAt,
-
         @Schema(description = "멘션 목록")
         List<MentionResDTO> mentions
+
 ) {
     public static CommentResDTO from(Comment comment,
                                      List<MentionResDTO> mentions,
@@ -53,17 +51,17 @@ public record CommentResDTO(
         return new CommentResDTO(
                 comment.getId(),
                 comment.getPost().getId(),
-                comment.getParent() != null ? comment.getParent().getId() : null,
-                comment.getParent() == null ? comment.getId() : comment.getRootId(),
+                comment.getRootId(),
                 comment.getDepth(),
                 comment.getContent(),
                 comment.getMember().getId(),
                 comment.getMember().getName(),
+                comment.getMember().getProfileImageUrl(),
                 comment.getLikeCount(),
                 liked,
                 comment.getCreatedAt(),
-                comment.getUpdatedAt(),
                 mentions
         );
     }
 }
+

--- a/src/main/java/com/tavemakers/surf/domain/comment/exception/CannotReplyToDeletedCommentException.java
+++ b/src/main/java/com/tavemakers/surf/domain/comment/exception/CannotReplyToDeletedCommentException.java
@@ -1,0 +1,13 @@
+package com.tavemakers.surf.domain.comment.exception;
+
+import com.tavemakers.surf.global.common.exception.BaseException;
+
+public class CannotReplyToDeletedCommentException extends BaseException {
+    public CannotReplyToDeletedCommentException() {
+        super(
+                ErrorMessage.CANNOT_REPLY_TO_DELETED_COMMENT.getStatus(),
+                ErrorMessage.CANNOT_REPLY_TO_DELETED_COMMENT.getMessage()
+        );
+    }
+}
+

--- a/src/main/java/com/tavemakers/surf/domain/comment/exception/ErrorMessage.java
+++ b/src/main/java/com/tavemakers/surf/domain/comment/exception/ErrorMessage.java
@@ -13,7 +13,8 @@ public enum ErrorMessage {
     INVALID_BLANK_COMMENT(HttpStatus.BAD_REQUEST, "[댓글] 내용은 공백일 수 없습니다."),
     ALREADY_DELETED_COMMENT(HttpStatus.BAD_REQUEST, "이미 삭제된 [댓글]입니다."),
     COMMENT_MENTION_SELF(HttpStatus.BAD_REQUEST, "자기 자신을 멘션할 수 없습니다."),
-    INVALID_MENTION_SEARCH_KEYWORD(HttpStatus.BAD_REQUEST, "회원 멘션은 @으로 시작해야 하며, 이름은 두 글자 이상 입력해주세요. ex) @홍길");
+    INVALID_MENTION_SEARCH_KEYWORD(HttpStatus.BAD_REQUEST, "회원 멘션은 @으로 시작해야 하며, 이름은 두 글자 이상 입력해주세요. ex) @홍길"),
+    CANNOT_REPLY_TO_DELETED_COMMENT(HttpStatus.BAD_REQUEST, "삭제된 [댓글]에는 대댓글을 작성할 수 없습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/tavemakers/surf/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/tavemakers/surf/domain/comment/repository/CommentRepository.java
@@ -25,7 +25,7 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     long countByPostIdAndDeletedFalse(Long postId);
 
     /** 대댓글이 있는 루트댓글의 경우 소프트 삭제 */
-    @Modifying
+    @Modifying(clearAutomatically = true)
     @Query("UPDATE Comment c SET c.deleted = true, c.content = '(삭제된 댓글입니다.)' WHERE c.id = :id")
     void softDeleteById(Long id);
 }

--- a/src/main/java/com/tavemakers/surf/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/tavemakers/surf/domain/comment/repository/CommentRepository.java
@@ -10,8 +10,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
-    /** 자식 댓글 존재 여부 확인용 (삭제 시) */
-    boolean existsByParentId(Long parentId);
+    boolean existsByRootIdAndDepth(Long rootId, int depth);
 
     /** 본인 댓글만 삭제 */
     @Transactional
@@ -21,4 +20,14 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     /** 게시글 내 모든 댓글 + 대댓글 조회 (작성 시간순) */
     Slice<Comment> findByPostIdOrderByCreatedAtAsc(Long postId, Pageable pageable);
+
+    /** 댓글 총 개수 */
+    long countByPostIdAndDeletedFalse(Long postId);
+
+    /** 대댓글이 있는 루트댓글의 경우 소프트 삭제 */
+    @Modifying
+    @Query("UPDATE Comment c SET c.deleted = true, c.content = '(삭제된 댓글입니다.)' WHERE c.id = :id")
+    void softDeleteById(Long id);
 }
+
+

--- a/src/main/java/com/tavemakers/surf/domain/comment/service/CommentService.java
+++ b/src/main/java/com/tavemakers/surf/domain/comment/service/CommentService.java
@@ -104,6 +104,10 @@ public class CommentService {
         Comment comment = commentRepository.findById(commentId)
                 .orElseThrow(CommentNotFoundException::new);
 
+        if (comment.isDeleted()) {
+            throw new AlreadyDeletedCommentException();
+        }
+
         // 본인이 쓴 댓글인지 확인
         if (!comment.getPost().getId().equals(postId) || !comment.getMember().getId().equals(memberId))
             throw new NotMyCommentException();


### PR DESCRIPTION
## 📄 작업 내용 요약

> **댓글 생성, 조회, 삭제 로직 전반을 리팩토링하고, 프론트에서 요청한 사항을 반영하였습니다.**

## 1. parentId 제거 및 댓글 depth 구조 정리
- 댓글 depth가 0(루트) / 1(대댓글) 2단계만 존재하므로 parentId와 rootId가 동일 -> parentId 필드를 완전히 제거함
- 서비스 로직에서 parentId 기반 분기를 삭제하고 rootId만으로 루트/대댓글 판별하도록 구조 통일.

## 2. 댓글 조회 응답 구조 통일 및 누락 항목 반영
> **`CommentListResDTO` 추가**
- 기존 Slice<CommentResDTO>만 반환하던 구조에서 프론트 요구사항에 맞게 아래 항목을 포함하는 전용 DTO로 통합
- comments (댓글 목록), totalCount (삭제되지 않은 댓글 수), hasNext (다음 페이지 존재 여부)

> **누락 항목 추가 반영**
- 댓글 프로필 이미지 URL 

## 3. 삭제 및 조회 관련 오류 수정
> **삭제된 댓글에 대댓글 작성이 되는 문제** 
- 삭제된 루트 댓글에 대댓글을 생성하지 못하도록 CannotReplyToDeletedCommentException 추가
- createComment() 내부에 root.isDeleted() 검사 로직 추가
`if (root.isDeleted()) throw new CannotReplyToDeletedCommentException();`

> **soft delete 시 totalCount가 줄어들지 않는 문제**
- 기존 countByPostId() → soft-delete 포함되어 잘못된 값 반환
- countByPostIdAndDeletedFalse() 추가하여 삭제되지 않은 댓글만 집계하도록 수정
`long totalCount = commentRepository.countByPostIdAndDeletedFalse(postId);`

## 4. 자동 수동 멘션 구분
> **댓글 클릭 → 자동 멘션 → 대댓글**
> **수동 @입력 멘션 → 루트 댓글**

- CommentCreateReqDTO에 isAutoMention(Boolean) 필드 추가
- 자동 멘션 여부에 따라 구분
  - isAutoMention = true: depth=1 대댓글 생성
  - isAutoMention = false: depth=0 루트 댓글로 처리 (수동 멘션이면 무조건 루트 취급)


## 📎 Issue 번호
closed #151

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 댓글 작성 요청에 rootId 및 자동 멘션(isAutoMention) 필드 추가
  * 댓글 응답에 작성자 프로필 이미지 표시 및 댓글 목록에 totalCount·hasNext 포함

* **Bug Fixes**
  * 삭제된 댓글에 대한 대댓글 작성 차단 로직 추가

* **Improvements**
  * 댓글 삭제 동작 개선(루트 댓글과 대댓글 구분하여 소프트/하드 삭제 처리, 댓글 수 정확화)
  * 댓글 조회 API 반환 형식 변경으로 목록·페이지 정보 명확화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->