### PR TITLE
[FEAT] 알림 조회 구현

### DIFF
--- a/src/main/java/com/tavemakers/surf/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/tavemakers/surf/domain/notification/controller/NotificationController.java
@@ -34,7 +34,7 @@ public class NotificationController {
     }
 
     @Operation(summary = "알람 읽음 처리", description = "특정 알람을 읽음 처리합니다.")
-    @PatchMapping("/v1/user/{notificationId}/read")
+    @PatchMapping("/v1/user/notifications/{notificationId}/read")
     public ApiResponse<Void> markRead(
             @PathVariable Long notificationId
     ) {

--- a/src/main/java/com/tavemakers/surf/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/tavemakers/surf/domain/notification/controller/NotificationController.java
@@ -1,0 +1,16 @@
+package com.tavemakers.surf.domain.notification.controller;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping
+@Tag(name = "알림")
+public class NotificationController {
+
+
+
+}

--- a/src/main/java/com/tavemakers/surf/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/tavemakers/surf/domain/notification/controller/NotificationController.java
@@ -1,9 +1,19 @@
 package com.tavemakers.surf.domain.notification.controller;
 
+import com.tavemakers.surf.domain.notification.dto.res.NotificationResDTO;
+import com.tavemakers.surf.domain.notification.service.NotificationService;
+import com.tavemakers.surf.global.common.response.ApiResponse;
+import com.tavemakers.surf.global.util.SecurityUtils;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+import static com.tavemakers.surf.domain.notification.controller.ResponseMessage.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -11,6 +21,27 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "알림")
 public class NotificationController {
 
+    private final NotificationService notificationService;
 
+    @GetMapping
+    public ApiResponse<List<NotificationResDTO>> getAll() {
+        Long memberId = SecurityUtils.getCurrentMemberId();
+        List<NotificationResDTO> response = notificationService.getList(memberId);
+        return ApiResponse.response(HttpStatus.OK, NOTIFICATION_READ.getMessage(), response);
+    }
+
+    @GetMapping("/activity")
+    public ApiResponse<List<NotificationResDTO>> getActivity() {
+        Long memberId = SecurityUtils.getCurrentMemberId();
+        List<NotificationResDTO> response = notificationService.getActivity(memberId);
+        return ApiResponse.response(HttpStatus.OK, NOTIFICATION_ACTIVITY_READ.getMessage(), response);
+    }
+
+    @GetMapping("/schedule")
+    public ApiResponse<List<NotificationResDTO>> getSchedule() {
+        Long memberId = SecurityUtils.getCurrentMemberId();
+        List<NotificationResDTO> response = notificationService.getSchedule(memberId);
+        return ApiResponse.response(HttpStatus.OK, NOTIFICATION_SCHEDULE_READ.getMessage(), response);
+    }
 
 }

--- a/src/main/java/com/tavemakers/surf/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/tavemakers/surf/domain/notification/controller/NotificationController.java
@@ -5,13 +5,11 @@ import com.tavemakers.surf.domain.notification.entity.NotificationCategory;
 import com.tavemakers.surf.domain.notification.service.NotificationService;
 import com.tavemakers.surf.global.common.response.ApiResponse;
 import com.tavemakers.surf.global.util.SecurityUtils;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -20,17 +18,28 @@ import static com.tavemakers.surf.domain.notification.controller.ResponseMessage
 @RestController
 @RequiredArgsConstructor
 @RequestMapping
