### PR TITLE
[Feat] 일정 개별 삭제 로직

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -63,6 +63,8 @@ dependencies {
     // AWS S3
     implementation ("org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE")
 
+    implementation ("io.github.cdimascio:dotenv-java:2.2.4")
+
 }
 
 // log4j2 사용을 위해 추가

--- a/src/main/java/com/tavemakers/surf/domain/post/controller/ScheduleDeleteController.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/controller/ScheduleDeleteController.java
@@ -26,4 +26,13 @@ public class ScheduleDeleteController {
         scheduleUseCase.deleteSchedule(scheduleId);
         return ApiResponse.response(HttpStatus.OK, SCHEDULE_DELETED.getMessage(), null);
     }
+
+    @Operation(summary = "게시글과 매핑된 일정 삭제", description = "일정을 삭제합니다.")
+    @DeleteMapping("/v1/admin/posts/{postId}/schedules/{scheduleId}")
+    public ApiResponse<Void> deleteScheduleAtPost(
+            @PathVariable("postId") Long postId,
+            @PathVariable("scheduleId") Long scheduleId) {
+        scheduleUseCase.deleteScheduleAtPost(postId, scheduleId);
+        return ApiResponse.response(HttpStatus.OK, SCHEDULE_DELETED.getMessage(), null);
+    }
 }

--- a/src/main/java/com/tavemakers/surf/domain/post/entity/Post.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/entity/Post.java
@@ -135,7 +135,7 @@ public class Post extends BaseEntity {
         return member.getId().equals(memberId);
     }
 
-    public void changeHasSchedule(){
-        this.hasSchedule = false;
+    public void changeHasSchedule(boolean hasSchedule) {
+        this.hasSchedule = hasSchedule;
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/post/repository/ScheduleRepository.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/repository/ScheduleRepository.java
@@ -23,5 +23,6 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
 
 
     @Query("SELECT s.post FROM Schedule s WHERE s.id = :scheduleId")
-    Optional<Post> findPostByScheduleId(Long scheduleId);
+    Post findPostByScheduleId(Long scheduleId);
+
 }

--- a/src/main/java/com/tavemakers/surf/domain/post/repository/ScheduleRepository.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/repository/ScheduleRepository.java
@@ -21,10 +21,5 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
 
     Optional<Schedule> findByPostId(Long postId);
 
-
-    @Query("SELECT s.post FROM Schedule s WHERE s.id = :scheduleId")
-
-    void deleteByPostId(Long postId);
-    Post findPostByScheduleId(Long scheduleId);
-
+    void deleteByPost(Post post);
 }

--- a/src/main/java/com/tavemakers/surf/domain/post/service/PostGetService.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/service/PostGetService.java
@@ -38,11 +38,4 @@ public class PostGetService {
                 .orElseThrow(PostNotFoundException::new);
     }
 
-    @Transactional
-    public void findByScheduleId(Long scheduleId) {
-        Post post = scheduleRepository.findPostByScheduleId(scheduleId);
-        if (post!=null){
-            post.changeHasSchedule();
-        }
-    }
 }

--- a/src/main/java/com/tavemakers/surf/domain/post/service/PostGetService.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/service/PostGetService.java
@@ -39,8 +39,10 @@ public class PostGetService {
     }
 
     @Transactional
