### PR TITLE
[Feat] 조회수 DB 백업 기능 구현

### DIFF
--- a/src/main/java/com/tavemakers/surf/SurfApplication.java
+++ b/src/main/java/com/tavemakers/surf/SurfApplication.java
@@ -4,8 +4,10 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableJpaAuditing
+@EnableScheduling
 @ConfigurationPropertiesScan
 @SpringBootApplication
 public class SurfApplication {

--- a/src/main/java/com/tavemakers/surf/domain/post/dto/PostViewUpdateDto.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/dto/PostViewUpdateDto.java
@@ -1,0 +1,7 @@
+package com.tavemakers.surf.domain.post.dto;
+
+public record PostViewUpdateDto(
+        Long postId,
+        int viewCount
+) {
+}

--- a/src/main/java/com/tavemakers/surf/domain/post/entity/Post.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/entity/Post.java
@@ -138,4 +138,8 @@ public class Post extends BaseEntity {
     public void changeHasSchedule(){
         this.hasSchedule = false;
     }
+
+    public void increaseViewCount() {
+        this.viewCount++;
+    }
 }

--- a/src/main/java/com/tavemakers/surf/domain/post/mapper/PostMapper.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/mapper/PostMapper.java
@@ -1,0 +1,30 @@
+package com.tavemakers.surf.domain.post.mapper;
+
+import com.tavemakers.surf.domain.post.dto.PostViewUpdateDto;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+
+@Slf4j
+@Component
+public class PostMapper {
+
+    private static final String KEY_DELIMITER = ":";
+    private static final int POST_ID_INDEX = 1;
+
+    public PostViewUpdateDto toUpdateDto(String key, String value) {
+        try {
+            Long postId = extractPostId(key);
+            int viewCount = Integer.parseInt(value);
+            return new PostViewUpdateDto(postId, viewCount);
+        } catch (NumberFormatException | ArrayIndexOutOfBoundsException e) {
+            log.warn("유효하지 않은 Key, Value 형식입니다. key={}, value={}", key, value);
+            return null;
+        }
+    }
+
+    private Long extractPostId(String key) {
+        return Long.parseLong(key.split(KEY_DELIMITER)[POST_ID_INDEX]);
+    }
+
+}

--- a/src/main/java/com/tavemakers/surf/domain/post/repository/PostJdbcRepository.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/repository/PostJdbcRepository.java
@@ -1,0 +1,9 @@
+package com.tavemakers.surf.domain.post.repository;
+
+import com.tavemakers.surf.domain.post.dto.PostViewUpdateDto;
+
+import java.util.List;
+
+public interface PostJdbcRepository {
+    void viewCountBulkUpdate(List<PostViewUpdateDto> updateDtoList);
+}

--- a/src/main/java/com/tavemakers/surf/domain/post/repository/PostJdbcRepositoryImpl.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/repository/PostJdbcRepositoryImpl.java
@@ -1,0 +1,31 @@
+package com.tavemakers.surf.domain.post.repository;
+
+import com.tavemakers.surf.domain.post.dto.PostViewUpdateDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.sql.PreparedStatement;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class PostJdbcRepositoryImpl implements PostJdbcRepository {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    @Override
+    public void viewCountBulkUpdate(List<PostViewUpdateDto> updateDtoList) {
+        String bulkUpdateSql =
+                "UPDATE post " +
+                "SET view_count = ? " +
+                "WHERE post_id = ?";
+
+        jdbcTemplate.batchUpdate(bulkUpdateSql, updateDtoList, updateDtoList.size(),
+                (PreparedStatement ps, PostViewUpdateDto dto) -> {
+                    ps.setInt(1, dto.viewCount());
+                    ps.setLong(2, dto.postId());
+                });
+    }
+
+}

--- a/src/main/java/com/tavemakers/surf/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/repository/PostRepository.java
@@ -46,4 +46,8 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     Slice<Post> findByTitleContainingIgnoreCaseOrContentContainingIgnoreCase(
             String title, String content, Pageable pageable);
+
+    @Modifying
+    @Query("UPDATE Post p SET p.viewCount = p.viewCount + 1 WHERE p.id = :postId")
+    void increaseViewCount(@Param("postId") Long postId);
 }

