### PR TITLE
[CHORE] mvp1 로그 작업

### DIFF
--- a/src/main/java/com/tavemakers/surf/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/tavemakers/surf/domain/comment/controller/CommentController.java
@@ -29,8 +29,9 @@ public class CommentController {
 
     @Operation(summary = "댓글 생성 (루트/대댓글)", description = "rootId가 null이면 루트 댓글")
     @PostMapping("/v1/user/posts/{postId}/comments")
-    public ApiResponse<CommentResDTO> createComment(@PathVariable Long postId,
-                                                    @Valid @RequestBody CommentCreateReqDTO req) {
+    public ApiResponse<CommentResDTO> createComment(
+            @PathVariable Long postId,
+            @Valid @RequestBody CommentCreateReqDTO req) {
         Long memberId = SecurityUtils.getCurrentMemberId();
         CommentResDTO response = commentService.createComment(postId, memberId, req);
         return ApiResponse.response(HttpStatus.CREATED, COMMENT_CREATED.getMessage(), response);

--- a/src/main/java/com/tavemakers/surf/domain/post/controller/PostController.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/controller/PostController.java
@@ -6,6 +6,7 @@ import com.tavemakers.surf.domain.post.dto.res.PostDetailResDTO;
 import com.tavemakers.surf.domain.post.dto.res.PostResDTO;
 import com.tavemakers.surf.domain.post.service.PostService;
 import com.tavemakers.surf.global.common.response.ApiResponse;
+import com.tavemakers.surf.global.logging.LogEvent;
 import com.tavemakers.surf.global.util.SecurityUtils;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -66,7 +67,7 @@ public class PostController {
     @Operation(summary = "특정 작성자의 게시글 목록", description = "특정 작성자가 작성한 게시글 목록을 조회합니다.")
     @GetMapping("/v1/user/posts/author/{authorId}")
     public ApiResponse<Slice<PostResDTO>> getPostsByMember(
-            @PathVariable (name = "authorId") Long authorId,
+            @PathVariable Long authorId,
             @PageableDefault(size = 12, sort = "postedAt", direction = Sort.Direction.DESC)
             Pageable pageable
     ) {

--- a/src/main/java/com/tavemakers/surf/domain/post/service/PostLikeService.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/service/PostLikeService.java
@@ -11,6 +11,7 @@ import com.tavemakers.surf.domain.post.exception.PostNotFoundException;
 import com.tavemakers.surf.domain.post.repository.PostLikeRepository;
 import com.tavemakers.surf.domain.post.repository.PostRepository;
 import com.tavemakers.surf.global.logging.LogEvent;
+import com.tavemakers.surf.global.logging.LogEventContext;
 import com.tavemakers.surf.global.logging.LogParam;
 import jakarta.persistence.OptimisticLockException;
 import java.util.Map;
@@ -34,6 +35,7 @@ public class PostLikeService {
     public void like(
             @LogParam("post_id") Long postId,
             @LogParam("user_id") Long memberId) {
+        LogEventContext.put("liked", true);
 
         if (postLikeRepository.existsByPostIdAndMemberId(postId, memberId)) {
             return;
@@ -66,6 +68,8 @@ public class PostLikeService {
             Long postId,
             @LogParam("user_id")
             Long memberId) {
+        LogEventContext.put("liked", false);
+
         long deleted = postLikeRepository.deleteByPostIdAndMemberId(postId, memberId);
         if (deleted > 0) {
             Post post = postRepository.findById(postId)

--- a/src/main/java/com/tavemakers/surf/domain/scrap/service/ScrapService.java
+++ b/src/main/java/com/tavemakers/surf/domain/scrap/service/ScrapService.java
@@ -11,6 +11,7 @@ import com.tavemakers.surf.domain.post.repository.PostRepository;
 import com.tavemakers.surf.domain.scrap.entity.Scrap;
 import com.tavemakers.surf.domain.scrap.repository.ScrapRepository;
 import com.tavemakers.surf.global.logging.LogEvent;
+import com.tavemakers.surf.global.logging.LogEventContext;
 import com.tavemakers.surf.global.logging.LogParam;
 import jakarta.persistence.OptimisticLockException;
 import lombok.RequiredArgsConstructor;
@@ -73,6 +74,7 @@ public class ScrapService {
         }
     }
 
+    @LogEvent(value = "scrap.list.view", message = "스크랩 목록 조회")
     public Slice<PostResDTO> getMyScraps(Long memberId, Pageable pageable) {
         Slice<Post> slice = scrapRepository.findPostsByMemberId(memberId, pageable);
 
@@ -82,9 +84,13 @@ public class ScrapService {
 
         Set<Long> likedIds = new HashSet<>(postLikeRepository.findLikedPostIdsByMemberAndPostIds(memberId, postIds));
 
-        return slice.map(post ->
+        Slice<PostResDTO> result = slice.map(post ->
                 PostResDTO.from(post, true, likedIds.contains(post.getId()))
         );
+
+        LogEventContext.put("count", slice.getNumberOfElements());
+
+        return result;
     }
 
     public boolean isScrappedByMe(Long memberId, Long postId) {

--- a/src/main/java/com/tavemakers/surf/global/logging/LogEventAspect.java
+++ b/src/main/java/com/tavemakers/surf/global/logging/LogEventAspect.java
@@ -45,6 +45,8 @@ public class LogEventAspect {
             // ✅ 2. 리턴값에서 ID 자동 보강
             enrichWithReturn(props, ret);
 
+            props.putAll(LogEventContext.drain());
+
             // ✅ 3. 성공 로그 emit
             if (msg == null || msg.isBlank()) {
                 emitter.emit(event, props);
@@ -54,6 +56,7 @@ public class LogEventAspect {
             return ret;
         }catch (Exception ex) {
             Map<String, Object> fail = new HashMap<>(props);
+            fail.putAll(LogEventContext.drain());
             fail.put("error_code", ex.getClass().getSimpleName());
             fail.put("error_msg", ex.getMessage());
 

--- a/src/main/java/com/tavemakers/surf/global/logging/LogEventAspect.java
+++ b/src/main/java/com/tavemakers/surf/global/logging/LogEventAspect.java
@@ -103,8 +103,18 @@ public class LogEventAspect {
         } catch (Exception ignored) {}
     }
 
-    private Long tryExtractId(Object dto) {
+    private Long  tryExtractId(Object dto) {
         if (dto == null) return null;
+
+        try {
+            for (var method : dto.getClass().getMethods()) {
+                String name = method.getName();
+                if (method.getParameterCount() == 0 && name.endsWith("Id")) {
+                    Object v = method.invoke(dto);
+                    if (v instanceof Number n) return n.longValue();
+                }
+            }
+        } catch (Exception ignore) {}
 
         try {
             var m1 = dto.getClass().getMethod("id");

--- a/src/main/java/com/tavemakers/surf/global/logging/LogEventContext.java
+++ b/src/main/java/com/tavemakers/surf/global/logging/LogEventContext.java
@@ -1,0 +1,34 @@
+package com.tavemakers.surf.global.logging;
+
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class LogEventContext {
+
+    public static void put(String key, Object value) {
+        if (value == null) return;
+
+        RequestLogContext ctx = RequestLogContext.get();
+        if (ctx.events.isEmpty()) return;
+
+        Map<String, Object> lastEvent = ctx.events.get(ctx.events.size() - 1);
+
+        Object propsObj = lastEvent.get("props");
+        Map<String, Object> props;
+
+        if (propsObj instanceof Map<?, ?> map) {
+            props = new HashMap<>();
+            map.forEach((k, v) -> {
+                if (k instanceof String) {
+                    props.put((String) k, v);
+                }
+            });
+        } else {
+            props = new HashMap<>();
+        }
+
+        props.put(key, value);
+        lastEvent.put("props", props);
+    }
+}

--- a/src/main/java/com/tavemakers/surf/global/logging/LogEventContext.java
+++ b/src/main/java/com/tavemakers/surf/global/logging/LogEventContext.java
@@ -7,28 +7,20 @@ import java.util.Map;
 public class LogEventContext {
 
     public static void put(String key, Object value) {
-        if (value == null) return;
+        if (key == null || key.isBlank() || value == null) return;
 
+        RequestLogContext.get().pendingProps.put(key, value);
+    }
+
+    static Map<String, Object> drain() {
         RequestLogContext ctx = RequestLogContext.get();
-        if (ctx.events.isEmpty()) return;
 
-        Map<String, Object> lastEvent = ctx.events.get(ctx.events.size() - 1);
-
-        Object propsObj = lastEvent.get("props");
-        Map<String, Object> props;
-
-        if (propsObj instanceof Map<?, ?> map) {
-            props = new HashMap<>();
-            map.forEach((k, v) -> {
-                if (k instanceof String) {
-                    props.put((String) k, v);
-                }
-            });
-        } else {
-            props = new HashMap<>();
+        if (ctx.pendingProps.isEmpty()) {
+            return Map.of();
         }
 
-        props.put(key, value);
-        lastEvent.put("props", props);
+        Map<String, Object> copy = new HashMap<>(ctx.pendingProps);
+        ctx.pendingProps.clear();
+        return copy;
     }
 }

--- a/src/main/java/com/tavemakers/surf/global/logging/LogEventContext.java
+++ b/src/main/java/com/tavemakers/surf/global/logging/LogEventContext.java
@@ -1,26 +1,49 @@
 package com.tavemakers.surf.global.logging;
 
-
 import java.util.HashMap;
 import java.util.Map;
 
 public class LogEventContext {
 
+    private static final String OVERRIDE_EVENT_KEY = "__override_event";
+    private static final String OVERRIDE_MESSAGE_KEY = "__override_message";
+
     public static void put(String key, Object value) {
         if (key == null || key.isBlank() || value == null) return;
-
         RequestLogContext.get().pendingProps.put(key, value);
+    }
+
+    // 이벤트명 런타임 교체
+    public static void overrideEvent(String event) {
+        if (event == null || event.isBlank()) return;
+        RequestLogContext.get().pendingProps.put(OVERRIDE_EVENT_KEY, event);
+    }
+
+    // 메시지 런타임 교체
+    public static void overrideMessage(String message) {
+        if (message == null || message.isBlank()) return;
+        RequestLogContext.get().pendingProps.put(OVERRIDE_MESSAGE_KEY, message);
     }
 
     static Map<String, Object> drain() {
         RequestLogContext ctx = RequestLogContext.get();
 
-        if (ctx.pendingProps.isEmpty()) {
-            return Map.of();
-        }
+        if (ctx.pendingProps.isEmpty()) return Map.of();
 
         Map<String, Object> copy = new HashMap<>(ctx.pendingProps);
         ctx.pendingProps.clear();
         return copy;
+    }
+
+    // drain 결과에서 override_event 추출 (+props에 남지 않게 remove)
+    static String extractOverrideEvent(Map<String, Object> drained) {
+        Object v = drained.remove(OVERRIDE_EVENT_KEY);
+        return (v instanceof String s && !s.isBlank()) ? s : null;
+    }
+
+    // drain 결과에서 override_message 추출 (+props에 남지 않게 remove)
+    static String extractOverrideMessage(Map<String, Object> drained) {
+        Object v = drained.remove(OVERRIDE_MESSAGE_KEY);
+        return (v instanceof String s && !s.isBlank()) ? s : null;
     }
 }

--- a/src/main/java/com/tavemakers/surf/global/logging/LogEventContext.java
+++ b/src/main/java/com/tavemakers/surf/global/logging/LogEventContext.java
@@ -28,7 +28,9 @@ public class LogEventContext {
     static Map<String, Object> drain() {
         RequestLogContext ctx = RequestLogContext.get();
 
-        if (ctx.pendingProps.isEmpty()) return Map.of();
+        if (ctx.pendingProps.isEmpty()) {
+            return new HashMap<>();
+        }
 
         Map<String, Object> copy = new HashMap<>(ctx.pendingProps);
         ctx.pendingProps.clear();

--- a/src/main/java/com/tavemakers/surf/global/logging/RequestLogContext.java
+++ b/src/main/java/com/tavemakers/surf/global/logging/RequestLogContext.java
@@ -2,6 +2,7 @@ package com.tavemakers.surf.global.logging;
 
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -19,6 +20,7 @@ public class RequestLogContext {
     public int status;
 
     public final List<Map<String, Object>> events = new ArrayList<>(); // event 레코드 모음
+    public final Map<String, Object> pendingProps = new HashMap<>();
 
     public static RequestLogContext get() { return LOCAL.get(); }
     public static void clear() { LOCAL.remove(); }


### PR DESCRIPTION
## 📄 작업 내용 요약
### 1. LogEventAspect 개선

서비스 로직 중에만 계산 가능한 값(liked, count, has_replies 등)을 AOP 외부에서 안전하게 전달할 필요가 있었습니다.
기존 방식에서는 이벤트 props를 직접 수정하며 타입 캐스팅/순서 문제의 여지가 있었고, 이를 drain 기반 병합 구조로 단순화했습니다.
JDK 프록시 환경에서 어노테이션 메타데이터 누락을 방지하기 위해 getMostSpecificMethod 처리를 추가했습니다.

### 2. LogEventContext 도입/확장

서비스 코드에서 이벤트 props를 보강할 수 있도록 LogEventContext.put(key, value)를 제공합니다.
put된 값은 즉시 이벤트에 반영되지 않고, 요청 컨텍스트의 pendingProps에 임시 저장됩니다.
AOP 종료 시점에 drain()으로 한 번에 소비되며 이벤트 props에 병합됩니다.
런타임에 이벤트명 또는 메시지를 교체할 수 있도록 override 용 키를 함께 관리합니다.

### 3. RequestLogContext 구조 정비

이벤트 로그는 “메서드”가 아니라 HTTP 요청 단위로 완성됩니다. 
공통 필드는 요청이 끝나야 확정되므로, 공지사항과 일반 게시물의 로그 분리를 위해 이벤트 발생 시점과 출력 시점을 분리할 필요가 있었습니다.
ThreadLocal을 사용함으로써 Filter / AOP / Service 간 상태 공유를 단순화했고 별도의 스코프 객체 없이 요청 단위 일관성을 확보했습니다.

정리
LogEventAspect는 이벤트 로그의 생명주기를 관리합니다.
LogEventContext는 서비스 로직에서 의미 있는 도메인 값을 안전하게 전달하는 통로입니다.
RequestLogContext는 요청 단위 로그 상태를 보존하고, 최종 로그 출력을 가능하게 합니다.

## 📎 Issue 번호
<!-- closed #188  -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * 내부 로깅 인프라 개선 및 ID 추출 로직 강화로 진단/모니터링 정확도 향상.
  * 성공/실패 경로에서 런타임 이벤트·메시지 오버라이드 처리 추가.
  * 게시물 조회, 스크랩, 좋아요/취소 흐름에 로깅 컨텍스트 통합 및 로그 컨텍스트 수집 강화.

* **New Features**
  * 요청별 로그 상태 관리를 위한 LogEventContext 추가 및 대기 속성(pendingProps) 관리 기능 도입.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->