### PR TITLE
[Feat] 공지사항 / 대댓글 알림 및 버그 수정

### DIFF
--- a/src/main/java/com/tavemakers/surf/domain/board/entity/Board.java
+++ b/src/main/java/com/tavemakers/surf/domain/board/entity/Board.java
@@ -43,4 +43,8 @@ public class Board extends BaseEntity {
         this.name = name;
         this.type = type;
     }
+
+    public boolean isNotice() {
+        return type == BoardType.NOTICE;
+    }
 }

--- a/src/main/java/com/tavemakers/surf/domain/comment/service/CommentService.java
+++ b/src/main/java/com/tavemakers/surf/domain/comment/service/CommentService.java
@@ -104,20 +104,6 @@ public class CommentService {
                 saved.markAsRoot();
             }
 
-            if(!post.getMember().getId().equals(memberId)) {
-
-                // 댓글 생성 알림 - 게시글 작성자에게
-                notificationCreateService.createAndSend(
-                        post.getMember().getId(),
-                        NotificationType.POST_COMMENT,
-                        Map.of(
-                                "actorName", member.getName(),
-                                "boardId", post.getBoard().getId(),
-                                "postId", postId
-                        )
-                );
-            }
-
             // 댓글 생성 알림 - 루트 댓글 작성자에게
             Long parentOwnerId = parent.getMember().getId();
             notificationCreateService.createAndSend(

--- a/src/main/java/com/tavemakers/surf/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/repository/MemberRepository.java
@@ -36,4 +36,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
         ORDER BY MAX(t.generation) DESC
     """)
     List<Member> findMentionCandidates(@Param("keyword") String keyword);
+
+    List<Member> findByActivityStatusTrue();
 }

--- a/src/main/java/com/tavemakers/surf/domain/notification/service/NotificationEventListener.java
+++ b/src/main/java/com/tavemakers/surf/domain/notification/service/NotificationEventListener.java
@@ -1,0 +1,37 @@
+package com.tavemakers.surf.domain.notification.service;
+
+import static com.tavemakers.surf.domain.post.exception.ErrorMessage.POST_NOT_FOUND;
+
+import com.tavemakers.surf.domain.post.entity.Post;
+import com.tavemakers.surf.domain.post.exception.PostNotFoundException;
+import com.tavemakers.surf.domain.post.repository.PostRepository;
+import com.tavemakers.surf.domain.post.service.PostPublishedEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NotificationEventListener {
+
+    private final PostRepository postRepository;
+    private final NotificationUseCase notificationUseCase;
+
+    @Async
+    @EventListener
+    public void handle(PostPublishedEvent event) {
+        Post post = postRepository.findById(event.getPostId())
+                .orElseThrow(PostNotFoundException::new);
+
+        if (!post.getBoard().isNotice()) {
+            return;
+        }
+
+        notificationUseCase.notifyNoticePost(post);
+
+        log.info("[NoticeNotification] sent for postId={}", post.getId());
+    }
+}

--- a/src/main/java/com/tavemakers/surf/domain/notification/service/NotificationUseCase.java
+++ b/src/main/java/com/tavemakers/surf/domain/notification/service/NotificationUseCase.java
@@ -1,0 +1,63 @@
+package com.tavemakers.surf.domain.notification.service;
+
+import com.tavemakers.surf.domain.member.entity.Member;
+import com.tavemakers.surf.domain.member.repository.MemberRepository;
+import com.tavemakers.surf.domain.notification.entity.Notification;
+import com.tavemakers.surf.domain.notification.entity.NotificationType;
+import com.tavemakers.surf.domain.notification.repository.NotificationRepository;
+import com.tavemakers.surf.domain.post.entity.Post;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class NotificationUseCase {
+
+    private final MemberRepository memberRepository;
+    private final NotificationCreateService notificationCreateService;
+
+
+    /**
+     * 공지 게시글 발행 시
+     * 이번 활동 기수(또는 활성 유저) 전체에게 알림 전송
+     */
+    @Transactional
+    public void notifyNoticePost(Post post) {
+
+        // 방어 로직 (이중 체크)
+        if (!post.getBoard().isNotice()) {
+            return;
+        }
+
+        // 1️⃣ 알림 대상 조회
+        List<Member> targets = memberRepository.findByActivityStatusTrue();
+
+        if (targets.isEmpty()) {
+            log.info("[NoticeNotification] no target members, postId={}", post.getId());
+            return;
+        }
+
+        // 2️⃣ Notification 엔티티 생성
+        for (Member member : targets) {
+            notificationCreateService.createAndSend(
+                    member.getId(),                    // 알림 받는 사람
+                    NotificationType.NOTICE,            // 공지 알림 타입
+                    Map.of(
+                            "boardId", post.getBoard().getId(),
+                            "postId", post.getId()
+                    )
+            );
+        }
+
+        log.info(
+                "[NoticeNotification] sent to {} members, postId={}",
+                targets.size(),
+                post.getId()
+        );
+    }
+}

--- a/src/main/java/com/tavemakers/surf/domain/notification/service/NotificationUseCase.java
+++ b/src/main/java/com/tavemakers/surf/domain/notification/service/NotificationUseCase.java
@@ -2,9 +2,7 @@ package com.tavemakers.surf.domain.notification.service;
 
 import com.tavemakers.surf.domain.member.entity.Member;
 import com.tavemakers.surf.domain.member.repository.MemberRepository;
-import com.tavemakers.surf.domain.notification.entity.Notification;
 import com.tavemakers.surf.domain.notification.entity.NotificationType;
-import com.tavemakers.surf.domain.notification.repository.NotificationRepository;
 import com.tavemakers.surf.domain.post.entity.Post;
 import java.util.List;
 import java.util.Map;
@@ -34,7 +32,7 @@ public class NotificationUseCase {
             return;
         }
 
-        // 1️⃣ 알림 대상 조회
+        // 1 알림 대상 조회
         List<Member> targets = memberRepository.findByActivityStatusTrue();
 
         if (targets.isEmpty()) {
@@ -42,7 +40,7 @@ public class NotificationUseCase {
             return;
         }
 
-        // 2️⃣ Notification 엔티티 생성
+        // 2 Notification 엔티티 생성
         for (Member member : targets) {
             notificationCreateService.createAndSend(
                     member.getId(),                    // 알림 받는 사람

--- a/src/main/java/com/tavemakers/surf/domain/post/entity/Post.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/entity/Post.java
@@ -161,4 +161,8 @@ public class Post extends BaseEntity {
     public void addScheduleId(Long scheduleId) {
         this.scheduleId = scheduleId;
     }
+
+    public void updateScheduleIdNull(){
+        this.scheduleId = null;
+    }
 }

--- a/src/main/java/com/tavemakers/surf/domain/post/entity/Post.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/entity/Post.java
@@ -78,6 +78,7 @@ public class Post extends BaseEntity {
     @Column(nullable = true)
     private Long scheduleId;
 
+
     public static Post of(PostCreateReqDTO req, Board board, BoardCategory category, Member member) {
         return Post.builder()
                 .title(req.title())
@@ -165,4 +166,5 @@ public class Post extends BaseEntity {
     public void updateScheduleIdNull(){
         this.scheduleId = null;
     }
+
 }

--- a/src/main/java/com/tavemakers/surf/domain/post/service/PostPublishedEvent.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/service/PostPublishedEvent.java
@@ -1,0 +1,10 @@
+package com.tavemakers.surf.domain.post.service;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class PostPublishedEvent {
+    private final Long postId;
+}

--- a/src/main/java/com/tavemakers/surf/domain/post/service/PostService.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/service/PostService.java
@@ -265,23 +265,6 @@ public class PostService {
                 .orElseThrow((PostNotFoundException::new));
     }
 
-    @Transactional
-    public void publish(Long postId) {
-        Post post = postRepository.findById(postId)
-                .orElseThrow(PostNotFoundException::new);
-
-        // 이미 발행된 글이면 스킵
-        if (!post.isReserved()) {
-            return;
-        }
-
-        post.publish();
-
-        eventPublisher.publishEvent(
-                new PostPublishedEvent(post.getId())
-        );
-    }
-
     private List<PostImageResDTO> getImageUrlList(Post post) {
         return imageGetService.getPostImageUrls(post.getId()).stream()
                 .map(PostImageResDTO::from)

--- a/src/main/java/com/tavemakers/surf/domain/post/service/SchedulePatchService.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/service/SchedulePatchService.java
@@ -19,7 +19,12 @@ public class SchedulePatchService {
 
     //일정 존재 여부 변경
     @Transactional
-    public void updateHasScheduleTrue(Post post, boolean hasSchedule) {
+    public void updateHasSchedule(Post post, boolean hasSchedule) {
         post.changeHasSchedule(hasSchedule);
+    }
+
+    @Transactional
+    public void updateScheduleIdNull(Post post) {
+        post.updateScheduleIdNull();
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/post/service/ScheduleUseCase.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/service/ScheduleUseCase.java
@@ -48,13 +48,15 @@ public class ScheduleUseCase {
         scheduleDeleteService.deleteSchedule(schedule);
     }
 
+    //일정 삭제 - 게시글과 매핑
     @Transactional
     public void deleteScheduleAtPost(Long postId, Long scheduleId) {
         Schedule schedule = scheduleGetService.getScheduleById(scheduleId);
         scheduleDeleteService.deleteSchedule(schedule);
 
         Post post = postGetService.getPost(postId);
-        schedulePatchService.updateHasScheduleTrue(post,false);
+        schedulePatchService.updateHasSchedule(post,false);
+        schedulePatchService.updateScheduleIdNull(post);
     }
 
     //게시글별 일정 조회

--- a/src/main/java/com/tavemakers/surf/domain/reservation/task/PostPublishRunner.java
+++ b/src/main/java/com/tavemakers/surf/domain/reservation/task/PostPublishRunner.java
@@ -3,11 +3,13 @@ package com.tavemakers.surf.domain.reservation.task;
 import com.tavemakers.surf.domain.post.entity.Post;
 import com.tavemakers.surf.domain.post.exception.PostAlreadyDeletedException;
 import com.tavemakers.surf.domain.post.service.PostGetService;
+import com.tavemakers.surf.domain.post.service.PostPublishedEvent;
 import com.tavemakers.surf.domain.reservation.entity.Reservation;
 import com.tavemakers.surf.domain.reservation.exception.ReservationCanceledException;
 import com.tavemakers.surf.domain.reservation.service.ReservationGetService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,6 +20,8 @@ public class PostPublishRunner {
 
     private final ReservationGetService reservationGetService;
     private final PostGetService postGetService;
+    private final ApplicationEventPublisher eventPublisher;
+
 
     @Transactional(noRollbackFor = PostAlreadyDeletedException.class)
     public void publishPost(Long reservationId) {
@@ -30,6 +34,11 @@ public class PostPublishRunner {
         log.info("예약 번호 {}번 예약 작업 수행", reservationId);
         post.publish();
         reservation.publish();
+
+        eventPublisher.publishEvent(
+                new PostPublishedEvent(post.getId())
+        );
+
     }
 
     private void cancelReservationIfPostDeleted(Post post, Reservation reservation) {


### PR DESCRIPTION
## 📄 작업 내용 요약

### 1. 공지사항 글 발행 시 활동 중인 유저에게 알림 발송

공지사항 게시글이 발행 될 때 활동 중인 유저들에게 일괄 알림을 발송하는 로직을 추가하였습니다.
우리 서비스에는 게시글에 예약 기능이 있기 떄문에, 예약 글일 경우에는 예약된 시간에 발행될 때 알림이 전송되게 로직을 구성하였습니다.

```
[예약글]
PostPublishRunner.run()
 └─ publish()
 └─ PostPublishedEvent

[즉시글]
createPost()
 └─ save()
 └─ PostPublishedEvent
```

### 2. 대댓글 알림 로직 수정

기존 : 대댓글 작성시 댓글 루트 작성자 + 게시글 작성자에게 알림
수정 : 대댓글 작성시 댓글 루트 작성자에게만 알림

### 3. 버그 수정
게시글 수정시 연동되어 있던 일정을 삭제하고 상세 조회하였을 때
ScheduleId가 null 처리 되지 않은 건 

## 📎 Issue 번호
<!-- closed #213  -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 공지글이 발행되면 활성 사용자들에게 알림이 대규모로 전송되는 알림 브로드캐스트 추가

* **버그 수정**
  * 루트 댓글 작성 시 게시물 작성자에게 불필요하게 전송되던 알림 제거

* **개선사항**
  * 게시물 예약·발행 흐름에 이벤트 기반 발행이 도입되어 발행 처리 신뢰성 향상
  * 일정 연결 해제 처리 개선 및 일정 관련 내부 상태 정리

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->