### PR TITLE
[FIX] post와의 연관관계 매핑 간 cascade 오류

### DIFF
--- a/src/main/java/com/tavemakers/surf/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/tavemakers/surf/domain/comment/repository/CommentRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
@@ -29,7 +30,9 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     @Query("UPDATE Comment c SET c.deleted = true, c.content = '(삭제된 댓글입니다.)' WHERE c.id = :id")
     void softDeleteById(Long id);
 
-    void deleteByPostId(Long postId);
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("delete from Comment c where c.post.id = :postId")
+    void deleteAllByPostId(@Param("postId") Long postId);
 }
 
 

--- a/src/main/java/com/tavemakers/surf/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/tavemakers/surf/domain/comment/repository/CommentRepository.java
@@ -28,6 +28,8 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     @Modifying(clearAutomatically = true)
     @Query("UPDATE Comment c SET c.deleted = true, c.content = '(삭제된 댓글입니다.)' WHERE c.id = :id")
     void softDeleteById(Long id);
+
+    void deleteByPostId(Long postId);
 }
 
 

--- a/src/main/java/com/tavemakers/surf/domain/post/entity/Post.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/entity/Post.java
@@ -73,18 +73,6 @@ public class Post extends BaseEntity {
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
-    @OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE, orphanRemoval = true)
-    private List<Comment> comments = new ArrayList<>();
-
-    @OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE, orphanRemoval = true)
-    private List<PostLike> postLikes = new ArrayList<>();
-
-    @OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE, orphanRemoval = true)
-    private List<Scrap> scraps = new ArrayList<>();
-
-    @OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE, orphanRemoval = true)
-    private List<PostImageUrl> postImageUrls = new ArrayList<>();
-
     private Boolean hasSchedule;
 
     public static Post of(PostCreateReqDTO req, Board board, BoardCategory category, Member member) {

--- a/src/main/java/com/tavemakers/surf/domain/post/entity/Post.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/entity/Post.java
@@ -2,9 +2,11 @@ package com.tavemakers.surf.domain.post.entity;
 
 import com.tavemakers.surf.domain.board.entity.Board;
 import com.tavemakers.surf.domain.board.entity.BoardCategory;
+import com.tavemakers.surf.domain.comment.entity.Comment;
 import com.tavemakers.surf.domain.member.entity.Member;
 import com.tavemakers.surf.domain.post.dto.req.PostCreateReqDTO;
 import com.tavemakers.surf.domain.post.dto.req.PostUpdateReqDTO;
+import com.tavemakers.surf.domain.scrap.entity.Scrap;
 import com.tavemakers.surf.global.common.entity.BaseEntity;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
@@ -14,6 +16,8 @@ import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -68,6 +72,18 @@ public class Post extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
+
+    @OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<Comment> comments = new ArrayList<>();
+
+    @OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<PostLike> postLikes = new ArrayList<>();
+
+    @OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<Scrap> scraps = new ArrayList<>();
+
+    @OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<PostImageUrl> postImageUrls = new ArrayList<>();
 
     private Boolean hasSchedule;
 

--- a/src/main/java/com/tavemakers/surf/domain/post/repository/PostLikeRepository.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/repository/PostLikeRepository.java
@@ -29,4 +29,6 @@ public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
             "FROM PostLike pl " +
             "WHERE pl.post.id = :postId")
     List<Member> findLikedMembersByPostId(@Param("postId") Long postId);
+
+    void deleteByPostId(Long postId);
 }

--- a/src/main/java/com/tavemakers/surf/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/repository/PostRepository.java
@@ -15,6 +15,10 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     Slice<Post> findByBoardIdAndCategoryId(Long boardId, Long categoryId, Pageable pageable);
 
+    Slice<Post> findByBoardIdAndIsReservedFalse(Long boardId, Pageable pageable);
+
+    Slice<Post> findByBoardIdAndCategoryIdAndIsReservedFalse(Long boardId, Long categoryId, Pageable pageable);
+
     Slice<Post> findByMemberId(Long memberId, Pageable pageable);
 
     @Query("select p.version from Post p where p.id = :id")

--- a/src/main/java/com/tavemakers/surf/domain/post/repository/ScheduleRepository.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/repository/ScheduleRepository.java
@@ -24,4 +24,6 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
 
     @Query("SELECT s.post FROM Schedule s WHERE s.id = :scheduleId")
     Optional<Post> findPostByScheduleId(Long scheduleId);
+
+    void deleteByPostId(Long postId);
 }

--- a/src/main/java/com/tavemakers/surf/domain/post/service/PostService.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/service/PostService.java
@@ -8,6 +8,7 @@ import com.tavemakers.surf.domain.board.exception.CategoryRequiredException;
 import com.tavemakers.surf.domain.board.exception.InvalidCategoryMappingException;
 import com.tavemakers.surf.domain.board.repository.BoardCategoryRepository;
 import com.tavemakers.surf.domain.board.repository.BoardRepository;
