### PR TITLE
[Feat] 게시글 조회수 기능 구현

### DIFF
--- a/src/main/java/com/tavemakers/surf/domain/post/dto/res/PostDetailResDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/dto/res/PostDetailResDTO.java
@@ -68,7 +68,9 @@ public record PostDetailResDTO(
             boolean scrappedByMe,
             boolean likedByMe,
             boolean isMine,
-            List<PostImageResDTO> imageUrlList) {
+            List<PostImageResDTO> imageUrlList,
+            int viewCount
+            ) {
         return PostDetailResDTO.builder()
                 .postId(post.getId())
                 .title(post.getTitle())
@@ -86,7 +88,7 @@ public record PostDetailResDTO(
                 .profileImageUrl(post.getMember().getProfileImageUrl())
                 .isMine(isMine)
                 .imageUrlList(imageUrlList)
-                .viewCount(post.getViewCount())
+                .viewCount(viewCount)
                 .hasSchedule(post.getHasSchedule())
                 .build();
     }

--- a/src/main/java/com/tavemakers/surf/domain/post/service/PostService.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/service/PostService.java
@@ -60,6 +60,7 @@ public class PostService {
     private final PostImageGetService postImageGetService;
     private final PostImageDeleteService postImageDeleteService;
     private final MemberGetService memberGetService;
+    private final ViewCountService viewCountService;
     private final FlagsMapper flagsMapper;
 
 
@@ -84,10 +85,10 @@ public class PostService {
             List<PostImageCreateReqDTO> imageUrlList = req.imageUrlList();
             saved.addThumbnailUrl(findFirstImage(imageUrlList));
             List<PostImageResDTO> imageUrlResponseList = imageSaveService.saveAll(saved, imageUrlList);
-            return PostDetailResDTO.of(saved, false, false, true, imageUrlResponseList);
+            return PostDetailResDTO.of(saved, false, false, true, imageUrlResponseList, 0);
         }
 
-        return PostDetailResDTO.of(saved, false, false,true,null);
+        return PostDetailResDTO.of(saved, false, false,true,null, 0);
     }
 
     @Transactional(readOnly = true)
@@ -98,7 +99,8 @@ public class PostService {
         boolean likedByMe = postLikeService.isLikedByMe(memberId, postId);
         boolean isMine = post.isOwner(memberId);
         List<PostImageResDTO> imageUrlList = getImageUrlList(post);
-        return PostDetailResDTO.of(post, scrappedByMe, likedByMe, isMine, imageUrlList);
+        int viewCount = viewCountService.increaseViewCount(post, memberId);
+        return PostDetailResDTO.of(post, scrappedByMe, likedByMe, isMine, imageUrlList, viewCount);
     }
 
     @Transactional(readOnly = true)
@@ -169,6 +171,7 @@ public class PostService {
 
         boolean scrappedByMe = scrapService.isScrappedByMe(viewerId, postId);
         boolean likedByMe = postLikeService.isLikedByMe(viewerId, postId);
+        int viewCount = viewCountService.increaseViewCount(post, viewerId);
 
         // 예약 시간 변경 시 -> 기존의 예약 시간 조회 -> 기존의 예약 시간을 CANCELD로 수정하고 schedule 호출하면 끝.
         if (req.isReservationChanged()) {
@@ -181,11 +184,11 @@ public class PostService {
             List<PostImageCreateReqDTO> changeImage = req.imageUrlList();
             post.addThumbnailUrl(findFirstImage(changeImage));
             List<PostImageResDTO> savedChangedImage = imageSaveService.saveAll(post, changeImage);
-            return PostDetailResDTO.of(post, scrappedByMe, likedByMe, true, savedChangedImage);
+            return PostDetailResDTO.of(post, scrappedByMe, likedByMe, true, savedChangedImage, viewCount);
         }
 
         List<PostImageResDTO> imageDtoList = getImageUrlList(post);
-        return PostDetailResDTO.of(post, scrappedByMe, likedByMe, true, imageDtoList);
+        return PostDetailResDTO.of(post, scrappedByMe, likedByMe, true, imageDtoList, viewCount);
     }
 
     private void deleteExistingImage(Post post) {

--- a/src/main/java/com/tavemakers/surf/domain/post/service/ViewCountService.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/service/ViewCountService.java
@@ -1,0 +1,46 @@
+package com.tavemakers.surf.domain.post.service;
+
+import com.tavemakers.surf.domain.post.entity.Post;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+@Service
+@RequiredArgsConstructor
+public class ViewCountService {
+
+    private static final String VIEW_COUNT_KEY = "post:%d:view:count";
+    private static final String VIEWERS_KEY = "post:%d:viewers:%d";
+    private static final Duration VIEW_COUNT_TTL = Duration.ofDays(1);
+
+    private final StringRedisTemplate redisTemplate;
+
+    public int increaseViewCount(Post post, Long viewerId) {
+        String viewCountKey = generateViewCountKey(post.getId());
+        String viewersKey = generateViewersKey(post.getId(), viewerId);
+
+        Boolean alreadyViewed = redisTemplate.hasKey(viewersKey);
+        if(Boolean.FALSE.equals(alreadyViewed)) {
+            if (Boolean.FALSE.equals(redisTemplate.hasKey(viewCountKey))) {
+                redisTemplate.opsForValue().set(viewCountKey, String.valueOf(post.getViewCount()));
+            }
+
+            redisTemplate.opsForValue().increment(viewCountKey, 1);
+            redisTemplate.opsForValue().set(viewersKey, "1", VIEW_COUNT_TTL);
+        }
+
+        String viewCount = redisTemplate.opsForValue().get(viewCountKey);
+        return viewCount != null ? Integer.parseInt(viewCount) : post.getViewCount();
+    }
+
+    private String generateViewCountKey(Long postId) {
+        return String.format(VIEW_COUNT_KEY, postId);
+    }
+
+    private String generateViewersKey(Long postId, Long viewerId) {
+        return String.format(VIEWERS_KEY, postId, viewerId);
+    }
+
+}


### PR DESCRIPTION
## 📄 작업 내용 요약

게시글 조회수 기능 구현

## 1️⃣  조회수 요구사항
- 게시글 상세 조회시 조회수가 증가한다.
- 단, 24시간이내 하나의 게시글에 대해서 조회수를 증가시킬 수 없다. (한 유저당)

## 2️⃣ 조회수 비지니스 로직

- Redis를 사용하여 조회수 기능을 구현했습니다.

1. 요청자가 24시간 이내에 본 게시글인 지 확인
2. 안봤다면
    1. Redis에 viewCountKey가 존재하는 지 확인한다. -> 없다면 DB 조회수를 세팅해준다.
    2. 조회수를 1 증가시킨다.
3. 24시간 이내에 봤다면 -> Redis에서 조회수를 그대로 가져온다. (증가시키지 않음)

## 3️⃣  Redis를 사용한 이유
### 낙관적 락의 문제

`Post`는 동시성 문제를 1차적인 해결책으로 `낙관적 락`을 사용하고 있습니다.
`좋아요`기능은 동시에 잘 일어나지 않기 때문에 이를 고려하여 `낙관적 락`을 사용한 것입니다.

그러나 조회수 기능은 `게시글 조회`에 일어나고 이는 가장 많이 일어나는 요청입니다.
따라서 낙관적 락으로는 동시성 문제가 발생할 수 밖에 없습니다.

### 비관적 락의 문제

비관적 락을 사용할 경우 동시성 문제를 해결할 수 있겠지만, 격리수준에 의한 성능 저하가 우려되어 사용하지 않았습니다.
또한 중복 방지 로직까지 적용하는 경우 RDB만으로는 비지니스 로직이 복잡해질 것이라 생각했습니다.

### Redis

이러한 이유로 인메모리 기반으로하여 디스크보다 빠르고, TTL로 중복 방지까지 구현하기 적절한 Redis를 선택했습니다.

## 4️⃣ 성능 비교

10초간 10명, 30초간 50명, 10초간 0명으로 줄어들도록 요청을 보내는 부하 테스트를 진행했습니다.
낙관적 락은 동시성 문제가 발생했으며, 비관적 락은 Redis에 비해서 성능이 떨어지는 것을 확인할 수 있었습니다.

### 낙관적 락 사용 시
응답 성공 `67%`
성공된 응답의 평균 `47.65ms`
성공된 응답의 95%는 65.19ms 보장.

### 비관적 락 사용 시
응답 성공 `100%`
평균 `65.16ms`
95%의 응답은 `96ms` 보장.

### Redis 사용 시
응답 성공 `100%`
평균 `29.26ms`
95%의 응답은 `43.88ms` 보장


## 5️⃣  viewCountKey가 없는 경우 DB 조회수를 넣는 이유

1. Post의 viewCount Field는 int타입이므로, Default Value가 0이라, Redis에 초기 조회수가 없는 경우 int의 Default Value인 0을 넣을 수 있습니다.
2. Redis에 장애가 발생 혹은 오래 조회되지않은 Post의 경우는 Redis에서 사라질 수 있음. 이때 DB 조회수를 넣어주기 위함.

## 📎 Issue 번호
<!-- closed #번호 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## 6️⃣ Flow Chart

<img width="575" height="1195" alt="게시글 조회 플로우 차트" src="https://github.com/user-attachments/assets/86f6b9e5-2a89-40af-8fa3-79a6f2712a70" />




## 릴리스 노트

* **New Features**
  * 게시물별 조회수 기능이 추가되어 각 게시물의 조회수가 정확하게 집계됩니다.
  * 동일 사용자의 중복 조회는 24시간 동안 중복 집계되지 않아 조회수 통계가 개선됩니다.
  * 게시물 생성·조회·수정 시 최신 조회수가 반영되어 사용자에게 일관된 조회수가 표시됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->