### PR TITLE
[FEAT] 게시글 반환 dto 필드 추가

### DIFF
--- a/src/main/java/com/tavemakers/surf/domain/post/dto/res/PostDetailResDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/dto/res/PostDetailResDTO.java
@@ -60,6 +60,9 @@ public record PostDetailResDTO(
         @Schema(description = "예약된 게시글 여부", example = "true")
         boolean isReserved,
 
+        @Schema(description = "게시글 예약 시간", example = "2023-12-01T10:00:00")
+        LocalDateTime reservedAt,
+
         @Schema(description = "게시글 조회수", example = "100")
         int viewCount,
 
@@ -75,6 +78,7 @@ public record PostDetailResDTO(
             boolean likedByMe,
             boolean isMine,
             List<PostImageResDTO> imageUrlList,
+            LocalDateTime reservedAt,
             int viewCount
             ) {
         return PostDetailResDTO.builder()
@@ -95,6 +99,7 @@ public record PostDetailResDTO(
                 .isMine(isMine)
                 .imageUrlList(imageUrlList)
                 .isReserved(post.isReserved())
+                .reservedAt(reservedAt)
                 .viewCount(viewCount)
                 .hasSchedule(post.getHasSchedule())
                 .scheduleId(post.getScheduleId())

--- a/src/main/java/com/tavemakers/surf/domain/post/dto/res/PostDetailResDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/dto/res/PostDetailResDTO.java
@@ -57,6 +57,9 @@ public record PostDetailResDTO(
         @Schema(description = "게시글 이미지 링크")
         List<PostImageResDTO> imageUrlList,
 
+        @Schema(description = "예약된 게시글 여부", example = "true")
+        boolean isReserved,
+
         @Schema(description = "게시글 조회수", example = "100")
         int viewCount,
 
@@ -91,6 +94,7 @@ public record PostDetailResDTO(
                 .profileImageUrl(post.getMember().getProfileImageUrl())
                 .isMine(isMine)
                 .imageUrlList(imageUrlList)
+                .isReserved(post.isReserved())
                 .viewCount(viewCount)
                 .hasSchedule(post.getHasSchedule())
                 .scheduleId(post.getScheduleId())

--- a/src/main/java/com/tavemakers/surf/domain/post/dto/res/PostResDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/dto/res/PostResDTO.java
@@ -52,6 +52,7 @@ public record PostResDTO(
         @Schema(description = "게시글 작성자 닉네임", example = "홍길동")
         String nickname,
 
+        @Schema(description = "예약된 게시글 여부", example = "true")
         boolean isReserved,
 
         @Schema(description = "게시글 조회수", example = "100")

--- a/src/main/java/com/tavemakers/surf/domain/post/entity/Post.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/entity/Post.java
@@ -133,6 +133,7 @@ public class Post extends BaseEntity {
 
     public void publish() {
         this.isReserved = false;
+        this.postedAt = LocalDateTime.now();
     }
 
     public void addThumbnailUrl(String originalUrl) {

--- a/src/main/java/com/tavemakers/surf/domain/post/service/PostService.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/service/PostService.java
@@ -41,6 +41,7 @@ import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import java.util.Comparator;
@@ -86,18 +87,20 @@ public class PostService {
         Post post = Post.of(req, board, category, member);
         Post saved = postRepository.save(post);
 
+        LocalDateTime reservedAt = null;
         if (req.isReserved()) {
             reservationUsecase.reservePost(saved.getId(), req.reservedAt());
+            reservedAt = req.reservedAt();
         }
 
+        List<PostImageResDTO> imageUrlResponseList = null;
         if (req.hasImage()) {
             List<PostImageCreateReqDTO> imageUrlList = req.imageUrlList();
             saved.addThumbnailUrl(findFirstImage(imageUrlList));
-            List<PostImageResDTO> imageUrlResponseList = imageSaveService.saveAll(saved, imageUrlList);
-            return PostDetailResDTO.of(saved, false, false, true, imageUrlResponseList, 0);
+            imageUrlResponseList = imageSaveService.saveAll(saved, imageUrlList);
         }
 
-        return PostDetailResDTO.of(saved, false, false,true,null, 0);
+        return PostDetailResDTO.of(saved, false, false,true,imageUrlResponseList, reservedAt,0);
     }
 
     @Transactional
@@ -109,7 +112,12 @@ public class PostService {
         boolean isMine = post.isOwner(memberId);
         List<PostImageResDTO> imageUrlList = getImageUrlList(post);
         int viewCount = viewCountService.increaseViewCount(post, memberId);
-        return PostDetailResDTO.of(post, scrappedByMe, likedByMe, isMine, imageUrlList, viewCount);
+        LocalDateTime reservedAt = null;
+        if (post.isReserved()) {
+            reservedAt = reservationUsecase.getReservedAt(postId);
+        }
+
+        return PostDetailResDTO.of(post, scrappedByMe, likedByMe, isMine, imageUrlList, reservedAt, viewCount);
     }
 
     @Transactional(readOnly = true)
@@ -217,6 +225,8 @@ public class PostService {
             reservationUsecase.updateReservationPost(post.getId(), req.reservedAt());
         }
 
+        LocalDateTime reservedAt = reservationUsecase.getReservedAt(postId);
+
         // 이미지 변경
         if (req.isImageChanged()) {
             deleteExistingImage(post);
@@ -224,16 +234,16 @@ public class PostService {
             if(changeImage.isEmpty()){
                 post.addThumbnailUrl(null);
                 // TODO Spring Event로 PostImageUrl 삭제 로직 분리.
-                return PostDetailResDTO.of(post, scrappedByMe, likedByMe, true, null, viewCount);
+                return PostDetailResDTO.of(post, scrappedByMe, likedByMe, true, null, reservedAt, viewCount);
             }
 
             post.addThumbnailUrl(findFirstImage(changeImage));
             List<PostImageResDTO> savedChangedImage = imageSaveService.saveAll(post, changeImage);
-            return PostDetailResDTO.of(post, scrappedByMe, likedByMe, true, savedChangedImage, viewCount);
+            return PostDetailResDTO.of(post, scrappedByMe, likedByMe, true, savedChangedImage, reservedAt, viewCount);
         }
 
         List<PostImageResDTO> imageDtoList = getImageUrlList(post);
-        return PostDetailResDTO.of(post, scrappedByMe, likedByMe, true, imageDtoList, viewCount);
+        return PostDetailResDTO.of(post, scrappedByMe, likedByMe, true, imageDtoList, reservedAt, viewCount);
     }
 
     private void deleteExistingImage(Post post) {

--- a/src/main/java/com/tavemakers/surf/domain/post/service/PostService.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/service/PostService.java
@@ -232,7 +232,10 @@ public class PostService {
             reservationUsecase.updateReservationPost(post.getId(), req.reservedAt());
         }
 
-        LocalDateTime reservedAt = reservationUsecase.getReservedAt(postId);
+        LocalDateTime reservedAt = null;
+        if (post.isReserved()) {
+            reservedAt = reservationUsecase.getReservedAt(postId);
+        }
 
         // 이미지 변경
         if (req.isImageChanged()) {

--- a/src/main/java/com/tavemakers/surf/domain/reservation/usecase/ReservationUsecase.java
+++ b/src/main/java/com/tavemakers/surf/domain/reservation/usecase/ReservationUsecase.java
@@ -29,6 +29,19 @@ public class ReservationUsecase {
         scheduleService.schedule(savedReservation.getId(), publishAt);
     }
 
+    @Transactional(readOnly = true)
+    public LocalDateTime getReservedAt(Long postId) {
+        Reservation existed = reservationGetService.findByPostIdAndStatus(postId);
+        if (existed == null) {
+            return null;
+        }
+
+        return LocalDateTime.ofInstant(
+                existed.getReservedAt(),
+                ZoneId.of("Asia/Seoul")
+        );
+    }
+
     @Transactional
     public void updateReservationPost(Long postId, LocalDateTime changedAt) {
         Reservation existed = reservationGetService.findByPostIdAndStatus(postId);


### PR DESCRIPTION
## 📄 작업 내용 요약
1. 예약된 게시글이 실제 작성될 때(post.publish가 호출 될 때), postedAt(작성 시간)을 실제 작성 시간으로 수정합니다.

2. 프론트엔드의 요청에 따라, 게시글 생성/수정/단건 조회에 사용되는 PostDetailResDTO에 예약글 여부/예약 시간(isReserved/reservedAt)을 추가합니다.

## 📎 Issue 번호
<!-- closed #218  -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 포스트 응답에 예약 여부(isReserved)와 예약 시각(reservedAt)이 포함됩니다.
  * 생성/조회/수정 흐름에서 reservedAt이 전달되어 상세 응답에 반영됩니다.
  * 목록용 DTO에도 예약 여부가 노출됩니다.
  * 포스트 발행 시 예약 상태가 자동으로 해제됩니다.
  * 예약된 게시글의 예약 시각을 조회하는 읽기 API(getReservedAt)가 추가되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->