### PR TITLE
[Feat] 회원검색기능 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -65,6 +65,12 @@ dependencies {
 
     implementation ("io.github.cdimascio:dotenv-java:2.2.4")
 
+    // QueryDSL
+    implementation ("com.querydsl:querydsl-jpa:5.0.0:jakarta")
+    annotationProcessor ("com.querydsl:querydsl-apt:5.0.0:jakarta")
+    annotationProcessor ("jakarta.annotation:jakarta.annotation-api")
+    annotationProcessor ("jakarta.persistence:jakarta.persistence-api")
+
 }
 
 // log4j2 사용을 위해 추가

--- a/src/main/java/com/tavemakers/surf/domain/member/controller/MemberSearchController.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/controller/MemberSearchController.java
@@ -65,6 +65,10 @@ public class MemberSearchController {
         return ApiResponse.response(HttpStatus.OK, MYPAGE_MY_PROFILE_READ.getMessage(), response);
     }
 
+    @Operation(
+            summary = "회원이름 및 학교로 검색 (기수/파트 필터링)",
+            description = "회원이름 및 학교로 검색 (기수/파트 필터링)"
+    )
     @GetMapping("/v1/user/members")
     public ApiResponse<MemberSearchSliceResDTO> searchMembers(
             @RequestParam int pageNum,

--- a/src/main/java/com/tavemakers/surf/domain/member/controller/MemberSearchController.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/controller/MemberSearchController.java
@@ -77,7 +77,7 @@ public class MemberSearchController {
             @RequestParam(required = false) Integer generation,
             @RequestParam(required = false) String part
     ) {
-        MemberSearchSliceResDTO response = memberUsecase.searchMembers(pageNum, pageSize, generation, keyword, part);
+        MemberSearchSliceResDTO response = memberUsecase.searchMembers(pageNum, pageSize, generation, part, keyword);
         return ApiResponse.response(HttpStatus.OK, MEMBER_LIST_SEARCH_SUCCESS.getMessage(), response);
     }
 

--- a/src/main/java/com/tavemakers/surf/domain/member/controller/MemberSearchController.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/controller/MemberSearchController.java
@@ -1,6 +1,7 @@
 package com.tavemakers.surf.domain.member.controller;
 
 import com.tavemakers.surf.domain.member.dto.response.MemberSearchResDTO;
+import com.tavemakers.surf.domain.member.dto.response.MemberSearchSliceResDTO;
 import com.tavemakers.surf.domain.member.dto.response.MemberSimpleResDTO;
 import com.tavemakers.surf.domain.member.dto.response.MyPageProfileResDTO;
 import com.tavemakers.surf.domain.member.usecase.MemberUsecase;
@@ -62,6 +63,18 @@ public class MemberSearchController {
         memberId = (memberId == null ? SecurityUtils.getCurrentMemberId() : memberId);
         MyPageProfileResDTO response = memberUsecase.getMyPageAndProfile(memberId);
         return ApiResponse.response(HttpStatus.OK, MYPAGE_MY_PROFILE_READ.getMessage(), response);
+    }
+
+    @GetMapping("/v1/user/members")
+    public ApiResponse<MemberSearchSliceResDTO> searchMembers(
+            @RequestParam int pageNum,
+            @RequestParam int pageSize,
+            @RequestParam(required = false) String keyword,
+            @RequestParam(required = false) Integer generation,
+            @RequestParam(required = false) String part
+    ) {
+        MemberSearchSliceResDTO response = memberUsecase.searchMembers(pageNum, pageSize, generation, keyword, part);
+        return ApiResponse.response(HttpStatus.OK, MEMBER_LIST_SEARCH_SUCCESS.getMessage(), response);
     }
 
 }

