### PR TITLE
[FEAT] 알림 생성 이벤트로 분리

### DIFF
--- a/src/main/java/com/tavemakers/surf/domain/home/dto/response/HomeResDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/home/dto/response/HomeResDTO.java
@@ -26,6 +26,9 @@ public record HomeResDTO(
         String nextScheduleTitle,
 
         @Schema(description = "다음 일정 날짜", example = "01.01")
-        String nextScheduleDate
+        String nextScheduleDate,
+
+        @Schema(description = "다음 일정 deeplink", example = "board/{boardId}/post/{postId}")
+        String nextScheduleDeepLink
 ) {
 }

--- a/src/main/java/com/tavemakers/surf/domain/home/dto/response/HomeResDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/home/dto/response/HomeResDTO.java
@@ -28,7 +28,7 @@ public record HomeResDTO(
         @Schema(description = "다음 일정 날짜", example = "01.01")
         String nextScheduleDate,
 
-        @Schema(description = "다음 일정 deeplink", example = "board/{boardId}/post/{postId}")
+        @Schema(description = "다음 일정 deeplink", example = "/board/{boardId}/post/{postId}")
         String nextScheduleDeepLink
 ) {
 }

--- a/src/main/java/com/tavemakers/surf/domain/home/service/HomeService.java
+++ b/src/main/java/com/tavemakers/surf/domain/home/service/HomeService.java
@@ -14,7 +14,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Comparator;
@@ -88,10 +87,9 @@ public class HomeService {
             nextTitle = s.getTitle();
             nextScheduleDate = s.getStartAt().toLocalDate().format(formatter);
 
-            if (s.getPost() != null) {
+            if (s.getPost() != null && s.getPost().getBoard() != null) {
                 Long postId = s.getPost().getId();
                 Long boardId = s.getPost().getBoard().getId();
-
                 nextScheduleDeepLink = "/board/" + boardId + "/post/" + postId;
             }
         }

--- a/src/main/java/com/tavemakers/surf/domain/home/service/HomeService.java
+++ b/src/main/java/com/tavemakers/surf/domain/home/service/HomeService.java
@@ -77,7 +77,11 @@ public class HomeService {
 
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("MM.dd");
 
-        Optional<Schedule> next = scheduleRepository.findFirstByStartAtAfterOrderByStartAtAsc(LocalDateTime.now());
+        Optional<Schedule> next = scheduleRepository.findFirstByCategoryAndStartAtAfterOrderByStartAtAsc(
+                "정규행사",
+                LocalDateTime.now()
+        );
+
         if (next.isPresent()) {
             Schedule s = next.get();
             nextTitle = s.getTitle();

--- a/src/main/java/com/tavemakers/surf/domain/home/service/HomeService.java
+++ b/src/main/java/com/tavemakers/surf/domain/home/service/HomeService.java
@@ -74,6 +74,7 @@ public class HomeService {
         // 4) next schedule
         String nextTitle = null;
         String nextScheduleDate = null;
+        String nextScheduleDeepLink = null;
 
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("MM.dd");
 
@@ -86,6 +87,13 @@ public class HomeService {
             Schedule s = next.get();
             nextTitle = s.getTitle();
             nextScheduleDate = s.getStartAt().toLocalDate().format(formatter);
+
+            if (s.getPost() != null) {
+                Long postId = s.getPost().getId();
+                Long boardId = s.getPost().getBoard().getId();
+
+                nextScheduleDeepLink = "/board/" + boardId + "/post/" + postId;
+            }
         }
 
         return new HomeResDTO(
@@ -95,7 +103,8 @@ public class HomeService {
                 memberGeneration,
                 memberPart,
                 nextTitle,
-                nextScheduleDate
+                nextScheduleDate,
+                nextScheduleDeepLink
         );
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/notification/controller/FcmTestController.java
+++ b/src/main/java/com/tavemakers/surf/domain/notification/controller/FcmTestController.java
@@ -36,7 +36,7 @@ public class FcmTestController {
             )
             @RequestBody FcmTestReqDTO req
     ) {
-        fcmService.sendToMember(req.memberId(), req.title(), req.body());
+        fcmService.sendToMember(req.memberId(), req.title(), req.body(), 1L);
         return ApiResponse.response(
                 HttpStatus.OK,
                 FCM_TEST_SUCCESS.getMessage()

--- a/src/main/java/com/tavemakers/surf/domain/notification/event/NotificationCreatedEvent.java
+++ b/src/main/java/com/tavemakers/surf/domain/notification/event/NotificationCreatedEvent.java
@@ -1,0 +1,6 @@
+package com.tavemakers.surf.domain.notification.event;
+
+public record NotificationCreatedEvent(
+        Long notificationId,
+        Long receiverId
+) {}

--- a/src/main/java/com/tavemakers/surf/domain/notification/event/NotificationFcmListener.java
+++ b/src/main/java/com/tavemakers/surf/domain/notification/event/NotificationFcmListener.java
@@ -1,0 +1,42 @@
+package com.tavemakers.surf.domain.notification.event;
+
+import com.tavemakers.surf.domain.notification.entity.Notification;
+import com.tavemakers.surf.domain.notification.repository.NotificationRepository;
+import com.tavemakers.surf.domain.notification.service.FcmService;
+import com.tavemakers.surf.domain.notification.service.NotificationRenderService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NotificationFcmListener {
+
+    private final NotificationRepository notificationRepository;
+    private final NotificationRenderService renderer;
+    private final FcmService fcmService;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void on(NotificationCreatedEvent e) {
+        try {
+            Notification notification = notificationRepository.findById(e.notificationId())
+                    .orElse(null);
+            if (notification == null) return;
+
+            String body = renderer.renderBody(notification);
+            String deeplink = renderer.renderDeeplink(notification);
+
+            fcmService.sendToMember(
+                    e.receiverId(),
+                    body,
+                    deeplink,
+                    notification.getId()
+            );
+        } catch (Exception ex) {
+            log.warn("FCM send failed after commit. notificationId={}", e.notificationId(), ex);
+        }
+    }
+}

--- a/src/main/java/com/tavemakers/surf/domain/notification/service/FcmService.java
+++ b/src/main/java/com/tavemakers/surf/domain/notification/service/FcmService.java
@@ -15,7 +15,7 @@ public class FcmService {
 
     private final DeviceTokenRepository deviceTokenRepository;
 
-    public void sendToMember(Long memberId, String body, String deeplink) {
+    public void sendToMember(Long memberId, String body, String deeplink, Long notificationId) {
         List<DeviceToken> tokens = deviceTokenRepository.findAllByMemberIdAndEnabledTrue(memberId);
         if (tokens.isEmpty()) return;
 
@@ -27,6 +27,7 @@ public class FcmService {
                         .setBody(body)
                         .build())
                 .putData("deepLink", deeplink)
+                .putData("notificationId", String.valueOf(notificationId))
                 // data payload는 나중에 딥링크/타입 붙일 때 추가하면 됨
                 .addAllTokens(tokenStrings)
                 .build();

--- a/src/main/java/com/tavemakers/surf/domain/post/repository/ScheduleRepository.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/repository/ScheduleRepository.java
@@ -23,5 +23,7 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
 
     void deleteByPost(Post post);
 
-    Optional<Schedule> findFirstByStartAtAfterOrderByStartAtAsc(LocalDateTime now);
+    Optional<Schedule> findFirstByCategoryAndStartAtAfterOrderByStartAtAsc(
+            String category,
+            LocalDateTime now);
 }


### PR DESCRIPTION
## 📄 작업 내용 요약
알림 생성 로직과 전송 로직을 이벤트 기반으로 분리하고, FCM payload에 notificationId를 추가했습니다.

기존 구조에서는 트랜잭션 내부에서 FCM 전송이 함께 수행되어, 트랜잭션이 롤백될 경우에도 푸시가 먼저 발송될 수 있는 가능성이 있었습니다. 이를 방지하기 위해 알림 저장 이후 NotificationCreatedEvent를 발행하고, @TransactionalEventListener(AFTER_COMMIT) 를 통해 트랜잭션 커밋이 확정된 이후에만 FCM 전송이 수행되도록 구조를 변경했습니다.

읽음 처리를 구현하기 위해 FCM 전송 시 notificationId를 data payload에 함께 포함하도록 수정했습니다. 알림 클릭 시 클라이언트는 이 notificationId를 기반으로 서버의 단건 읽음 처리 API를 호출할 수 있습니다. 
## 📎 Issue 번호
<!-- closed #173-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 알림 생성 이벤트 발행 및 이벤트 기반 푸시 전송 리스너 추가.
  * 푸시 페이로드에 알림 ID 포함.

* **리팩토링**
  * 알림 생성 로직을 이벤트 발행 방식으로 전환해 전송 책임을 분리.
  * 테스트용 푸시 엔드포인트 호출이 새 파라미터를 사용하도록 업데이트.

* **버그·동작 변경**
  * 홈 화면의 다음 일정이 특정 카테고리("정규행사")로 필터링되며, 다음 일정의 deeplink가 응답에 포함됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->