--- a/src/main/java/com/tavemakers/surf/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/repository/PostRepository.java
@@ -46,8 +46,4 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     Slice<Post> findByTitleContainingIgnoreCaseOrContentContainingIgnoreCase(
             String title, String content, Pageable pageable);
-
-    @Modifying
-    @Query("UPDATE Post p SET p.viewCount = p.viewCount + 1 WHERE p.id = :postId")
-    void increaseViewCount(@Param("postId") Long postId);
 }

--- a/src/main/java/com/tavemakers/surf/domain/post/scheduler/ViewCountScheduler.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/scheduler/ViewCountScheduler.java
@@ -30,7 +30,7 @@ public class ViewCountScheduler {
     private final PostUpdateService postUpdateService;
 
     private static final String VIEW_COUNT_PATTERN = "post:*:view:count";
-    private static final int SCAN_SIZE = 1000;
+    private static final int SCAN_SIZE = 100;
 
     @Scheduled(cron = "0 0 * * * *")
     @ExecutionTimeLog(jobName = "조회수 동기화 작업")

--- a/src/main/java/com/tavemakers/surf/domain/post/scheduler/ViewCountScheduler.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/scheduler/ViewCountScheduler.java
@@ -1,0 +1,87 @@
+package com.tavemakers.surf.domain.post.scheduler;
+
+import com.tavemakers.surf.domain.post.dto.PostViewUpdateDto;
+import com.tavemakers.surf.domain.post.mapper.PostMapper;
+import com.tavemakers.surf.domain.post.repository.PostRepository;
+import com.tavemakers.surf.domain.post.service.PostUpdateService;
+import com.tavemakers.surf.global.common.aop.annotations.ExecutionTimeLog;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.Cursor;
+import org.springframework.data.redis.core.ScanOptions;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.IntStream;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ViewCountScheduler {
+
+    private final StringRedisTemplate redisTemplate;
+    private final PostMapper postMapper;
+    private final PostUpdateService postUpdateService;
+
+    private static final String VIEW_COUNT_PATTERN = "post:*:view:count";
+    private static final int SCAN_SIZE = 1000;
+
+    @Scheduled(cron = "0 0 * * * *")
+    @ExecutionTimeLog(jobName = "조회수 동기화 작업")
+    public void synchronizeViewCount() {
+        ScanOptions scanOption = ScanOptions.scanOptions()
+                .match(VIEW_COUNT_PATTERN)
+                .count(SCAN_SIZE)
+                .build();
+
+        List<String> keyBuffer = new ArrayList<>(SCAN_SIZE);
+        try (Cursor<String> cursor = redisTemplate.scan(scanOption)) {
+            while (cursor.hasNext()) {
+                keyBuffer.add(cursor.next());
+
+                if (keyBuffer.size() >= SCAN_SIZE) {
+                    processBulkUpdate(keyBuffer);
+                    keyBuffer.clear();
+                }
+            }
+
+            if (!keyBuffer.isEmpty()) {
+                processBulkUpdate(keyBuffer);
+            }
+        } catch (Exception e) {
+            log.error("조회수 동기화 작업에 실패했습니다.", e);
+        }
+    }
+
+    private void processBulkUpdate(List<String> viewCountKeys) {
+        List<String> viewCountValues = readViewCountValues(viewCountKeys);
+        List<PostViewUpdateDto> updateDtoList = convertToUpdateDtoList(viewCountKeys, viewCountValues);
+        executeViewCountUpdate(updateDtoList);
+    }
+
+    private List<String> readViewCountValues(List<String> keys) {
+        List<String> values = redisTemplate.opsForValue().multiGet(keys);
+        return values != null ? values : List.of();
+    }
+
+    private List<PostViewUpdateDto> convertToUpdateDtoList(List<String> keys, List<String> values) {
+        return IntStream.range(0, keys.size())
+                .filter(i -> values.get(i) != null)
+                .mapToObj(i -> postMapper.toUpdateDto(keys.get(i), values.get(i)))
+                .filter(Objects::nonNull)
+                .toList();
+    }
+
+    private void executeViewCountUpdate(List<PostViewUpdateDto> updateDtoList) {
+        if (!updateDtoList.isEmpty()) {
+            postUpdateService.updateViewCount(updateDtoList);
+        }
+    }
+
+}

--- a/src/main/java/com/tavemakers/surf/domain/post/service/PostService.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/service/PostService.java
@@ -99,7 +99,7 @@ public class PostService {
         return PostDetailResDTO.of(saved, false, false,true,null, 0);
     }
 
-    @Transactional(readOnly = true)
+    @Transactional
     public PostDetailResDTO getPost(Long postId, Long memberId) {
         Post post = postRepository.findById(postId)
                 .orElseThrow(PostNotFoundException::new);

--- a/src/main/java/com/tavemakers/surf/domain/post/service/PostUpdateService.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/service/PostUpdateService.java
@@ -2,6 +2,7 @@ package com.tavemakers.surf.domain.post.service;
 
 import com.tavemakers.surf.domain.post.dto.PostViewUpdateDto;
 import com.tavemakers.surf.domain.post.repository.PostJdbcRepositoryImpl;
+import com.tavemakers.surf.domain.post.repository.PostRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -11,10 +12,15 @@ import java.util.List;
 @RequiredArgsConstructor
 public class PostUpdateService {
 
-    private final PostJdbcRepositoryImpl postRepository;
+    private final PostJdbcRepositoryImpl postJdbcRepository;
+    private final PostRepository postRepository;
 
     public void updateViewCount(List<PostViewUpdateDto> updateDtoList) {
-        postRepository.viewCountBulkUpdate(updateDtoList);
+        postJdbcRepository.viewCountBulkUpdate(updateDtoList);
+    }
+
+    public void increaseViewCount(Long postId) {
+        postRepository.increaseViewCount(postId);
     }
 
 }

--- a/src/main/java/com/tavemakers/surf/domain/post/service/PostUpdateService.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/service/PostUpdateService.java
@@ -1,0 +1,20 @@
+package com.tavemakers.surf.domain.post.service;
+
+import com.tavemakers.surf.domain.post.dto.PostViewUpdateDto;
+import com.tavemakers.surf.domain.post.repository.PostJdbcRepositoryImpl;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class PostUpdateService {
+
+    private final PostJdbcRepositoryImpl postRepository;
+
+    public void updateViewCount(List<PostViewUpdateDto> updateDtoList) {
+        postRepository.viewCountBulkUpdate(updateDtoList);
+    }
+
+}

--- a/src/main/java/com/tavemakers/surf/domain/post/service/PostUpdateService.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/service/PostUpdateService.java
@@ -19,8 +19,4 @@ public class PostUpdateService {
         postJdbcRepository.viewCountBulkUpdate(updateDtoList);
     }
 
-    public void increaseViewCount(Long postId) {
-        postRepository.increaseViewCount(postId);
-    }
-
 }

--- a/src/main/java/com/tavemakers/surf/domain/post/service/ViewCountService.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/service/ViewCountService.java
@@ -40,7 +40,8 @@ public class ViewCountService {
             return viewCount != null ? Integer.parseInt(viewCount) : post.getViewCount();
         } catch (Exception e) {
             log.error("Redis 커넥션 에러로 Database에서 조회합니다. Error: {}", e.getMessage());
-            return increaseViewCountInDatabase(post.getId());
+            post.increaseViewCount();
+            return post.getViewCount();
         }
     }
 
