### PR TITLE
[Feat] Enum name 그대로 Dto에 반환

### DIFF
--- a/src/main/java/com/tavemakers/surf/domain/member/dto/response/TrackResDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/dto/response/TrackResDTO.java
@@ -16,7 +16,7 @@ public record TrackResDTO(
     public static TrackResDTO from(Track track) {
         return TrackResDTO.builder()
                 .generation(track.getGeneration())
-                .part(track.getPart().getDisplayName())
+                .part(track.getPart().name())
                 .build();
     }
 }


### PR DESCRIPTION
## 📄 작업 내용 요약
- Enum name 그대로 Dto에 반환

```java
    public static TrackResDTO from(Track track) {
        return TrackResDTO.builder()
                .generation(track.getGeneration())
                .part(track.getPart().getDisplayName()) // 수정 전
                .build();
    }
```

```java
    public static TrackResDTO from(Track track) {
        return TrackResDTO.builder()
                .generation(track.getGeneration())
                .part(track.getPart().name()) // 수정 후
                .build();
    }
```


## 📎 Issue 번호
<!-- closed #번호 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * Track 정보에서 Part 필드의 표시 방식을 변경했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->