-    public Post findByScheduleId(Long scheduleId) {
-        return scheduleRepository.findPostByScheduleId(scheduleId)
-                .orElseThrow(PostNotFoundException::new);
+    public void findByScheduleId(Long scheduleId) {
+        Post post = scheduleRepository.findPostByScheduleId(scheduleId);
+        if (post!=null){
+            post.changeHasSchedule();
+        }
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/post/service/PostService.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/service/PostService.java
@@ -71,7 +71,6 @@ public class PostService {
     private final ViewCountService viewCountService;
     private final FlagsMapper flagsMapper;
 
-
     @Transactional
     @LogEvent(value = "post.create", message = "게시글 생성 성공")
     public PostDetailResDTO createPost(PostCreateReqDTO req, Long memberId) {
@@ -219,7 +218,8 @@ public class PostService {
         Member member = memberGetService.getMember(SecurityUtils.getCurrentMemberId());
         validateOwnerOrManager(post, member);
 
-        scheduleRepository.deleteByPostId(postId);
+        //일정 삭제
+        scheduleRepository.deleteByPost(post);
         postLikeRepository.deleteByPostId(postId);
         scrapRepository.deleteByPostId(postId);
         commentRepository.deleteAllByPostId(postId);

--- a/src/main/java/com/tavemakers/surf/domain/post/service/SchedulePatchService.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/service/SchedulePatchService.java
@@ -1,6 +1,7 @@
 package com.tavemakers.surf.domain.post.service;
 
 import com.tavemakers.surf.domain.post.dto.req.ScheduleUpdateReqDTO;
+import com.tavemakers.surf.domain.post.entity.Post;
 import com.tavemakers.surf.domain.post.entity.Schedule;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -14,5 +15,11 @@ public class SchedulePatchService {
     @Transactional
     public void updateSchedule(Schedule schedule, ScheduleUpdateReqDTO dto) {
         schedule.updateSchedule(dto);
+    }
+
+    //일정 존재 여부 변경
+    @Transactional
+    public void updateHasScheduleTrue(Post post, boolean hasSchedule) {
+        post.changeHasSchedule(hasSchedule);
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/post/service/ScheduleUseCase.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/service/ScheduleUseCase.java
@@ -44,8 +44,7 @@ public class ScheduleUseCase {
     @Transactional
     public void deleteSchedule(Long id) {
         Schedule schedule = scheduleGetService.getScheduleById(id);
-        Post post = postGetService.findByScheduleId(id);
-        post.changeHasSchedule();
+        postGetService.findByScheduleId(id);
         scheduleDeleteService.deleteSchedule(schedule);
     }
 

--- a/src/main/java/com/tavemakers/surf/domain/post/service/ScheduleUseCase.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/service/ScheduleUseCase.java
@@ -40,12 +40,20 @@ public class ScheduleUseCase {
         schedulePatchService.updateSchedule(schedule, dto);
     }
 
-    //일정 삭제
+    //일정 삭제 - 개별
     @Transactional
     public void deleteSchedule(Long id) {
         Schedule schedule = scheduleGetService.getScheduleById(id);
-        postGetService.findByScheduleId(id);
         scheduleDeleteService.deleteSchedule(schedule);
+    }
+
+    @Transactional
+    public void deleteScheduleAtPost(Long postId, Long scheduleId) {
+        Schedule schedule = scheduleGetService.getScheduleById(scheduleId);
+        scheduleDeleteService.deleteSchedule(schedule);
+
+        Post post = postGetService.getPost(postId);
+        schedulePatchService.updateHasScheduleTrue(post,false);
     }
 
     //게시글별 일정 조회


### PR DESCRIPTION
## 📄 작업 내용 요약
기존에는 공지사항과 연동되어 있는 일정 삭제만 고려하여서 문제가 있었습니다..

그래서 일단 간단하게 매핑된 Post가 있는 경우에는 해당 Post의 연관 필드를 변경하고, 없는 경우엔 따로 예외처리를 하지 않는 방향으로 작성하였습니다.

추후에 좀 더 리팩토링 할 예정입니다.

## 📎 Issue 번호
<!-- closed #166  -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 관리자용 새 API: 특정 게시글에 연결된 일정을 한 번에 삭제하고 응답을 반환합니다.
* **리팩토링**
  * 게시글의 일정 보유 여부를 설정하는 방식이 좀 더 명시적으로 변경되어 값 지정이 가능합니다.
* **동작 변경**
  * 일정 삭제 흐름이 분리되어 게시글 상태 갱신은 별도 호출로 처리됩니다.
* **기타**
  * 일정 삭제 시 내부 삭제 방법이 엔티티 참조 기반으로 바뀌었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->