### PR TITLE
[Hotfix] 카카오 로그인 리다이렉트 임시로 프론트 로컬 고정

### DIFF
--- a/src/main/java/com/tavemakers/surf/domain/member/controller/AuthController.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/controller/AuthController.java
@@ -140,20 +140,25 @@ public class AuthController {
     }
 
     /** 요청이 어디서 왔는지 확인하고 카카오 로그인 후에 리다이렉트할 프론트 주소를 결정 */
+//    private String determineRedirectUri(HttpServletRequest request) {
+//        String origin = request.getHeader("Origin");
+//        String host = request.getHeader("Host");
+//
+//        log.info("[AuthRedirect] origin={}, host={}", origin, host);
+//
+//        String base = origin != null ? origin : host;
+//
+//        if (base != null &&
+//                (base.contains("localhost") || base.contains("127.0.0.1"))) {
+//            return "http://localhost:3000/login/callback";
+//        }
+//
+//        return "https://www.tavesurf.site/login/callback"; // 운영 프론트 주소
+//    }
+
+    /** 현재는 로컬 환경에서만 사용 */
     private String determineRedirectUri(HttpServletRequest request) {
-        String origin = request.getHeader("Origin");
-        String host = request.getHeader("Host");
-
-        log.info("[AuthRedirect] origin={}, host={}", origin, host);
-
-        String base = origin != null ? origin : host;
-
-        if (base != null &&
-                (base.contains("localhost") || base.contains("127.0.0.1"))) {
-            return "http://localhost:3000/login/callback";
-        }
-
-        return "https://tavesurf.site/login/callback"; // 운영 프론트 주소
+        return "http://localhost:3000/login/callback";
     }
 
 }


### PR DESCRIPTION
## 📄 작업 내용 요약
- 카카오 로그인 리다이렉트 URI를 로컬 주소로 고정

## 📎 Issue 번호
closed #221 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 인증 리다이렉트 로직을 간소화했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->