### PR TITLE
[Hotfix] swagger 배포 인증 로직 보완

### DIFF
--- a/src/main/java/com/tavemakers/surf/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/tavemakers/surf/global/jwt/JwtAuthenticationFilter.java
@@ -47,7 +47,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 .filter(jwtService::isTokenValid).orElse(null);
 
         String accessToken = jwtService.extractAccessTokenFromCookie(request)
-                .filter(jwtService::isTokenValid).orElse(null);
+                .or(() -> jwtService.extractAccessTokenFromHeader(request))
+                .filter(jwtService::isTokenValid)
+                .orElse(null);
+
 
         log.debug("URI: {}, accessToken? {}, refreshToken? {}", uri, accessToken != null, refreshToken != null);
 

--- a/src/main/java/com/tavemakers/surf/global/jwt/JwtService.java
+++ b/src/main/java/com/tavemakers/surf/global/jwt/JwtService.java
@@ -12,6 +12,8 @@ public interface JwtService {
 
     Optional<String> extractAccessTokenFromCookie(HttpServletRequest request);
 
+    Optional<String> extractAccessTokenFromHeader(HttpServletRequest request);
+
     Optional<String> extractRefreshToken(HttpServletRequest request);
 
     Optional<Long> extractMemberId(String token);

--- a/src/main/java/com/tavemakers/surf/global/jwt/JwtServiceImpl.java
+++ b/src/main/java/com/tavemakers/surf/global/jwt/JwtServiceImpl.java
@@ -184,6 +184,13 @@ public class JwtServiceImpl implements JwtService {
             return Optional.empty();
         }
 
+        // 표준: Bearer 토큰
+        if (header.startsWith("Bearer ")) {
+            return Optional.of(header.substring(7));
+        }
+
+        // Swagger 테스트 편의: 토큰만 들어온 경우도 허용
         return Optional.of(header);
     }
+
 }

--- a/src/main/java/com/tavemakers/surf/global/jwt/JwtServiceImpl.java
+++ b/src/main/java/com/tavemakers/surf/global/jwt/JwtServiceImpl.java
@@ -177,4 +177,13 @@ public class JwtServiceImpl implements JwtService {
                 .parseClaimsJws(token)
                 .getBody();
     }
+
+    public Optional<String> extractAccessTokenFromHeader(HttpServletRequest request) {
+        String header = request.getHeader("Authorization");
+        if (header == null || header.isBlank()) {
+            return Optional.empty();
+        }
+
+        return Optional.of(header);
+    }
 }


### PR DESCRIPTION
## 📄 작업 내용 요약
배포(dev) 환경에서 Swagger 테스트 시 쿠키가 전달되지 않아 인증이 실패하던 문제를 수정했습니다.
- 쿠키가 없는 경우 Authorization 헤더의 accessToken으로 인증을 처리하도록 로직을 보완했습니다.
- 기존 HttpOnly 쿠키 기반 인증 방식은 그대로 유지됩니다.


## 📎 Issue 번호
closed #211 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **개선사항**
  * 액세스 토큰 검증 로직을 확장하여, 쿠키에서 토큰을 찾지 못할 경우 Authorization 헤더에서 토큰을 대체 검색하고 유효성을 확인합니다.
  * 인증 처리의 유연성이 향상되어 다양한 클라이언트 전송 방식이 지원됩니다.
  * 리프레시 토큰 처리 방식에는 변경이 없습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->