### PR TITLE
[Feat] Track이 Generation의 오름차순으로 정렬

### DIFF
--- a/src/main/java/com/tavemakers/surf/domain/member/entity/Track.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/entity/Track.java
@@ -10,7 +10,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Track extends BaseEntity {
+public class Track extends BaseEntity implements Comparable<Track>{
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -56,6 +56,11 @@ public class Track extends BaseEntity {
     public void update(Integer generation, Part part) {
         if (generation != null) this.generation = generation;
         if (part != null) this.part = part;
+    }
+
+    @Override
+    public int compareTo(Track o) {
+        return this.generation.compareTo(o.getGeneration());
     }
 
 }

--- a/src/main/java/com/tavemakers/surf/domain/member/service/TrackGetService.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/service/TrackGetService.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -23,6 +24,13 @@ public class TrackGetService {
 
     public List<Track> getTrack(Long memberId) {
         return trackRepository.findByMemberId(memberId);
+    }
+
+    public List<Track> getTrackSortedByGeneration(Long memberId) {
+        return trackRepository.findByMemberId(memberId)
+                .stream()
+                .sorted()
+                .toList();
     }
 
     //트랙과 함께 모든 회원 반환

--- a/src/main/java/com/tavemakers/surf/domain/member/usecase/MemberUsecase.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/usecase/MemberUsecase.java
@@ -217,8 +217,10 @@ public class MemberUsecase {
     }
 
     private List<TrackResDTO> getMyTracks(Long memberId) {
-        return trackGetService.getTrack(memberId)
-                .stream().map(TrackResDTO::from).toList();
+        return trackGetService.getTrackSortedByGeneration(memberId)
+                .stream()
+                .map(TrackResDTO::from)
+                .toList();
     }
 
     public MemberSearchSliceResDTO searchMembers( int pageNum, int pageSize, Integer generation, String part, String keyword) {


### PR DESCRIPTION
## 📄 작업 내용 요약
- Track이 Generation의 오름차순으로 정렬

## Comparable
Track Entity를 정렬하기 위해 Comparable을 구현했습니다.

프론트 요청은 Generation을 기순으로 `오름차순`정렬이기 때문에 이를 위해 다음과 같이 구현합니다.

```java
    @Override
    public int compareTo(Track o) {
        return this.generation.compareTo(o.getGeneration());
    }
```

## 📎 Issue #225
<!-- closed #225 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 트랙을 세대별로 정렬하는 기능이 추가되었습니다.
* 사용자의 트랙 목록 조회 시 세대순으로 정렬되어 반환됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->