### PR TITLE
[FIX] 대댓글 depth 무한대 허용 및 오류 수정

### DIFF
--- a/src/main/java/com/tavemakers/surf/domain/comment/dto/req/CommentCreateReqDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/comment/dto/req/CommentCreateReqDTO.java
@@ -11,12 +11,13 @@ public record CommentCreateReqDTO(
 
         @Schema(
                 description = """
-                루트 댓글을 생성할 때는 null,
-                대댓글을 생성할 때는 루트 댓글의 ID를 입력합니다.
+                부모 댓글 ID (바로 위 상위 댓글).
+                자동 멘션(=대댓글)일 때만 값 있음.
+                수동 멘션 또는 일반 루트 댓글이면 null.
                 """,
                 example = "null"
         )
-        Long rootId, // 해당 값 null 이면 루트 댓글, 값 있으면 대댓글
+        Long parentId,
 
         @Schema(description = "내용", example = "좋은 공지 감사합니다!")
         @NotBlank

--- a/src/main/java/com/tavemakers/surf/domain/comment/dto/res/CommentResDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/comment/dto/res/CommentResDTO.java
@@ -14,10 +14,13 @@ public record CommentResDTO(
         @Schema(description = "게시글 ID", example = "3")
         Long postId,
 
-        @Schema(description = "루트 댓글 ID", example = "15")
+        @Schema(description = "루트 댓글 ID (최상위 댓글)", example = "15")
         Long rootId,
 
-        @Schema(description = "댓글 깊이 (0=루트, 1=대댓글)", example = "0")
+        @Schema(description = "부모 댓글 ID (루트면 null)", example = "null")
+        Long parentId,
+
+        @Schema(description = "댓글 깊이 (0=루트, 그 외=대댓글)", example = "0")
         int depth,
 
         @Schema(description = "댓글 내용", example = "좋은 공지 감사합니다!")
@@ -52,6 +55,7 @@ public record CommentResDTO(
                 comment.getId(),
                 comment.getPost().getId(),
                 comment.getRootId(),
+                comment.getParent() != null ? comment.getParent().getId() : null,
                 comment.getDepth(),
                 comment.getContent(),
                 comment.getMember().getId(),

--- a/src/main/java/com/tavemakers/surf/domain/comment/exception/CannotLikeDeletedCommentException.java
+++ b/src/main/java/com/tavemakers/surf/domain/comment/exception/CannotLikeDeletedCommentException.java
@@ -1,0 +1,14 @@
+package com.tavemakers.surf.domain.comment.exception;
+
+import com.tavemakers.surf.domain.comment.exception.ErrorMessage;
+import com.tavemakers.surf.global.common.exception.BaseException;
+
+public class CannotLikeDeletedCommentException extends BaseException {
+
+    public CannotLikeDeletedCommentException() {
+        super(
+                ErrorMessage.CANNOT_LIKE_DELETED_COMMENT.getStatus(),
+                ErrorMessage.CANNOT_LIKE_DELETED_COMMENT.getMessage()
+        );
+    }
+}

--- a/src/main/java/com/tavemakers/surf/domain/comment/exception/CommentDepthExceedException.java
+++ b/src/main/java/com/tavemakers/surf/domain/comment/exception/CommentDepthExceedException.java
@@ -1,9 +1,0 @@
-package com.tavemakers.surf.domain.comment.exception;
-
-import com.tavemakers.surf.global.common.exception.BaseException;
-
-public class CommentDepthExceedException extends BaseException {
-    public CommentDepthExceedException() {
-        super(ErrorMessage.COMMENT_DEPTH_EXCEEDED.getStatus(), ErrorMessage.COMMENT_DEPTH_EXCEEDED.getMessage());
-    }
-}

--- a/src/main/java/com/tavemakers/surf/domain/comment/exception/ErrorMessage.java
+++ b/src/main/java/com/tavemakers/surf/domain/comment/exception/ErrorMessage.java
@@ -8,13 +8,13 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum ErrorMessage {
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 [댓글]입니다."),
-    COMMENT_DEPTH_EXCEEDED(HttpStatus.BAD_REQUEST, "[댓글]의 최대 깊이(2)를 초과했습니다."),
     NOT_MY_COMMENT(HttpStatus.FORBIDDEN, "본인의 [댓글]이 아닙니다."),
     INVALID_BLANK_COMMENT(HttpStatus.BAD_REQUEST, "[댓글] 내용은 공백일 수 없습니다."),
     ALREADY_DELETED_COMMENT(HttpStatus.BAD_REQUEST, "이미 삭제된 [댓글]입니다."),
     COMMENT_MENTION_SELF(HttpStatus.BAD_REQUEST, "자기 자신을 멘션할 수 없습니다."),
     INVALID_MENTION_SEARCH_KEYWORD(HttpStatus.BAD_REQUEST, "회원 멘션은 @으로 시작해야 하며, 이름은 두 글자 이상 입력해주세요. ex) @홍길"),
-    CANNOT_REPLY_TO_DELETED_COMMENT(HttpStatus.BAD_REQUEST, "삭제된 [댓글]에는 대댓글을 작성할 수 없습니다.");
+    CANNOT_REPLY_TO_DELETED_COMMENT(HttpStatus.BAD_REQUEST, "삭제된 [댓글]에는 대댓글을 작성할 수 없습니다."),
+    CANNOT_LIKE_DELETED_COMMENT(HttpStatus.BAD_REQUEST, "삭제된 [댓글]에는 좋아요를 누를 수 없습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/tavemakers/surf/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/tavemakers/surf/domain/comment/repository/CommentRepository.java
@@ -10,9 +10,10 @@ import org.springframework.transaction.annotation.Transactional;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
-    boolean existsByRootIdAndDepth(Long rootId, int depth);
+    /** 대댓글(자식 댓글) 존재 여부 확인, parentId 기반으로만 확인 */
+    boolean existsByParentId(Long parentId);
 
-    /** 본인 댓글만 삭제 */
+    /** 본인 댓글만 삭제 (hard delete) */
     @Transactional
     @Modifying(clearAutomatically = true)
     @Query(value = "DELETE FROM comment WHERE id = :id AND post_id = :postId AND member_id = :memberId", nativeQuery = true)

--- a/src/main/java/com/tavemakers/surf/domain/comment/service/CommentLikeService.java
+++ b/src/main/java/com/tavemakers/surf/domain/comment/service/CommentLikeService.java
@@ -1,9 +1,9 @@
 package com.tavemakers.surf.domain.comment.service;
 
 import com.tavemakers.surf.domain.comment.dto.res.CommentLikeMemberResDTO;
-import com.tavemakers.surf.domain.comment.dto.res.MentionResDTO;
 import com.tavemakers.surf.domain.comment.entity.Comment;
 import com.tavemakers.surf.domain.comment.entity.CommentLike;
+import com.tavemakers.surf.domain.comment.exception.CannotLikeDeletedCommentException;
 import com.tavemakers.surf.domain.comment.exception.CommentNotFoundException;
 import com.tavemakers.surf.domain.comment.repository.CommentLikeRepository;
 import com.tavemakers.surf.domain.comment.repository.CommentRepository;
@@ -33,6 +33,11 @@ public class CommentLikeService {
                 .orElseThrow(CommentNotFoundException::new);
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(MemberNotFoundException::new);
+
+        // soft delete 댓글에는 좋아요 불가
+        if (comment.isDeleted()) {
+            throw new CannotLikeDeletedCommentException();
+        }
 
         Post post = comment.getPost();
         if (post == null) throw new CommentNotFoundException();


### PR DESCRIPTION
## 📄 작업 내용 요약

> 댓글 파트 연동 중 프론트 요청 및 soft delete 관련 오류가 발견되어 수정하였습니다.
> 디자인 파트에서 댓글 기능은 토스증권 앱의 댓글을 벤치마킹했다고 합니다.

## 1. 대댓글 관련 정리 
- root 댓글은 원 댓글, parent 댓글은 바로 상위의 댓글
- 대댓글 조건:  `parentId != null && isAutoMention = true`
- 수동 멘션(@직접 입력)은 대댓글이 아님

## 2. 무한 depth 구조 구현
> 기존 구조는 depth=0(root), depth=1(child)만 허용했으나 대댓글의 대댓글 같은 경우를 위해 무한 depth 구조를 지원하도록 변경했습니다.

- UI는 depth=0로 동일하게 보여주되, 내부적으로는 무한 depth 지원
- rootId + depth 제한 구조 제거
- parentId 기반 트리 구조로 변경

## 3. soft 삭제된 댓글에 좋아요 불가 처리
> soft delete된 댓글에도 좋아요가 눌려지는 문제를 수정하기 위해 해당 코드를 추가하였습니다.
```
// soft delete 댓글에는 좋아요 불가
      if (comment.isDeleted()) {
          throw new CannotLikeDeletedCommentException();
      }
```

## 4. soft delete → hard delete 자동 전환

아래와 같은 구조에서
```
A
└ B
   └ C
      └ D
```
- 기존 문제: C soft delete 후 D hard delete 시 C가 soft delete 된 상태(삭제된 댓글입니다 표기)로 계속 존재
- 변경: C soft delete 후 D hard delete 시 C도 자동으로 삭제됨
- 삭제 전에 parent를 영속 상태로 로딩해둔 뒤, 자식이 더 이상 없고 soft 삭제된 부모들을 위로 올라가며 연쇄 하드 삭제하도록 구성하였습니다.
```
Comment parent = null;
if (comment.getParent() != null) {
    Long parentId = comment.getParent().getId();
    parent = commentRepository.findById(parentId).orElse(null);
}

while (parent != null) {
    if (parent.isDeleted() && !commentRepository.existsByParentId(parent.getId())) {
        Long nextParentId = parent.getParent() != null ? parent.getParent().getId() : null;
        commentRepository.delete(parent);
        parent = nextParentId != null ? commentRepository.findById(nextParentId).orElse(null) : null;
    } else break;
}
```

## 📎 Issue 번호 
#159 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 댓글에 대한 무한 깊이의 답글 작성 지원
  * 삭제된 댓글에 좋아요 기능 비활성화
  * 삭제된 댓글에 대한 답글 작성 방지

* **Bug Fixes**
  * 댓글 삭제 시 내용을 보호된 메시지로 변경하여 데이터 무결성 개선

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->