### PR TITLE
[Chore] 댓글 일부 로그 작업

### DIFF
--- a/src/main/java/com/tavemakers/surf/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/tavemakers/surf/domain/comment/controller/CommentController.java
@@ -40,7 +40,7 @@ public class CommentController {
 
     @Operation(summary = "댓글 목록 조회 (페이징)", description = "루트 댓글과 대댓글 모두 포함. 페이징 처리")
     @GetMapping("/v1/user/posts/{postId}/comments")
-    @LogEvent("comment.list.expend")
+    @LogEvent("comment.list.expand")
     public ApiResponse<CommentListResDTO> getComments(
             @LogParam("post_id") @PathVariable Long postId,
             @ParameterObject

--- a/src/main/java/com/tavemakers/surf/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/tavemakers/surf/domain/comment/controller/CommentController.java
@@ -5,6 +5,8 @@ import com.tavemakers.surf.domain.comment.dto.res.CommentListResDTO;
 import com.tavemakers.surf.domain.comment.dto.res.CommentResDTO;
 import com.tavemakers.surf.domain.comment.service.CommentService;
 import com.tavemakers.surf.global.common.response.ApiResponse;
+import com.tavemakers.surf.global.logging.LogEvent;
+import com.tavemakers.surf.global.logging.LogParam;
 import com.tavemakers.surf.global.util.SecurityUtils;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -38,8 +40,9 @@ public class CommentController {
 
     @Operation(summary = "댓글 목록 조회 (페이징)", description = "루트 댓글과 대댓글 모두 포함. 페이징 처리")
     @GetMapping("/v1/user/posts/{postId}/comments")
+    @LogEvent("comment.list.expend")
     public ApiResponse<CommentListResDTO> getComments(
-            @PathVariable Long postId,
+            @LogParam("post_id") @PathVariable Long postId,
             @ParameterObject
             @PageableDefault(page = 0, size = 10, sort = "createdAt", direction = Sort.Direction.DESC)
             Pageable pageable

--- a/src/main/java/com/tavemakers/surf/domain/comment/dto/res/CommentResDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/comment/dto/res/CommentResDTO.java
@@ -49,11 +49,12 @@ public record CommentResDTO(
 
 ) {
     public static CommentResDTO from(Comment comment,
+                                     Long postId,
                                      List<MentionResDTO> mentions,
                                      Boolean liked) {
         return new CommentResDTO(
                 comment.getId(),
-                comment.getPost().getId(),
+                postId,
                 comment.getRootId(),
                 comment.getParent() != null ? comment.getParent().getId() : null,
                 comment.getDepth(),

--- a/src/main/java/com/tavemakers/surf/domain/comment/service/CommentLikeService.java
+++ b/src/main/java/com/tavemakers/surf/domain/comment/service/CommentLikeService.java
@@ -15,6 +15,9 @@ import com.tavemakers.surf.domain.notification.service.NotificationCreateService
 import com.tavemakers.surf.domain.post.entity.Post;
 import com.tavemakers.surf.domain.post.repository.PostRepository;
 import java.util.Map;
+
+import com.tavemakers.surf.global.logging.LogEvent;
+import com.tavemakers.surf.global.logging.LogParam;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -35,7 +38,8 @@ public class CommentLikeService {
 
     /** 좋아요 및 좋아요 취소 */
     @Transactional
-    public boolean toggleLike(Long commentId, Long memberId) {
+    @LogEvent("comment.like.toggle")
+    public boolean toggleLike(@LogParam("comment_id") Long commentId, Long memberId) {
         Comment comment = commentRepository.findById(commentId)
                 .orElseThrow(CommentNotFoundException::new);
         Member member = memberRepository.findById(memberId)
@@ -46,8 +50,9 @@ public class CommentLikeService {
             throw new CannotLikeDeletedCommentException();
         }
 
-        Post post = comment.getPost();
-        if (post == null) throw new CommentNotFoundException();
+        Post post = postRepository.findById(
+                comment.getPost().getId()
+        ).orElseThrow(CommentNotFoundException::new);
 
         // 좋아요 이미 존재하면 취소
         int removed = commentLikeRepository.deleteByCommentAndMember(comment, member);

--- a/src/main/java/com/tavemakers/surf/domain/comment/service/CommentService.java
+++ b/src/main/java/com/tavemakers/surf/domain/comment/service/CommentService.java
@@ -139,14 +139,14 @@ public class CommentService {
         // 응답 DTO (멘션, 좋아요 포함)
         List<MentionResDTO> mentions = commentMentionService.getMentions(saved.getId());
         boolean liked = false; // 새 댓글은 기본적으로 좋아요 없음
-        return CommentResDTO.from(saved, mentions, liked);
+        return CommentResDTO.from(saved, postId, mentions, liked);
     }
 
     /** 댓글 삭제 */
     @Transactional
-    @LogEvent(value = "comment.delete", message = "댓글 삭제 성공")
+    @LogEvent("comment.delete")
     public void deleteComment(
-            @LogParam("post_id") Long postId,
+            Long postId,
             @LogParam("comment_id") Long commentId,
             Long memberId
     ) {
@@ -227,7 +227,7 @@ public class CommentService {
                 .map(comment -> {
                     List<MentionResDTO> mentions = commentMentionService.getMentions(comment.getId());
                     boolean liked = memberId != null && commentLikeService.isLikedByMe(comment.getId(), memberId);
-                    return CommentResDTO.from(comment, mentions, liked);
+                    return CommentResDTO.from(comment, postId, mentions, liked);
                 })
                 .toList();
 


### PR DESCRIPTION
## 📄 작업 내용 요약
> 댓글 도메인에서 @LogParam, buildProps로 처리 가능한 값들만 로그 작업

## 1. 로그 작업한 부분
<img width="1400" height="300" alt="image" src="https://github.com/user-attachments/assets/c5aa0b71-2db0-4b4c-b4ae-1bf4a8c4f45d" />

- 댓글 좋아요 클릭 부분의 `comment_id`
- 댓글 삭제 부분의 `comment_id`
- 댓글 목록 더보기의 `post_id`
  
## 2. 기타 이슈
- 댓글 좋아요 클릭 시 알림 생성 과정에서 `post.getBoard().getId()` 호출 시 LAZY 로딩 예외가 발생하는 문제 확인
- 댓글 응답 DTO(CommentResDTO) 생성 시 엔티티 연관(`Comment` → `Post`) 접근을 제거하고 `postId`를 외부에서 전달하도록 구조 수정

### 예시
```
2025-12-25 15:19:20 [default] INFO  [http-nio-8080-exec-3] api-event - {
  "message" : "�̺�Ʈ��: comment.like.toggle",
  "props" : {
    "comment_id" : 53
  },
  "result" : "success",
  "duration_ms" : 282,
  "path" : "/v1/user/comments/53/like",
  "event_type" : "INFO",
  "http_method" : "POST",
  "user_id" : "1",
  "event" : "comment.like.toggle",
  "request_id" : "4d5172d0-1487-443f-9859-f7eaa8d7811e",
  "timestamp" : "2025-12-25T06:19:20.482626500Z",
  "status" : 200,
  "actor_role" : "ROLE_MANAGER"
}
```

## 📎 Issue 번호
closed #190

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 댓글 관련 로깅을 강화해 조회·좋아요 토글·삭제 등 주요 작업의 추적을 개선했습니다.
  * 댓글 응답에 게시물 식별자(postId)를 명시적으로 포함하도록 응답 포맷을 업데이트했습니다.
  * 응답 생성 흐름에서 게시물 컨텍스트가 일관되게 전달되도록 처리했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->