-@Tag(name = "알림")
+@Tag(name = "알람")
 public class NotificationController {
 
     private final NotificationService notificationService;
 
-    @GetMapping
+    @Operation(summary = "알람 조회", description = "category 파라미터로 카테고리별 필터링 조회합니다. null일 경우 전체 알람 조회")
+    @GetMapping("/v1/user/notifications")
     public ApiResponse<List<NotificationResDTO>> getNotifications(
             @RequestParam(required = false) NotificationCategory category
     ) {
         Long memberId = SecurityUtils.getCurrentMemberId();
         List<NotificationResDTO> response = notificationService.getNotifications(memberId, category);
         return ApiResponse.response(HttpStatus.OK, NOTIFICATION_READ.getMessage(), response);
+    }
+
+    @Operation(summary = "알람 읽음 처리", description = "특정 알람을 읽음 처리합니다.")
+    @PatchMapping("/v1/user/{notificationId}/read")
+    public ApiResponse<Void> markRead(
+            @PathVariable Long notificationId
+    ) {
+        Long memberId = SecurityUtils.getCurrentMemberId();
+        notificationService.markAsRead(notificationId, memberId);
+        return ApiResponse.response(HttpStatus.OK, NOTIFICATION_READ_MARK.getMessage());
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/tavemakers/surf/domain/notification/controller/NotificationController.java
@@ -1,6 +1,7 @@
 package com.tavemakers.surf.domain.notification.controller;
 
 import com.tavemakers.surf.domain.notification.dto.res.NotificationResDTO;
+import com.tavemakers.surf.domain.notification.entity.NotificationCategory;
 import com.tavemakers.surf.domain.notification.service.NotificationService;
 import com.tavemakers.surf.global.common.response.ApiResponse;
 import com.tavemakers.surf.global.util.SecurityUtils;
@@ -9,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -24,24 +26,11 @@ public class NotificationController {
     private final NotificationService notificationService;
 
     @GetMapping
-    public ApiResponse<List<NotificationResDTO>> getAll() {
+    public ApiResponse<List<NotificationResDTO>> getNotifications(
+            @RequestParam(required = false) NotificationCategory category
+    ) {
         Long memberId = SecurityUtils.getCurrentMemberId();
-        List<NotificationResDTO> response = notificationService.getList(memberId);
+        List<NotificationResDTO> response = notificationService.getNotifications(memberId, category);
         return ApiResponse.response(HttpStatus.OK, NOTIFICATION_READ.getMessage(), response);
     }
-
-    @GetMapping("/activity")
-    public ApiResponse<List<NotificationResDTO>> getActivity() {
-        Long memberId = SecurityUtils.getCurrentMemberId();
-        List<NotificationResDTO> response = notificationService.getActivity(memberId);
-        return ApiResponse.response(HttpStatus.OK, NOTIFICATION_ACTIVITY_READ.getMessage(), response);
-    }
-
-    @GetMapping("/schedule")
-    public ApiResponse<List<NotificationResDTO>> getSchedule() {
-        Long memberId = SecurityUtils.getCurrentMemberId();
-        List<NotificationResDTO> response = notificationService.getSchedule(memberId);
-        return ApiResponse.response(HttpStatus.OK, NOTIFICATION_SCHEDULE_READ.getMessage(), response);
-    }
-
 }

--- a/src/main/java/com/tavemakers/surf/domain/notification/controller/ResponseMessage.java
+++ b/src/main/java/com/tavemakers/surf/domain/notification/controller/ResponseMessage.java
@@ -1,0 +1,15 @@
+package com.tavemakers.surf.domain.notification.controller;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ResponseMessage {
+
+    NOTIFICATION_READ("[알림]이 성공적으로 조회되었습니다."),
+    NOTIFICATION_ACTIVITY_READ("[알림 - 활동]이 성공적으로 조회되었습니다."),
+    NOTIFICATION_SCHEDULE_READ("[알림 - 일정]이 성공적으로 조회되었습니다.");
+
+    private final String message;
+}

--- a/src/main/java/com/tavemakers/surf/domain/notification/controller/ResponseMessage.java
+++ b/src/main/java/com/tavemakers/surf/domain/notification/controller/ResponseMessage.java
@@ -7,9 +7,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ResponseMessage {
 
-    NOTIFICATION_READ("[알림]이 성공적으로 조회되었습니다."),
-    NOTIFICATION_ACTIVITY_READ("[알림 - 활동]이 성공적으로 조회되었습니다."),
-    NOTIFICATION_SCHEDULE_READ("[알림 - 일정]이 성공적으로 조회되었습니다.");
+    NOTIFICATION_READ("[알림]이 성공적으로 조회되었습니다.");
 
     private final String message;
 }

--- a/src/main/java/com/tavemakers/surf/domain/notification/controller/ResponseMessage.java
+++ b/src/main/java/com/tavemakers/surf/domain/notification/controller/ResponseMessage.java
@@ -7,7 +7,8 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ResponseMessage {
 
-    NOTIFICATION_READ("[알림]이 성공적으로 조회되었습니다.");
+    NOTIFICATION_READ("[알람]이 성공적으로 조회되었습니다."),
+    NOTIFICATION_READ_MARK("[알람]이 성공적으로 읽음 처리되었습니다.");
 
     private final String message;
 }

--- a/src/main/java/com/tavemakers/surf/domain/notification/dto/res/NotificationResDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/notification/dto/res/NotificationResDTO.java
@@ -2,13 +2,25 @@ package com.tavemakers.surf.domain.notification.dto.res;
 
 import com.tavemakers.surf.domain.notification.entity.Notification;
 import com.tavemakers.surf.domain.notification.entity.NotificationType;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 public record NotificationResDTO (
+        @Schema(description = "알람 ID", example = "1")
         Long id,
+
+        @Schema(description = "알람 유형", example = "POST_LIKE")
         NotificationType type,
+
+        @Schema(description = "알람 카테고리", example = "ACTIVITY")
         String category,       // ACTIVITY / SCHEDULE
+
+        @Schema(description = "알람 본문 내용", example = "누군가가 회원님의 게시글을 좋아합니다.")
         String body,
+
+        @Schema(description = "알람 읽음 여부", example = "false")
         boolean read,
+
+        @Schema(description = "알람 생성 일시", example = "2023-10-05T14:48:00")
         String createdAt
 ){
     public static NotificationResDTO from(Notification n) {

--- a/src/main/java/com/tavemakers/surf/domain/notification/dto/res/NotificationResDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/notification/dto/res/NotificationResDTO.java
@@ -1,0 +1,18 @@
+package com.tavemakers.surf.domain.notification.dto.res;
+
+import com.tavemakers.surf.domain.notification.entity.NotificationType;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class NotificationResDTO {
+
+    private Long id;
+    private NotificationType type;
+    private String category;       // ACTIVITY / SCHEDULE
+    private String body;
+    private boolean read;
+    private String createdAt;      // yyyy-MM-dd HH:mm 형태 또는 ISO
+
+}

--- a/src/main/java/com/tavemakers/surf/domain/notification/dto/res/NotificationResDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/notification/dto/res/NotificationResDTO.java
@@ -4,6 +4,8 @@ import com.tavemakers.surf.domain.notification.entity.Notification;
 import com.tavemakers.surf.domain.notification.entity.NotificationType;
 import io.swagger.v3.oas.annotations.media.Schema;
 
+import java.time.LocalDateTime;
+
 public record NotificationResDTO (
         @Schema(description = "알람 ID", example = "1")
         Long id,
@@ -21,7 +23,7 @@ public record NotificationResDTO (
         boolean read,
 
         @Schema(description = "알람 생성 일시", example = "2023-10-05T14:48:00")
-        String createdAt
+        LocalDateTime createdAt
 ){
     public static NotificationResDTO from(Notification n) {
         return new NotificationResDTO(
@@ -30,7 +32,7 @@ public record NotificationResDTO (
                 n.getType().getCategory().name(),
                 n.getBody(),
                 n.isRead(),
-                n.getCreatedAt().toString()
+                n.getCreatedAt()
         );
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/notification/dto/res/NotificationResDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/notification/dto/res/NotificationResDTO.java
@@ -1,18 +1,13 @@
 package com.tavemakers.surf.domain.notification.dto.res;
 
 import com.tavemakers.surf.domain.notification.entity.NotificationType;
-import lombok.Builder;
-import lombok.Getter;
 
-@Getter
-@Builder
-public class NotificationResDTO {
-
-    private Long id;
-    private NotificationType type;
-    private String category;       // ACTIVITY / SCHEDULE
-    private String body;
-    private boolean read;
-    private String createdAt;      // yyyy-MM-dd HH:mm 형태 또는 ISO
-
+public record NotificationResDTO (
+        Long id,
+    NotificationType type,
+    String category,       // ACTIVITY / SCHEDULE
+    String body,
+    boolean read,
+    String createdAt
+){
 }

--- a/src/main/java/com/tavemakers/surf/domain/notification/dto/res/NotificationResDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/notification/dto/res/NotificationResDTO.java
@@ -1,13 +1,24 @@
 package com.tavemakers.surf.domain.notification.dto.res;
 
+import com.tavemakers.surf.domain.notification.entity.Notification;
 import com.tavemakers.surf.domain.notification.entity.NotificationType;
 
 public record NotificationResDTO (
         Long id,
-    NotificationType type,
-    String category,       // ACTIVITY / SCHEDULE
-    String body,
-    boolean read,
-    String createdAt
+        NotificationType type,
+        String category,       // ACTIVITY / SCHEDULE
+        String body,
+        boolean read,
+        String createdAt
 ){
+    public static NotificationResDTO from(Notification n) {
+        return new NotificationResDTO(
+                n.getId(),
+                n.getType(),
+                n.getType().getCategory().name(),
+                n.getBody(),
+                n.isRead(),
+                n.getCreatedAt().toString()
+        );
+    }
 }

--- a/src/main/java/com/tavemakers/surf/domain/notification/dto/res/notificationResDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/notification/dto/res/notificationResDTO.java
@@ -1,0 +1,4 @@
+package com.tavemakers.surf.domain.notification.dto.res;
+
+public class notificationResDTO {
+}

--- a/src/main/java/com/tavemakers/surf/domain/notification/dto/res/notificationResDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/notification/dto/res/notificationResDTO.java
@@ -1,4 +1,0 @@
-package com.tavemakers.surf.domain.notification.dto.res;
-
-public class notificationResDTO {
-}

--- a/src/main/java/com/tavemakers/surf/domain/notification/entity/Notification.java
+++ b/src/main/java/com/tavemakers/surf/domain/notification/entity/Notification.java
@@ -1,0 +1,39 @@
+package com.tavemakers.surf.domain.notification.entity;
+
+import com.tavemakers.surf.global.common.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Notification extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /** 수신자 */
+    @Column(nullable = false)
+    private Long memberId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 40)
+    private NotificationType type;
+
+    @Column(nullable = false, length = 500)
+    private String body;
+
+    /** 읽음 여부 */
+    @Column(nullable = false)
+    private boolean read;
+
+}

--- a/src/main/java/com/tavemakers/surf/domain/notification/entity/NotificationCategory.java
+++ b/src/main/java/com/tavemakers/surf/domain/notification/entity/NotificationCategory.java
@@ -1,0 +1,6 @@
+package com.tavemakers.surf.domain.notification.entity;
+
+public enum NotificationCategory {
+    ACTIVITY,   // 활동
+    SCHEDULE    // 일정
+}

--- a/src/main/java/com/tavemakers/surf/domain/notification/entity/NotificationType.java
+++ b/src/main/java/com/tavemakers/surf/domain/notification/entity/NotificationType.java
@@ -1,0 +1,26 @@
+package com.tavemakers.surf.domain.notification.entity;
+
+public enum NotificationType {
+
+    // ===== 활동(ACTIVITY) =====
+    POST_LIKE(NotificationCategory.ACTIVITY),           // 본인 작성 글 좋아요
+    POST_COMMENT(NotificationCategory.ACTIVITY),        // 본인 작성 글 댓글
+    COMMENT_LIKE(NotificationCategory.ACTIVITY),        // 본인 댓글에 좋아요
+    COMMENT_REPLY(NotificationCategory.ACTIVITY),       // 본인 댓글에 대댓글
+    MESSAGE_RECEIVED(NotificationCategory.ACTIVITY),    // 쪽지
+    BADGE_UPDATED(NotificationCategory.ACTIVITY),       // 활동 뱃지 업데이트
+    SCORE_UPDATED(NotificationCategory.ACTIVITY),       // 활동 점수 업데이트
+
+    // ===== 일정(SCHEDULE) =====
+    EVENT_NOTICE(NotificationCategory.SCHEDULE);        // 행사 공지사항 등록
+
+    private final NotificationCategory category;
+
+    NotificationType(NotificationCategory category) {
+        this.category = category;
+    }
+
+    public NotificationCategory getCategory() {
+        return category;
+    }
+}

--- a/src/main/java/com/tavemakers/surf/domain/notification/exception/ErrorMessage.java
+++ b/src/main/java/com/tavemakers/surf/domain/notification/exception/ErrorMessage.java
@@ -1,0 +1,16 @@
+package com.tavemakers.surf.domain.notification.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorMessage {
+
+    NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "요청하신 [알람]을 찾을 수 없습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+
+}

--- a/src/main/java/com/tavemakers/surf/domain/notification/exception/NotificationNotFoundException.java
+++ b/src/main/java/com/tavemakers/surf/domain/notification/exception/NotificationNotFoundException.java
@@ -1,0 +1,11 @@
+package com.tavemakers.surf.domain.notification.exception;
+
+import com.tavemakers.surf.global.common.exception.BaseException;
+
+import static com.tavemakers.surf.domain.notification.exception.ErrorMessage.NOTIFICATION_NOT_FOUND;
+
+public class NotificationNotFoundException extends BaseException {
+    public NotificationNotFoundException() {
+        super(NOTIFICATION_NOT_FOUND.getStatus(), NOTIFICATION_NOT_FOUND.getMessage());
+    }
+}

--- a/src/main/java/com/tavemakers/surf/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/tavemakers/surf/domain/notification/repository/NotificationRepository.java
@@ -3,6 +3,9 @@ package com.tavemakers.surf.domain.notification.repository;
 import com.tavemakers.surf.domain.notification.entity.Notification;
 import com.tavemakers.surf.domain.notification.entity.NotificationType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Collection;
 import java.util.List;
@@ -12,4 +15,16 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
     List<Notification> findByMemberIdOrderByIdDesc(Long memberId);
 
     List<Notification> findByMemberIdAndTypeInOrderByIdDesc(Long memberId, Collection<NotificationType> types);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+        update Notification n
+           set n.read = true
+         where n.id = :id
+           and n.memberId = :memberId
+           and n.read = false
+        """)
+    int markAsRead(@Param("id") Long id, @Param("memberId") Long memberId);
+
+    boolean existsByIdAndMemberId(Long id, Long memberId);
 }

--- a/src/main/java/com/tavemakers/surf/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/tavemakers/surf/domain/notification/repository/NotificationRepository.java
@@ -1,0 +1,15 @@
+package com.tavemakers.surf.domain.notification.repository;
+
+import com.tavemakers.surf.domain.notification.entity.Notification;
+import com.tavemakers.surf.domain.notification.entity.NotificationType;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Collection;
+import java.util.List;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+    List<Notification> findByMemberIdOrderByIdDesc(Long memberId);
+
+    List<Notification> findByMemberIdAndTypeInOrderByIdDesc(Long memberId, Collection<NotificationType> types);
+}

--- a/src/main/java/com/tavemakers/surf/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/tavemakers/surf/domain/notification/service/NotificationService.java
@@ -1,0 +1,50 @@
+package com.tavemakers.surf.domain.notification.service;
+
+import com.tavemakers.surf.domain.notification.dto.res.NotificationResDTO;
+import com.tavemakers.surf.domain.notification.entity.Notification;
+import com.tavemakers.surf.domain.notification.entity.NotificationCategory;
+import com.tavemakers.surf.domain.notification.entity.NotificationType;
+import com.tavemakers.surf.domain.notification.repository.NotificationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Arrays;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationService {
+
+    private final NotificationRepository notificationRepository;
+
+    public List<NotificationResDTO> getList(Long memberId) {
+        return notificationRepository.findByMemberIdOrderByIdDesc(memberId)
+                .stream()
+                .map(NotificationResDTO::from)
+                .toList();
+    }
+
+    public List<NotificationResDTO> getActivity(Long memberId) {
+        List<NotificationType> types = Arrays.stream(NotificationType.values())
+                .filter(t -> t.getCategory() == NotificationCategory.ACTIVITY)
+                .toList();
+
+        List<Notification> list = notificationRepository
+                .findByMemberIdAndTypeInOrderByIdDesc(memberId, types);
+        return list.stream()
+                .map(NotificationResDTO::from)
+                .toList();
+    }
+
+    public List<NotificationResDTO> getSchedule(Long memberId) {
+        List<NotificationType> types = Arrays.stream(NotificationType.values())
+                .filter(t -> t.getCategory() == NotificationCategory.SCHEDULE)
+                .toList();
+
+        List<Notification> list = notificationRepository
+                .findByMemberIdAndTypeInOrderByIdDesc(memberId, types);
+        return list.stream()
+                .map(NotificationResDTO::from)
+                .toList();
+    }
+}

--- a/src/main/java/com/tavemakers/surf/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/tavemakers/surf/domain/notification/service/NotificationService.java
@@ -42,7 +42,7 @@ public class NotificationService {
     }
 
     @Transactional
-    public void markAsRead(Long memberId, Long notificationId) {
+    public void markAsRead(Long notificationId, Long memberId) {
         int updated = notificationRepository.markAsRead(notificationId, memberId);
 
         if (updated == 0) {

--- a/src/main/java/com/tavemakers/surf/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/tavemakers/surf/domain/notification/service/NotificationService.java
@@ -4,6 +4,7 @@ import com.tavemakers.surf.domain.notification.dto.res.NotificationResDTO;
 import com.tavemakers.surf.domain.notification.entity.Notification;
 import com.tavemakers.surf.domain.notification.entity.NotificationCategory;
 import com.tavemakers.surf.domain.notification.entity.NotificationType;
+import com.tavemakers.surf.domain.notification.exception.NotificationNotFoundException;
 import com.tavemakers.surf.domain.notification.repository.NotificationRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -25,21 +26,30 @@ public class NotificationService {
 
         if (category == null) {
             // 전체 알림
-            notifications = notificationRepository
-                    .findByMemberIdOrderByIdDesc(memberId);
-
+            notifications = notificationRepository.findByMemberIdOrderByIdDesc(memberId);
         } else {
             // 해당 카테고리의 타입 목록 추출
             List<NotificationType> types = Arrays.stream(NotificationType.values())
                     .filter(t -> t.getCategory() == category)
                     .toList();
 
-            notifications = notificationRepository
-                    .findByMemberIdAndTypeInOrderByIdDesc(memberId, types);
+            notifications = notificationRepository.findByMemberIdAndTypeInOrderByIdDesc(memberId, types);
         }
 
         return notifications.stream()
                 .map(NotificationResDTO::from)
                 .toList();
+    }
+
+    @Transactional
+    public void markAsRead(Long memberId, Long notificationId) {
+        int updated = notificationRepository.markAsRead(notificationId, memberId);
+
+        if (updated == 0) {
+            boolean exists = notificationRepository.existsByIdAndMemberId(notificationId, memberId);
+            if (!exists) {
+                throw new NotificationNotFoundException();
+            }
+        }
     }
 }


### PR DESCRIPTION
## 📄 작업 내용 요약

알람 조회, 읽음 처리 구현하였습니다.
알람 조회는 전체 / 카테고리별(ACTIVITY, SCHEDULE) 필터링을 지원하며, 
화면 상에서 알람을 클릭했을 때, 읽음 처리와 페이지 이동을 동시에 진행될 것이라고 가정하고 읽음 처리한 알람이 리스트에서 삭제되거나 하는 추가 작업이 없고,  이미 읽은 알림이어도 에러 없이 통과하도록 구성했습니다.

```
@Modifying(clearAutomatically = true, flushAutomatically = true)
    @Query("""
        update Notification n
           set n.read = true
         where n.id = :id
           and n.memberId = :memberId
           and n.read = false
        """)
    int markAsRead(@Param("id") Long id, @Param("memberId") Long memberId);
```
JPA 엔티티를 조회한 뒤 상태를 변경하는 방식 대신, JPQL 벌크 업데이트 쿼리를 사용했습니다. 알림 읽음 처리의 경우 비즈니스 로직이 단순히 read = true 플래그를 변경하는 수준이고, 추가적인 도메인 규칙(이벤트 발행, 복잡한 상태 전이 등)이 없기 때문에, 엔티티를 굳이 영속성 컨텍스트에 올려서 더티체킹을 태우는 것보다 곧바로 update 쿼리를 실행하는 편이 쿼리 수, 메모리 사용량 측면에서 더 효율적입니다.


## 📎 Issue 번호
<!-- closed #173  -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 사용자 알림을 조회할 수 있습니다.
  * 카테고리(활동, 일정)별로 알림을 필터링할 수 있습니다.
  * 알림을 읽음 상태로 표시할 수 있습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->