### PR TITLE
[Feat] 게시글 상세 조회 시 일정 id 응답값 추가

### DIFF
--- a/src/main/java/com/tavemakers/surf/domain/post/dto/req/PostImageCreateReqDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/dto/req/PostImageCreateReqDTO.java
@@ -6,11 +6,11 @@ import jakarta.validation.constraints.NotNull;
 
 public record PostImageCreateReqDTO(
 
-        @Schema(description = "이미지 원본 S3 URL")
+        @Schema(description = "이미지 원본 S3 URL", example = "meeting.jpg")
         @NotBlank
         String originalUrl,
 
-        @Schema(description = "이미지 게시 순서")
+        @Schema(description = "이미지 게시 순서", example = "1")
         @NotNull
         Integer sequence
 

--- a/src/main/java/com/tavemakers/surf/domain/post/dto/res/PostDetailResDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/dto/res/PostDetailResDTO.java
@@ -61,7 +61,10 @@ public record PostDetailResDTO(
         int viewCount,
 
         @Schema(description = "일정 매핑 유무", example = "true")
-        Boolean hasSchedule
+        Boolean hasSchedule,
+
+        @Schema(description = "일정 Id", example = "2")
+        Long scheduleId
 ) {
     public static PostDetailResDTO of(
             Post post,
@@ -90,6 +93,7 @@ public record PostDetailResDTO(
                 .imageUrlList(imageUrlList)
                 .viewCount(viewCount)
                 .hasSchedule(post.getHasSchedule())
+                .scheduleId(post.getScheduleId())
                 .build();
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/post/entity/Post.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/entity/Post.java
@@ -157,4 +157,8 @@ public class Post extends BaseEntity {
     public void increaseViewCount() {
         this.viewCount++;
     }
+
+    public void addScheduleId(Long scheduleId) {
+        this.scheduleId = scheduleId;
+    }
 }

--- a/src/main/java/com/tavemakers/surf/domain/post/entity/Post.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/entity/Post.java
@@ -75,6 +75,9 @@ public class Post extends BaseEntity {
 
     private Boolean hasSchedule;
 
+    @Column(nullable = true)
+    private Long scheduleId;
+
     public static Post of(PostCreateReqDTO req, Board board, BoardCategory category, Member member) {
         return Post.builder()
                 .title(req.title())
@@ -99,11 +102,18 @@ public class Post extends BaseEntity {
         this.title = req.title();
         this.content = req.content();
         this.pinned = req.pinned() != null ? req.pinned() : this.pinned;
+
         this.board = board;
         this.boardName = board.getName();
+
         this.category = category;
         this.categoryName = category.getName();
+
         this.hasSchedule = req.hasSchedule();
+
+        if (Boolean.FALSE.equals(req.hasSchedule())) {
+            this.scheduleId = null;
+        }
     }
 
     @PrePersist

--- a/src/main/java/com/tavemakers/surf/domain/post/service/PostUpdateService.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/service/PostUpdateService.java
@@ -19,4 +19,6 @@ public class PostUpdateService {
         postJdbcRepository.viewCountBulkUpdate(updateDtoList);
     }
 
+    //게시글과 매핑된 스케쥴 아이디 추가
+
 }

--- a/src/main/java/com/tavemakers/surf/domain/post/service/ScheduleCreateService.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/service/ScheduleCreateService.java
@@ -14,9 +14,9 @@ public class ScheduleCreateService {
     private final ScheduleRepository scheduleRepository;
 
     @Transactional
-    public void createScheduleAtPost(ScheduleCreateReqDTO dto, Post post) {
+    public Long createScheduleAtPost(ScheduleCreateReqDTO dto, Post post) {
         Schedule schedule = Schedule.of(dto, post);
-        scheduleRepository.save(schedule);
+        return scheduleRepository.save(schedule).getId();
     }
 
     @Transactional

--- a/src/main/java/com/tavemakers/surf/domain/post/service/ScheduleUseCase.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/service/ScheduleUseCase.java
@@ -24,7 +24,8 @@ public class ScheduleUseCase {
     @Transactional
     public void createScheduleAtPost(ScheduleCreateReqDTO dto, Long postId) {
         Post post = postService.findPostById(postId);
-        scheduleCreateService.createScheduleAtPost(dto, post);
+        Long scheduleId = scheduleCreateService.createScheduleAtPost(dto, post);
+        post.addScheduleId(scheduleId);
     }
 
     //개별 일정 생성(캘린더에서)


### PR DESCRIPTION
## 📄 작업 내용 요약
게시글 상세 조회 API 응답에 scheduleId 필드를 추가하였습니다.

이를 위해 Post 테이블에 scheduleId 컬럼을 신규로 추가하였으며,
기본값은 null 로 설정하여 일정이 없는 게시글과 명확히 구분되도록 처리했습니다.

현재 전체 로직은 다음과 같습니다.
	1.게시글 생성 요청 시, 일정이 함께 작성된 경우 프론트에서 hasSchedule = true 값을 전달합니다.
	2.전달받은 일정 정보를 기반으로 일정을 생성합니다.
	3.일정 생성이 완료되면, 생성된 일정 ID를 연관된 게시글의 scheduleId 필드에 저장합니다.

단순히 게시글 상세 조회 DTO에 scheduleId를 계산하여 추가하는 방식도 가능했지만,
그 경우 게시글 ID를 기준으로 매번 일정 테이블을 조회해야 하므로 DB 접근 횟수가 증가하게 됩니다.

이에 따라, 일정 생성 시점에 해당 일정의 ID를 게시글에 직접 저장하는 방식으로 설계를 변경하였고,
이를 통해 게시글 상세 조회 시 추가적인 DB 조회 없이 scheduleId를 바로 응답할 수 있도록 최적화했습니다.

이 구조를 통해
	•조회 성능을 개선하고
	•게시글과 일정 간의 관계를 명확하게 관리할 수 있도록 하였습니다.

## 📎 Issue 번호 204
<!-- closed #204 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새 기능
* 게시물에 스케줄을 연결할 수 있는 기능이 추가되었습니다.
* 스케줄 생성 시 해당 스케줄의 ID가 게시물과 함께 자동으로 저장됩니다.

## 문서화
* API 문서에 이미지 업로드 필드의 예제 정보가 추가되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->