--- a/src/main/java/com/tavemakers/surf/domain/member/controller/ResponseMessage.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/controller/ResponseMessage.java
@@ -13,6 +13,7 @@ public enum ResponseMessage {
     // 이름 규칙 변경 및 메시지에 Placeholder(%s) 추가
     MEMBER_SEARCH_SUCCESS("'%s'(으)로 활동 중인 [회원]을 조회했습니다."),
     MEMBER_GROUP_SUCCESS("[트랙]별로 현재 활동 중인 [회원]을 조회했습니다."),
+    MEMBER_LIST_SEARCH_SUCCESS("[회원 목록]을 검색합니다."),
 
     // 프로필 조회
     MYPAGE_MY_PROFILE_READ("본인 마이페이지에서 [프로필 정보]를 조회합니다."),

--- a/src/main/java/com/tavemakers/surf/domain/member/dto/response/MemberSearchDetailResDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/dto/response/MemberSearchDetailResDTO.java
@@ -1,0 +1,33 @@
+package com.tavemakers.surf.domain.member.dto.response;
+
+import com.tavemakers.surf.domain.member.entity.Member;
+import com.tavemakers.surf.domain.member.entity.Track;
+import lombok.Builder;
+
+import java.util.Comparator;
+import java.util.List;
+
+@Builder
+public record MemberSearchDetailResDTO(
+        Long memberId,
+        String name,
+        String university,
+        String profileImageUrl,
+        List<TrackResDTO> trackList
+) {
+    public static MemberSearchDetailResDTO from(Member member) {
+        List<TrackResDTO> trackDtoList = member.getTracks()
+                .stream()
+                .sorted(Comparator.comparing(Track::getGeneration).reversed())
+                .map(TrackResDTO::from)
+                .toList();
+
+        return MemberSearchDetailResDTO.builder()
+                .memberId(member.getId())
+                .name(member.getName())
+                .university(member.getUniversity())
+                .profileImageUrl(member.getProfileImageUrl())
+                .trackList(trackDtoList)
+                .build();
+    }
+}

--- a/src/main/java/com/tavemakers/surf/domain/member/dto/response/MemberSearchSliceResDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/dto/response/MemberSearchSliceResDTO.java
@@ -1,0 +1,26 @@
+package com.tavemakers.surf.domain.member.dto.response;
+
+import lombok.Builder;
+import org.springframework.data.domain.Slice;
+
+import java.util.List;
+
+@Builder
+public record MemberSearchSliceResDTO(
+        List<MemberSearchDetailResDTO> content,
+        int pageNumber,
+        int pageSize,
+        int numberOfElements,
+        boolean isLast
+) {
+    public static MemberSearchSliceResDTO from(Slice<MemberSearchDetailResDTO> slice) {
+        return MemberSearchSliceResDTO.builder()
+                .content(slice.getContent())
+                .pageNumber(slice.getNumber())
+                .pageSize(slice.getSize())
+                .numberOfElements(slice.getNumberOfElements())
+                .isLast(slice.isLast())
+                .build();
+    }
+
+}

--- a/src/main/java/com/tavemakers/surf/domain/member/entity/Member.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/entity/Member.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Objects;
 
 import lombok.extern.slf4j.Slf4j;
+import org.hibernate.annotations.BatchSize;
 
 
 @Entity
@@ -52,6 +53,7 @@ public class Member extends BaseEntity {
     private Boolean phoneNumberPublic=false;
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    @BatchSize(size = 20)
     private List<Track> tracks = new ArrayList<>();
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/tavemakers/surf/domain/member/repository/MemberSearchRepository.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/repository/MemberSearchRepository.java
@@ -26,6 +26,10 @@ public class MemberSearchRepository {
 
     private final JPAQueryFactory queryFactory;
 
+    /*
+    * NOTE: SURF 규칙
+    * "기수 > 이름 > 대학 > 가입일" 순으로 정렬
+    * */
     public Slice<Member> searchMembers(Integer generation, Part part, String keyword, Pageable pageable) {
         BooleanBuilder builder = new BooleanBuilder();
 

--- a/src/main/java/com/tavemakers/surf/domain/member/repository/MemberSearchRepository.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/repository/MemberSearchRepository.java
@@ -1,0 +1,83 @@
+package com.tavemakers.surf.domain.member.repository;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.tavemakers.surf.domain.member.entity.Member;
+import com.tavemakers.surf.domain.member.entity.QTrack;
+import com.tavemakers.surf.domain.member.entity.enums.Part;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import com.querydsl.core.types.dsl.Expressions;
+
+import static com.tavemakers.surf.domain.member.entity.QMember.member;
+import static com.tavemakers.surf.domain.member.entity.QTrack.track;
+
+@Repository
+@RequiredArgsConstructor
+public class MemberSearchRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    public Slice<Member> searchMembers(Integer generation, Part part, String keyword, Pageable pageable) {
+        BooleanBuilder builder = new BooleanBuilder();
+
+        if (generation != null) {
+            builder.and(member.tracks.any().generation.eq(generation));
+        }
+
+        if (part != null) {
+            builder.and(member.tracks.any().part.eq(part));
+        }
+
+        if (keyword != null && !keyword.isBlank()) {
+            BooleanExpression nameMatch = member.name.containsIgnoreCase(keyword);
+            BooleanExpression universityMatch = member.university.containsIgnoreCase(keyword);
+            BooleanExpression graduateSchoolMatch = member.graduateSchool.containsIgnoreCase(keyword);
+
+            builder.and(nameMatch.or(universityMatch).or(graduateSchoolMatch));
+        }
+
+        NumberExpression<Integer> maxGeneration = getMaxGenerationExpression();
+        List<Member> results = queryFactory
+                .selectFrom(member)
+                .distinct()
+                .leftJoin(member.tracks, track)
+                .where(builder)
+                .orderBy(
+                        maxGeneration.desc().nullsLast(),
+                        member.name.asc(),
+                        member.university.asc(),
+                        member.createdAt.asc()
+                )
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize() + 1)
+                .fetch();
+
+        boolean hasNext = false;
+        if (results.size() > pageable.getPageSize()) {
+            hasNext = true;
+            results.remove(results.size() - 1);
+        }
+
+        return new SliceImpl<>(results, pageable, hasNext);
+    }
+
+    private NumberExpression<Integer> getMaxGenerationExpression() {
+        QTrack subTrack = new QTrack("subTrack");
+        return Expressions.asNumber(
+                JPAExpressions
+                        .select(subTrack.generation.max())
+                        .from(subTrack)
+                        .where(subTrack.member.eq(member))
+        );
+    }
+
+}

--- a/src/main/java/com/tavemakers/surf/domain/member/service/MemberGetService.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/service/MemberGetService.java
@@ -2,10 +2,14 @@ package com.tavemakers.surf.domain.member.service;
 
 import com.tavemakers.surf.domain.member.entity.Member;
 import com.tavemakers.surf.domain.member.entity.enums.MemberStatus;
+import com.tavemakers.surf.domain.member.entity.enums.Part;
 import com.tavemakers.surf.domain.member.exception.MemberNotFoundException;
 import com.tavemakers.surf.domain.member.repository.MemberRepository;
+import com.tavemakers.surf.domain.member.repository.MemberSearchRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,6 +22,7 @@ import java.util.List;
 public class MemberGetService {
 
     private final MemberRepository memberRepository;
+    private final MemberSearchRepository memberSearchRepository;
 
     public Member getMemberByStatus(Long memberId, MemberStatus memberStatus) {
         return memberRepository.findByIdAndStatus(memberId, memberStatus)
@@ -40,5 +45,8 @@ public class MemberGetService {
         return null;
     }
 
+    public Slice<Member> searchMembers(Integer generation, Part part, String keyword, Pageable pageable) {
+        return memberSearchRepository.searchMembers(generation, part, keyword, pageable);
+    }
 
 }

--- a/src/main/java/com/tavemakers/surf/domain/member/usecase/MemberUsecase.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/usecase/MemberUsecase.java
@@ -11,6 +11,7 @@ import com.tavemakers.surf.domain.member.entity.Member;
 import com.tavemakers.surf.domain.member.entity.Track;
 import com.tavemakers.surf.domain.member.entity.enums.MemberRole;
 import com.tavemakers.surf.domain.member.entity.enums.MemberStatus;
+import com.tavemakers.surf.domain.member.entity.enums.Part;
 import com.tavemakers.surf.domain.member.exception.TrackNotFoundException;
 import com.tavemakers.surf.domain.member.service.*;
 import com.tavemakers.surf.domain.score.service.PersonalScoreGetService;
@@ -20,6 +21,9 @@ import com.tavemakers.surf.global.util.SecurityUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationContext;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -216,4 +220,18 @@ public class MemberUsecase {
         return trackGetService.getTrack(memberId)
                 .stream().map(TrackResDTO::from).toList();
     }
+
+    public MemberSearchSliceResDTO searchMembers( int pageNum, int pageSize, Integer generation, String part, String keyword) {
+        Pageable pageable = PageRequest.of(pageNum, pageSize);
+        Part memberPart = part == null ? null : Part.valueOf(part);
+
+        Slice<MemberSearchDetailResDTO> slice = search(generation, memberPart, keyword, pageable);
+        return MemberSearchSliceResDTO.from(slice);
+    }
+
+    private Slice<MemberSearchDetailResDTO> search(Integer generation, Part part, String keyword, Pageable pageable) {
+        return memberGetService.searchMembers(generation, part, keyword, pageable)
+                .map(MemberSearchDetailResDTO::from);
+    }
+
 }

--- a/src/main/java/com/tavemakers/surf/global/config/QueryDslConfig.java
+++ b/src/main/java/com/tavemakers/surf/global/config/QueryDslConfig.java
@@ -1,0 +1,20 @@
+package com.tavemakers.surf.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+
+}


### PR DESCRIPTION
## 📄 작업 내용 요약
회원 검색기능을 구현했습니다.

### SURF 기본 규칙
1. `기수` > `이름` > `대학` > `가입일` 순으로 정렬합니다.
2. 여러 파트를 가진 경우 `기수`가 `높은 순`으로 내림차순 정렬합니다. 

### 검색 조건 & 필터링 조건

1. 검색어(keyword)는 이름과 학교가 포함되는 지 확인합니다.
2. 기수와 파트는 필터링 조건으로 동작합니다.

### QueryDSL
조건과 필터링 조건이 많아, 용이하게 작성할 수 있도록 QueryDsl을 사용했습니다.


## 📎 Issue #182
<!-- closed #182 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 회원 검색 API 추가: 키워드·기수·파트 필터 및 페이지네이션으로 회원 목록과 상세(이름, 대학, 프로필, 트랙) 조회 지원.
* **성능 개선**
  * 연관 트랙 로딩 최적화 및 정렬/페이징 로직 개선으로 조회 효율 및 응답 일관성 향상.
* **기타(Chores)**
  * QueryDSL 설정 및 검색 로직 통합, 검색 성공 응답 메시지 및 페이징 DTO 추가.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->