### PR TITLE
[Refactor] 게시글 수정 시 이미지를 비울 경우도 반영

### DIFF
--- a/src/main/java/com/tavemakers/surf/domain/post/entity/Post.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/entity/Post.java
@@ -126,6 +126,11 @@ public class Post extends BaseEntity {
     }
 
     public void addThumbnailUrl(String originalUrl) {
+        if (originalUrl == null) {
+            this.thumbnailUrl = null;
+            return;
+        }
+
         String url = originalUrl.replace("/original/", "/thumbnail/");
         int dotIndex = url.lastIndexOf('.');
         this.thumbnailUrl = url.substring(0, dotIndex) + WEBP_EXTENSION;

--- a/src/main/java/com/tavemakers/surf/domain/post/service/PostService.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/service/PostService.java
@@ -196,6 +196,11 @@ public class PostService {
         if (req.isImageChanged()) {
             deleteExistingImage(post);
             List<PostImageCreateReqDTO> changeImage = req.imageUrlList();
+            if(changeImage.isEmpty()){
+                post.addThumbnailUrl(null);
+                return PostDetailResDTO.of(post, scrappedByMe, likedByMe, true, null, viewCount);
+            }
+
             post.addThumbnailUrl(findFirstImage(changeImage));
             List<PostImageResDTO> savedChangedImage = imageSaveService.saveAll(post, changeImage);
             return PostDetailResDTO.of(post, scrappedByMe, likedByMe, true, savedChangedImage, viewCount);

--- a/src/main/java/com/tavemakers/surf/domain/post/service/PostService.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/service/PostService.java
@@ -198,6 +198,7 @@ public class PostService {
             List<PostImageCreateReqDTO> changeImage = req.imageUrlList();
             if(changeImage.isEmpty()){
                 post.addThumbnailUrl(null);
+                // TODO Spring Event로 PostImageUrl 삭제 로직 분리.
                 return PostDetailResDTO.of(post, scrappedByMe, likedByMe, true, null, viewCount);
             }
 


### PR DESCRIPTION
## 📄 작업 내용 요약
게시글 수정 시 이미지를 비울 경우도 반영합니다.

우선 게시글 수정시 이미지가 사라진 경우에는 Post의 thumbnailUrl을 null로 초기화합니다.

이러면 S3에는 존재하지만 DB에 없는 즉, 더이상 사용하지 않는 S3 객체가 존재합니다.
해당 고아 객체를 다룰 방안에 대해서는 다음 이슈에 다룰 예정입니다.

## 📎 Issue 번호
<!-- closed #번호 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
* 이미지가 없거나 비어있는 경우 포스트 업데이트 시 발생하던 오류를 해결했습니다.
* 썸네일 처리 시 null 값에 대한 안정적인 처리를 개선했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->