### PR TITLE
[Refact] 카카오로그인 JWT 인증 방식 통일 (HttpOnly 쿠키 기반)

### DIFF
--- a/src/main/java/com/tavemakers/surf/domain/login/LoginResDto.java
+++ b/src/main/java/com/tavemakers/surf/domain/login/LoginResDto.java
@@ -9,12 +9,9 @@ import io.swagger.v3.oas.annotations.media.Schema;
  * - refreshToken, expiresIn 은 제외 (보안 및 불필요 데이터 제거)
  */
 
-@Schema(description = "인가 코드(code)를 받아 JWT AccessToken과 사용자 정보를 반환합니다.")
+@Schema(description = "로그인 성공 시 사용자 기본 정보 응답 DTO")
 @Builder
 public record LoginResDto(
-
-        @Schema(description = "JWT Access Token", example = "abcdefg...jwt")
-        String accessToken,
 
         @Schema(description = "사용자 닉네임", example = "홍길동")
         String nickname,
@@ -29,9 +26,8 @@ public record LoginResDto(
      * 정적 팩토리 메서드
      * - accessToken + nickname → LoginResDto 변환
      */
-    public static LoginResDto of(String accessToken, String nickname, String email, String profileImageUrl) {
+    public static LoginResDto of(String nickname, String email, String profileImageUrl) {
         return LoginResDto.builder()
-                .accessToken(accessToken)
                 .nickname(nickname)
                 .email(email)
                 .profileImageUrl(profileImageUrl)

--- a/src/main/java/com/tavemakers/surf/domain/member/controller/AuthController.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/controller/AuthController.java
@@ -102,7 +102,6 @@ public class AuthController {
 
             var account = userInfo.kakaoAccount();
             LoginResDto loginRes = LoginResDto.of(
-                    accessToken,
                     account.profile().nickname(),
                     account.email(),
                     account.profile().profileImageUrl()

--- a/src/main/java/com/tavemakers/surf/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/tavemakers/surf/global/jwt/JwtAuthenticationFilter.java
@@ -47,7 +47,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         String refreshToken = jwtService.extractRefreshToken(request)
                 .filter(jwtService::isTokenValid).orElse(null);
 
-        String accessToken = jwtService.extractAccessToken(request)
+        String accessToken = jwtService.extractAccessTokenFromCookie(request)
                 .filter(jwtService::isTokenValid).orElse(null);
 
         log.debug("URI: {}, accessToken? {}, refreshToken? {}", uri, accessToken != null, refreshToken != null);
@@ -66,10 +66,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         // 액세스 없음 + 리프레시만 있는 경우: 재발급 후 401로 재시도 유도
         if (accessToken == null && refreshToken != null) {
             String newAccess = reIssueAccessToken(refreshToken);
-            jwtService.sendAccessToken(response, newAccess);
+            jwtService.sendAccessAndRefreshToken(response, newAccess, refreshToken);
 
             response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-            response.getWriter().write("Access token re-issued. Please retry with the new token.");
             return;
         }
 

--- a/src/main/java/com/tavemakers/surf/global/jwt/JwtService.java
+++ b/src/main/java/com/tavemakers/surf/global/jwt/JwtService.java
@@ -10,7 +10,8 @@ public interface JwtService {
     String createAccessToken(Long memberId, String role);
     String createRefreshToken(Long memberId);
 
-    Optional<String> extractAccessToken(HttpServletRequest request);
+    Optional<String> extractAccessTokenFromCookie(HttpServletRequest request);
+
     Optional<String> extractRefreshToken(HttpServletRequest request);
 
     Optional<Long> extractMemberId(String token);
@@ -18,5 +19,4 @@ public interface JwtService {
     long getExpiration(String token);
 
     void sendAccessAndRefreshToken(HttpServletResponse res, String accessToken, String refreshToken);
-    void sendAccessToken(HttpServletResponse res, String accessToken);
 }


### PR DESCRIPTION
## 📄 작업 내용 요약
> 카카오로그인 JWT 인증 방식을 HttpOnly 쿠키 기반으로 통일하였습니다.

### 1. 기존 구조
> `RefreshToken`: `HttpOnly` 쿠키
> `AccessToken`: `Authorization` 헤더 + `Response Body`

- JS에서 `AccessToken` 접근 가능 → `HttpOnly` 보안 목적 훼손
- 문제를 해결하기 위해 JWT 인증 방식을 `HttpOnly` 쿠키 기준으로 완전 통일

### 2. 주요 변경 사항
> 인증 책임을 응답 Body/헤더가 아닌 쿠키(JWT) 에 위임

- `AccessToken` / `RefreshToken` 모두 `HttpOnly` 쿠키로 발급
```
ResponseCookie accessCookie = ResponseCookie.from(ACCESS_COOKIE_NAME, accessToken)
        .httpOnly(true)
        .secure(isProd)
        .domain(isProd ? ".tavesurf.site" : "localhost")
        .path("/")
        .maxAge(Duration.ofMillis(accessTokenExpireMs))
        .sameSite(sameSite)
        .build();

ResponseCookie refreshCookie = ResponseCookie.from(REFRESH_COOKIE_NAME, refreshToken)
        .httpOnly(true)
        .secure(isProd)
        .domain(isProd ? ".tavesurf.site" : "localhost")
        .path("/")
        .maxAge(Duration.ofMillis(refreshTokenExpireMs))
        .sameSite(sameSite)
        .build();
```

- `Authorization` 헤더 기반 인증 로직 완전 제거 및 헤더 전송 / 추출 로직 삭제
- JWT 추출 로직을 쿠키 기반으로 통일
- 로그인 응답에서 `accessToken` 필드 제거, 사용자 정보만 반환

## 📎 Issue 번호
closed #198 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 접근 토큰 전달 방식을 HTTP 쿠키 기반으로 변경하여 보안 개선
  * 토큰 재발급 시 접근 및 갱신 토큰 모두 쿠키로 전달

* **Changes**
  * 로그인 응답에서 접근 토큰 필드 제거; 사용자 정보(닉네임, 이메일, 프로필 이미지)만 반환

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->