+import com.tavemakers.surf.domain.comment.repository.CommentRepository;
 import com.tavemakers.surf.domain.member.entity.Member;
 import com.tavemakers.surf.domain.member.exception.MemberNotFoundException;
 import com.tavemakers.surf.domain.member.repository.MemberRepository;
@@ -23,8 +24,11 @@ import com.tavemakers.surf.domain.post.entity.PostImageUrl;
 import com.tavemakers.surf.domain.post.exception.PostDeleteAccessDeniedException;
 import com.tavemakers.surf.domain.post.exception.PostImageListEmptyException;
 import com.tavemakers.surf.domain.post.exception.PostNotFoundException;
+import com.tavemakers.surf.domain.post.repository.PostLikeRepository;
 import com.tavemakers.surf.domain.post.repository.PostRepository;
+import com.tavemakers.surf.domain.post.repository.ScheduleRepository;
 import com.tavemakers.surf.domain.reservation.usecase.ReservationUsecase;
+import com.tavemakers.surf.domain.scrap.repository.ScrapRepository;
 import com.tavemakers.surf.domain.scrap.service.ScrapService;
 import com.tavemakers.surf.global.logging.LogEvent;
 import com.tavemakers.surf.global.logging.LogParam;
@@ -49,6 +53,10 @@ public class PostService {
     private final PostRepository postRepository;
     private final MemberRepository memberRepository;
     private final BoardCategoryRepository boardCategoryRepository;
+    private final ScheduleRepository scheduleRepository;
+    private final ScrapRepository scrapRepository;
+    private final CommentRepository commentRepository;
+    private final PostLikeRepository postLikeRepository;
 
     private final ScrapService scrapService;
     private final PostLikeService postLikeService;
@@ -200,6 +208,11 @@ public class PostService {
         Post post = postGetService.getPost(postId);
         Member member = memberGetService.getMember(SecurityUtils.getCurrentMemberId());
         validateOwnerOrManager(post, member);
+
+        scheduleRepository.deleteByPostId(postId);
+        postLikeRepository.deleteByPostId(postId);
+        scrapRepository.deleteByPostId(postId);
+        commentRepository.deleteByPostId(postId);
 
         List<PostImageUrl> postImageUrls = postImageGetService.getPostImageUrls(post.getId());
         if (postImageUrls != null && !postImageUrls.isEmpty()) {

--- a/src/main/java/com/tavemakers/surf/domain/post/service/PostService.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/service/PostService.java
@@ -219,7 +219,7 @@ public class PostService {
         scheduleRepository.deleteByPostId(postId);
         postLikeRepository.deleteByPostId(postId);
         scrapRepository.deleteByPostId(postId);
-        commentRepository.deleteByPostId(postId);
+        commentRepository.deleteAllByPostId(postId);
 
         List<PostImageUrl> postImageUrls = postImageGetService.getPostImageUrls(post.getId());
         if (postImageUrls != null && !postImageUrls.isEmpty()) {

--- a/src/main/java/com/tavemakers/surf/domain/scrap/repository/ScrapRepository.java
+++ b/src/main/java/com/tavemakers/surf/domain/scrap/repository/ScrapRepository.java
@@ -33,4 +33,6 @@ public interface ScrapRepository extends JpaRepository<Scrap, Long> {
              and s.post.id in :postIds
            """)
     Set<Long> findScrappedPostIdsByMemberAndPostIds(Long memberId, Collection<Long> postIds);
+
+    void deleteByPostId(Long postId);
 }


### PR DESCRIPTION
## 📄 작업 내용 요약
post와 연관관계 매핑이 이루어져있는 comment, scrap, postlike 등에 의해 post 삭제가 정상적으로 이루어지지 않았습니다.
서비스 코드 내에서 repository를 호출하여 post 삭제 전 모든 관계되어 있는 데이터를 삭제하였습니다.

특히, comment에서는 자기참조로 인해 
```
@Modifying(clearAutomatically = true, flushAutomatically = true)
    @Query("delete from Comment c where c.post.id = :postId")
    void deleteAllByPostId(@Param("postId") Long postId);
```
를 작성하여 댓글의 root와 depth와 관계없이 post 삭제 시 모든 댓글이 삭제되도록 하였습니다.
이전에 있던 parent_id와 그것에 관한 fk가 여전히 db상에 남아 있어 해당 부분은 수정해두었습니다.

또한, 게시글 조회 시 member의 role과 상관없이 예약처리된 게시물이 조회되는 문제가 있었습니다.
이미 존재하던 hasDeleteRole을 사용하여 일반 회원은 예약처리된 게시물 (isReserved = true)가 조회되지 않도록 수정하였습니다.


## 📎 Issue 번호
<!-- closed #163  -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 게시물 조회에 권한 기반 접근 제어 추가: 관리자는 모든 게시물 조회, 일반 사용자는 예약되지 않은 게시물만 조회
  * 게시물 삭제 시 연관된 댓글·좋아요·일정·스크랩이 함께 자동 삭제되도록 연쇄 삭제 처리 개선

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->