@@ -50,12 +51,6 @@ public class ViewCountService {
 
     private String generateViewersKey(Long postId, Long viewerId) {
         return String.format(VIEWERS_KEY, postId, viewerId);
-    }
-
-    private int increaseViewCountInDatabase(Long postId) {
-        postUpdateService.increaseViewCount(postId);
-        Post updatedPost = postGetService.readPost(postId);
-        return updatedPost.getViewCount();
     }
 
 }

--- a/src/main/java/com/tavemakers/surf/domain/post/service/ViewCountService.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/service/ViewCountService.java
@@ -2,11 +2,13 @@ package com.tavemakers.surf.domain.post.service;
 
 import com.tavemakers.surf.domain.post.entity.Post;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 
 import java.time.Duration;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ViewCountService {
@@ -16,23 +18,30 @@ public class ViewCountService {
     private static final Duration VIEW_COUNT_TTL = Duration.ofDays(1);
 
     private final StringRedisTemplate redisTemplate;
+    private final PostUpdateService postUpdateService;
+    private final PostGetService postGetService;
 
     public int increaseViewCount(Post post, Long viewerId) {
         String viewCountKey = generateViewCountKey(post.getId());
         String viewersKey = generateViewersKey(post.getId(), viewerId);
 
-        Boolean alreadyViewed = redisTemplate.hasKey(viewersKey);
-        if(Boolean.FALSE.equals(alreadyViewed)) {
-            if (Boolean.FALSE.equals(redisTemplate.hasKey(viewCountKey))) {
-                redisTemplate.opsForValue().set(viewCountKey, String.valueOf(post.getViewCount()));
+        try {
+            Boolean alreadyViewed = redisTemplate.hasKey(viewersKey);
+            if(Boolean.FALSE.equals(alreadyViewed)) {
+                if (Boolean.FALSE.equals(redisTemplate.hasKey(viewCountKey))) {
+                    redisTemplate.opsForValue().set(viewCountKey, String.valueOf(post.getViewCount()));
+                }
+
+                redisTemplate.opsForValue().increment(viewCountKey, 1);
+                redisTemplate.opsForValue().set(viewersKey, "1", VIEW_COUNT_TTL);
             }
 
-            redisTemplate.opsForValue().increment(viewCountKey, 1);
-            redisTemplate.opsForValue().set(viewersKey, "1", VIEW_COUNT_TTL);
+            String viewCount = redisTemplate.opsForValue().get(viewCountKey);
+            return viewCount != null ? Integer.parseInt(viewCount) : post.getViewCount();
+        } catch (Exception e) {
+            log.error("Redis 커넥션 에러로 Database에서 조회합니다. Error: {}", e.getMessage());
+            return increaseViewCountInDatabase(post.getId());
         }
-
-        String viewCount = redisTemplate.opsForValue().get(viewCountKey);
-        return viewCount != null ? Integer.parseInt(viewCount) : post.getViewCount();
     }
 
     private String generateViewCountKey(Long postId) {
@@ -41,6 +50,12 @@ public class ViewCountService {
 
     private String generateViewersKey(Long postId, Long viewerId) {
         return String.format(VIEWERS_KEY, postId, viewerId);
+    }
+
+    private int increaseViewCountInDatabase(Long postId) {
+        postUpdateService.increaseViewCount(postId);
+        Post updatedPost = postGetService.readPost(postId);
+        return updatedPost.getViewCount();
     }
 
 }

--- a/src/main/java/com/tavemakers/surf/domain/post/service/ViewCountService.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/service/ViewCountService.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Duration;
 
@@ -21,6 +22,7 @@ public class ViewCountService {
     private final PostUpdateService postUpdateService;
     private final PostGetService postGetService;
 
+    @Transactional
     public int increaseViewCount(Post post, Long viewerId) {
         String viewCountKey = generateViewCountKey(post.getId());
         String viewersKey = generateViewersKey(post.getId(), viewerId);

--- a/src/main/java/com/tavemakers/surf/global/common/aop/annotations/ExecutionTimeLog.java
+++ b/src/main/java/com/tavemakers/surf/global/common/aop/annotations/ExecutionTimeLog.java
@@ -1,0 +1,12 @@
+package com.tavemakers.surf.global.common.aop.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ExecutionTimeLog {
+    String jobName() default "";
+}

--- a/src/main/java/com/tavemakers/surf/global/common/aop/aspect/ExecutionTimeAspect.java
+++ b/src/main/java/com/tavemakers/surf/global/common/aop/aspect/ExecutionTimeAspect.java
@@ -1,0 +1,31 @@
+package com.tavemakers.surf.global.common.aop.aspect;
+
+import com.tavemakers.surf.global.common.aop.annotations.ExecutionTimeLog;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Aspect
+@Component
+public class ExecutionTimeAspect {
+
+    @Around("@annotation(com.tavemakers.surf.global.common.aop.annotations.ExecutionTimeLog)")
+    public Object logExecutionTime(ProceedingJoinPoint joinPoint) throws Throwable {
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        ExecutionTimeLog annotation = signature.getMethod().getAnnotation(ExecutionTimeLog.class);
+
+        String jobName = annotation.jobName();
+        long startTime = System.currentTimeMillis();
+
+        try {
+            return joinPoint.proceed();
+        } finally {
+            long executionTime = System.currentTimeMillis() - startTime;
+            log.info("[{}] 실행 완료 (소요시간: {}ms)", jobName, executionTime);
+        }
+    }
+}


### PR DESCRIPTION
## 📄 작업 내용 요약
조회수 DB 동기화 기능 구현

## DB 동기화 Flow
1시간 주기로 동작합니다.

1. Redis에서 `post:*:view:count`의 Key Format을 모두 가져옵니다. (이때, Redis의 Scan 명령어를 사용합니다.)
2. postId와 viewCount로 `PostViewUpdateDto`를 만듭니다.
3. List<PostViewUpdateDto>를 BulkUpdate합니다.

## 성능 비교
게시글 중 극히 일부만 조회수가 변경된 경우 성능 차이는 미미하지만,
조회수가 변경된 게시글이 많을수록, Update 쿼리에 대한 성능차이는 심해지는 걸 확인했습니다.

### 1000개의 게시글 조회수가 변경된 경우
더티체킹 Update - `605.2ms`
BulkUpdate - `192ms`

### 1000개의 게시글 中 10개만 변경된 경우
더티체킹 Update - `123.8ms`
BulkUpdate - `123.6ms`


## 개선점
1. 현재는 스케줄링 주기가 1시간이지만, 24시간 주기로 하여도 괜찮을 거 같습니다.
2. 데이터가 많아지면, 조회수Key에도 TTL을 걸고, 조회될 때마다 TTL을 갱신해주는 방법을 고려해봐야할 거 같습니다. -> 이를 통해, 모든 게시물에 대한 조회수가 Redis에 남지않고, 인기 게시글 조회수만 Redis에 남도록할 수 있습니다. -> 그러나 조회수 증가, TTL 갱신의 정합성을 보장하는 방법을 고려해봐야합니다.


## 📎 Issue 번호
<!-- closed #번호 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 캐시된 게시글 조회수를 정기 동기화하는 스케줄러가 추가되었습니다.
  * 메서드별 실행 시간 로깅을 위한 어노테이션과 AOP 기반 로깅이 도입되었습니다.

* **개선 사항**
  * 다수 게시글 조회수를 일괄 업데이트하는 배치 업데이트로 성능이 향상되었습니다.
  * Redis 장애 시 데이터베이스로 자동 폴백되어 조회수 집계가 유지됩니다.

* **기타**
  * 조회수 증가 처리 흐름과 트랜잭션 동작이 일관되게 보장됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->