### PR TITLE
[FEAT] 회원탈퇴 구현

### DIFF
--- a/src/main/java/com/tavemakers/surf/domain/comment/dto/res/CommentResDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/comment/dto/res/CommentResDTO.java
@@ -1,6 +1,8 @@
 package com.tavemakers.surf.domain.comment.dto.res;
 
 import com.tavemakers.surf.domain.comment.entity.Comment;
+import com.tavemakers.surf.domain.member.entity.Member;
+import com.tavemakers.surf.domain.member.entity.enums.MemberStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
@@ -48,10 +50,14 @@ public record CommentResDTO(
         List<MentionResDTO> mentions
 
 ) {
-    public static CommentResDTO from(Comment comment,
-                                     Long postId,
-                                     List<MentionResDTO> mentions,
-                                     Boolean liked) {
+    public static CommentResDTO from(
+            Comment comment,
+            Long postId,
+            List<MentionResDTO> mentions,
+            Boolean liked
+    ) {
+        Member writer = comment.getMember();
+
         return new CommentResDTO(
                 comment.getId(),
                 postId,
@@ -59,9 +65,9 @@ public record CommentResDTO(
                 comment.getParent() != null ? comment.getParent().getId() : null,
                 comment.getDepth(),
                 comment.getContent(),
-                comment.getMember().getId(),
-                comment.getMember().getName(),
-                comment.getMember().getProfileImageUrl(),
+                writer.getStatus() == MemberStatus.WITHDRAWN ? null : writer.getId(),
+                writer.getName(),
+                writer.getProfileImageUrl(),
                 comment.getLikeCount(),
                 liked,
                 comment.getCreatedAt(),

--- a/src/main/java/com/tavemakers/surf/domain/comment/service/CommentMentionService.java
+++ b/src/main/java/com/tavemakers/surf/domain/comment/service/CommentMentionService.java
@@ -5,6 +5,7 @@ import com.tavemakers.surf.domain.comment.entity.CommentMention;
 import com.tavemakers.surf.domain.comment.exception.CommentMentionSelfException;
 import com.tavemakers.surf.domain.comment.repository.CommentMentionRepository;
 import com.tavemakers.surf.domain.member.entity.Member;
+import com.tavemakers.surf.domain.member.entity.enums.MemberStatus;
 import com.tavemakers.surf.domain.member.repository.MemberRepository;
 import com.tavemakers.surf.domain.comment.dto.res.MentionResDTO;
 import com.tavemakers.surf.domain.comment.dto.res.MentionSearchResDTO;
@@ -78,7 +79,7 @@ public class CommentMentionService {
         String namePart = keyword.trim();
 
         // DB 조회 (정렬 없이)
-        List<Member> candidates = memberRepository.findMentionCandidates(namePart);
+        List<Member> candidates = memberRepository.findMentionCandidates(namePart, MemberStatus.WITHDRAWN);
 
         // 자바에서 정렬: 가장 최근 기수 → 오래된 순
         return candidates.stream()

--- a/src/main/java/com/tavemakers/surf/domain/comment/service/CommentMentionService.java
+++ b/src/main/java/com/tavemakers/surf/domain/comment/service/CommentMentionService.java
@@ -83,13 +83,6 @@ public class CommentMentionService {
 
         // 자바에서 정렬: 가장 최근 기수 → 오래된 순
         return candidates.stream()
-                .sorted(Comparator.comparing(
-                        (Member m) -> m.getTracks().stream()
-                                .map(track -> track.getGeneration())
-                                .max(Integer::compareTo) // track 중 최신 기수 기준
-                                .orElse(0),
-                        Comparator.reverseOrder()
-                ))
                 .limit(10)
                 .map(MentionSearchResDTO::from)
                 .toList();

--- a/src/main/java/com/tavemakers/surf/domain/home/service/HomeService.java
+++ b/src/main/java/com/tavemakers/surf/domain/home/service/HomeService.java
@@ -78,7 +78,7 @@ public class HomeService {
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("MM.dd");
 
         Optional<Schedule> next = scheduleRepository.findFirstByCategoryAndStartAtAfterOrderByStartAtAsc(
-                "정규행사",
+                "regular",
                 LocalDateTime.now()
         );
 

--- a/src/main/java/com/tavemakers/surf/domain/member/controller/MemberWithdrawController.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/controller/MemberWithdrawController.java
@@ -1,0 +1,32 @@
+package com.tavemakers.surf.domain.member.controller;
+
+import com.tavemakers.surf.domain.member.usecase.MemberUsecase;
+import com.tavemakers.surf.global.common.response.ApiResponse;
+import com.tavemakers.surf.global.jwt.JwtService;
+import com.tavemakers.surf.global.util.SecurityUtils;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "회원 탈퇴", description = "회원 탈퇴 API")
+@RestController
+@RequiredArgsConstructor
+public class MemberWithdrawController {
+
+    private final MemberUsecase memberUsecase;
+    private final JwtService jwtService;
+
+    @PostMapping("/v1/user/members/withdraw")
+    public ApiResponse<Void> withdraw(HttpServletResponse response) {
+        Long memberId = SecurityUtils.getCurrentMemberId();
+
+        memberUsecase.withdraw(memberId);
+
+        jwtService.clearRefreshTokenCookie(response);
+
+        return ApiResponse.response(HttpStatus.NO_CONTENT, "회원 탈퇴 완료", null);
+    }
+}

--- a/src/main/java/com/tavemakers/surf/domain/member/dto/response/MemberLikeListResDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/dto/response/MemberLikeListResDTO.java
@@ -1,6 +1,7 @@
 package com.tavemakers.surf.domain.member.dto.response;
 
 import com.tavemakers.surf.domain.member.entity.Member;
+import com.tavemakers.surf.domain.member.entity.enums.MemberStatus;
 import lombok.Builder;
 
 @Builder
@@ -11,7 +12,7 @@ public record MemberLikeListResDTO(
 ){
     public static MemberLikeListResDTO from(Member member) {
         return MemberLikeListResDTO.builder()
-                .id(member.getId())
+                .id(member.getStatus() == MemberStatus.WITHDRAWN ? null : member.getId())
                 .name(member.getName())
                 .profileImageUrl(member.getProfileImageUrl())
                 .build();

--- a/src/main/java/com/tavemakers/surf/domain/member/entity/Member.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/entity/Member.java
@@ -278,6 +278,7 @@ public class Member extends BaseEntity {
 
         this.name = "탈퇴한 회원";
         this.profileImageUrl = null;
+        this.password = null;
         this.phoneNumber = null;
         this.phoneNumberPublic = false;
         this.selfIntroduction = null;

--- a/src/main/java/com/tavemakers/surf/domain/member/entity/Member.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/entity/Member.java
@@ -256,10 +256,32 @@ public class Member extends BaseEntity {
 
     // 회원 탈퇴 처리
     public void withdraw() {
+        if (this.isDeleted || this.status == MemberStatus.WITHDRAWN) return;
+
         this.isDeleted = true;
         this.deletedAt = LocalDateTime.now();
         this.activityStatus = false;
         this.status = MemberStatus.WITHDRAWN;
+
+        anonymizeOnWithdraw();
+    }
+
+    private void anonymizeOnWithdraw() {
+        if (this.id == null) {
+            throw new IllegalStateException("withdraw는 영속화된 회원만 가능합니다.");
+        }
+
+        this.name = "탈퇴한 회원";
+        this.profileImageUrl = null;
+        this.phoneNumber = null;
+        this.phoneNumberPublic = false;
+        this.selfIntroduction = null;
+        this.link = null;
+        this.university = null;
+        this.graduateSchool = null;
+
+        this.email = "withdrawn_" + this.id + "_" + System.currentTimeMillis() + "@deleted.local";
+        this.kakaoId = -this.id;
     }
 }
 

--- a/src/main/java/com/tavemakers/surf/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/repository/MemberRepository.java
@@ -20,7 +20,7 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByEmail(String email);
 
     //현재 활동 중 + 특정 이름을 가진 회원 리스트 반환
-    List<Member> findByActivityStatusAndName(Boolean activityStatus, String name);
+    List<Member> findByActivityStatusAndNameAndStatusNot(Boolean activityStatus, String name, MemberStatus status);
 
     Optional<Member> findByEmailAndStatus(String email, MemberStatus status);
   
@@ -31,11 +31,14 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
         SELECT m
         FROM Member m
         LEFT JOIN m.tracks t
-        WHERE LOWER(m.name) LIKE LOWER(CONCAT('%', :keyword, '%'))
+        WHERE m.status <> :status
+              AND LOWER(m.name) LIKE LOWER(CONCAT('%', :keyword, '%'))
         GROUP BY m.id
         ORDER BY MAX(t.generation) DESC
     """)
-    List<Member> findMentionCandidates(@Param("keyword") String keyword);
+    List<Member> findMentionCandidates(
+            @Param("keyword") String keyword,
+            @Param("status") MemberStatus status);
 
-    List<Member> findByActivityStatusTrue();
+    List<Member> findByActivityStatusTrueAndStatusNot(MemberStatus status);
 }

--- a/src/main/java/com/tavemakers/surf/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/repository/MemberRepository.java
@@ -40,5 +40,13 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
             @Param("keyword") String keyword,
             @Param("status") MemberStatus status);
 
-    List<Member> findByActivityStatusTrueAndStatusNot(MemberStatus status);
+    @Query("""
+        select m.id
+        from Member m
+        where m.activityStatus = true
+          and m.status <> :status
+    """)
+    List<Long> findActiveMemberIdsExcludeStatus(@Param("status") MemberStatus status);
+
+    boolean existsByIdAndStatusNot(Long id, MemberStatus status);
 }

--- a/src/main/java/com/tavemakers/surf/domain/member/repository/MemberSearchRepository.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/repository/MemberSearchRepository.java
@@ -1,12 +1,12 @@
 package com.tavemakers.surf.domain.member.repository;
 
 import com.querydsl.core.BooleanBuilder;
-import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.tavemakers.surf.domain.member.entity.Member;
 import com.tavemakers.surf.domain.member.entity.QTrack;
+import com.tavemakers.surf.domain.member.entity.enums.MemberStatus;
 import com.tavemakers.surf.domain.member.entity.enums.Part;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -71,6 +71,8 @@ public class MemberSearchRepository {
 
     private BooleanBuilder createSearchBuilder(Integer generation, Part part, String keyword) {
         BooleanBuilder builder = new BooleanBuilder();
+
+        builder.and(member.status.ne(MemberStatus.WITHDRAWN));
 
         if (generation != null) {
             builder.and(member.tracks.any().generation.eq(generation));

--- a/src/main/java/com/tavemakers/surf/domain/member/service/MemberGetService.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/service/MemberGetService.java
@@ -36,7 +36,7 @@ public class MemberGetService {
 
     //회원 조회 - 이름 기반 - ID 리스트 반환
     public List<Member> getMemberByName(String name) {
-        return memberRepository.findByActivityStatusAndName(true, name);
+        return memberRepository.findByActivityStatusAndNameAndStatusNot(true, name, MemberStatus.WITHDRAWN);
     }
 
     public Void validateMember(Long memberId) {

--- a/src/main/java/com/tavemakers/surf/domain/member/service/MemberGetService.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/service/MemberGetService.java
@@ -52,5 +52,4 @@ public class MemberGetService {
     public Long countSearchingMembers(Integer generation, Part memberPart, String keyword) {
         return memberSearchRepository.countMembers(generation, memberPart, keyword);
     }
-
 }

--- a/src/main/java/com/tavemakers/surf/domain/member/service/MemberWithdrawService.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/service/MemberWithdrawService.java
@@ -1,0 +1,27 @@
+package com.tavemakers.surf.domain.member.service;
+
+import com.tavemakers.surf.domain.login.auth.service.RefreshTokenService;
+import com.tavemakers.surf.domain.member.entity.Member;
+import com.tavemakers.surf.domain.member.entity.enums.MemberStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MemberWithdrawService {
+
+    private final MemberGetService memberGetService;
+    private final RefreshTokenService refreshTokenService;
+
+    @Transactional
+    public void withdraw(Long memberId) {
+        Member member = memberGetService.getMember(memberId);
+
+        refreshTokenService.invalidateAll(memberId);
+
+        if (member.getStatus() != MemberStatus.WITHDRAWN) {
+            member.withdraw();
+        }
+    }
+}

--- a/src/main/java/com/tavemakers/surf/domain/member/usecase/MemberUsecase.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/usecase/MemberUsecase.java
@@ -1,7 +1,5 @@
 package com.tavemakers.surf.domain.member.usecase;
 
-import com.tavemakers.surf.domain.member.dto.request.CareerCreateReqDTO;
-import com.tavemakers.surf.domain.member.dto.request.CareerUpdateReqDTO;
 import com.tavemakers.surf.domain.member.dto.request.MemberSignupReqDTO;
 import com.tavemakers.surf.domain.member.dto.response.*;
 import com.tavemakers.surf.domain.member.dto.request.ProfileUpdateReqDTO;
@@ -18,7 +16,6 @@ import com.tavemakers.surf.domain.score.service.PersonalScoreGetService;
 import com.tavemakers.surf.global.logging.LogEvent;
 import com.tavemakers.surf.global.logging.LogParam;
 import com.tavemakers.surf.global.util.SecurityUtils;
-import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationContext;

--- a/src/main/java/com/tavemakers/surf/domain/member/usecase/MemberUsecase.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/usecase/MemberUsecase.java
@@ -18,6 +18,7 @@ import com.tavemakers.surf.domain.score.service.PersonalScoreGetService;
 import com.tavemakers.surf.global.logging.LogEvent;
 import com.tavemakers.surf.global.logging.LogParam;
 import com.tavemakers.surf.global.util.SecurityUtils;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationContext;
@@ -47,6 +48,7 @@ public class MemberUsecase {
     private final CareerGetService careerGetService;
     private final MemberPatchService memberPatchService;
     private final MemberService memberService;
+    private final MemberWithdrawService memberWithdrawService;
     private final ApplicationContext context;
 
     /** 마이페이지 + 프로필 조회 */
@@ -209,6 +211,11 @@ public class MemberUsecase {
             String errorReason
     ) {
         throw new RuntimeException(errorReason);
+    }
+
+    @Transactional
+    public void withdraw(Long memberId) {
+        memberWithdrawService.withdraw(memberId);
     }
 
     private List<CareerResDTO> getMyCareers(Long memberId) {

--- a/src/main/java/com/tavemakers/surf/domain/notification/controller/DeviceTokenPostController.java
+++ b/src/main/java/com/tavemakers/surf/domain/notification/controller/DeviceTokenPostController.java
@@ -1,7 +1,6 @@
 package com.tavemakers.surf.domain.notification.controller;
 
 import static com.tavemakers.surf.domain.notification.controller.ResponseMessage.DEVICE_TOKEN_SUCCESS;
-import static com.tavemakers.surf.domain.notification.controller.ResponseMessage.FCM_TEST_SUCCESS;
 
 import com.tavemakers.surf.domain.member.entity.CustomUserDetails;
 import com.tavemakers.surf.domain.notification.dto.req.DeviceTokenReqDTO;
@@ -12,7 +11,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 

--- a/src/main/java/com/tavemakers/surf/domain/notification/service/NotificationCreateService.java
+++ b/src/main/java/com/tavemakers/surf/domain/notification/service/NotificationCreateService.java
@@ -1,6 +1,8 @@
 package com.tavemakers.surf.domain.notification.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tavemakers.surf.domain.member.entity.enums.MemberStatus;
+import com.tavemakers.surf.domain.member.repository.MemberRepository;
 import com.tavemakers.surf.domain.notification.entity.Notification;
 import com.tavemakers.surf.domain.notification.entity.NotificationType;
 import com.tavemakers.surf.domain.notification.event.NotificationCreatedEvent;
@@ -18,6 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class NotificationCreateService {
 
     private final NotificationRepository notificationRepository;
+    private final MemberRepository memberRepository;
     private final ObjectMapper objectMapper;
     private final ApplicationEventPublisher eventPublisher;
 
@@ -48,6 +51,10 @@ public class NotificationCreateService {
             NotificationType type,
             Map<String, Object> payload
     ) {
+        boolean activeReceiver =
+                memberRepository.existsByIdAndStatusNot(receiverId, MemberStatus.WITHDRAWN);
+        if (!activeReceiver) return;
+
         Notification notification = create(receiverId, type, payload);
 
         eventPublisher.publishEvent(

--- a/src/main/java/com/tavemakers/surf/domain/notification/service/NotificationUseCase.java
+++ b/src/main/java/com/tavemakers/surf/domain/notification/service/NotificationUseCase.java
@@ -34,17 +34,17 @@ public class NotificationUseCase {
         }
 
         // 1 알림 대상 조회
-        List<Member> targets = memberRepository.findByActivityStatusTrueAndStatusNot(MemberStatus.WITHDRAWN);
+        List<Long> targetIds = memberRepository.findActiveMemberIdsExcludeStatus(MemberStatus.WITHDRAWN);
 
-        if (targets.isEmpty()) {
+        if (targetIds.isEmpty()) {
             log.info("[NoticeNotification] no target members, postId={}", post.getId());
             return;
         }
 
         // 2 Notification 엔티티 생성
-        for (Member member : targets) {
+        for (Long memberId : targetIds) {
             notificationCreateService.createAndSend(
-                    member.getId(),                    // 알림 받는 사람
+                    memberId,                   // 알림 받는 사람
                     NotificationType.NOTICE,            // 공지 알림 타입
                     Map.of(
                             "boardId", post.getBoard().getId(),
@@ -55,7 +55,7 @@ public class NotificationUseCase {
 
         log.info(
                 "[NoticeNotification] sent to {} members, postId={}",
-                targets.size(),
+                targetIds.size(),
                 post.getId()
         );
     }

--- a/src/main/java/com/tavemakers/surf/domain/notification/service/NotificationUseCase.java
+++ b/src/main/java/com/tavemakers/surf/domain/notification/service/NotificationUseCase.java
@@ -1,6 +1,7 @@
 package com.tavemakers.surf.domain.notification.service;
 
 import com.tavemakers.surf.domain.member.entity.Member;
+import com.tavemakers.surf.domain.member.entity.enums.MemberStatus;
 import com.tavemakers.surf.domain.member.repository.MemberRepository;
 import com.tavemakers.surf.domain.notification.entity.NotificationType;
 import com.tavemakers.surf.domain.post.entity.Post;
@@ -33,7 +34,7 @@ public class NotificationUseCase {
         }
 
         // 1 알림 대상 조회
-        List<Member> targets = memberRepository.findByActivityStatusTrue();
+        List<Member> targets = memberRepository.findByActivityStatusTrueAndStatusNot(MemberStatus.WITHDRAWN);
 
         if (targets.isEmpty()) {
             log.info("[NoticeNotification] no target members, postId={}", post.getId());

--- a/src/main/java/com/tavemakers/surf/domain/post/controller/PostController.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/controller/PostController.java
@@ -6,7 +6,6 @@ import com.tavemakers.surf.domain.post.dto.res.PostDetailResDTO;
 import com.tavemakers.surf.domain.post.dto.res.PostResDTO;
 import com.tavemakers.surf.domain.post.service.PostService;
 import com.tavemakers.surf.global.common.response.ApiResponse;
-import com.tavemakers.surf.global.logging.LogEvent;
 import com.tavemakers.surf.global.util.SecurityUtils;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;

--- a/src/main/java/com/tavemakers/surf/domain/post/dto/res/PostDetailResDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/dto/res/PostDetailResDTO.java
@@ -1,5 +1,7 @@
 package com.tavemakers.surf.domain.post.dto.res;
 
+import com.tavemakers.surf.domain.member.entity.Member;
+import com.tavemakers.surf.domain.member.entity.enums.MemberStatus;
 import com.tavemakers.surf.domain.post.entity.Post;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
@@ -45,6 +47,9 @@ public record PostDetailResDTO(
         @Schema(description = "게시글 댓글 수", example = "0")
         long commentCount,
 
+        @Schema(description = "게시글 작성자 회원 ID (탈퇴 회원이면 null)", example = "7")
+        Long memberId,
+
         @Schema(description = "게시글 작성자 닉네임", example = "홍길동")
         String nickname,
 
@@ -80,29 +85,32 @@ public record PostDetailResDTO(
             List<PostImageResDTO> imageUrlList,
             LocalDateTime reservedAt,
             int viewCount
-            ) {
-        return PostDetailResDTO.builder()
-                .postId(post.getId())
-                .title(post.getTitle())
-                .content(post.getContent())
-                .pinned(post.isPinned())
-                .postedAt(post.getPostedAt())
-                .boardId(post.getBoard().getId())
-                .categoryId(post.getCategory().getId())
-                .scrappedByMe(scrappedByMe)
-                .scrapCount(post.getScrapCount())
-                .likedByMe(likedByMe)
-                .likeCount(post.getLikeCount())
-                .commentCount(post.getCommentCount())
-                .nickname(post.getMember().getName())
-                .profileImageUrl(post.getMember().getProfileImageUrl())
-                .isMine(isMine)
-                .imageUrlList(imageUrlList)
-                .isReserved(post.isReserved())
-                .reservedAt(reservedAt)
-                .viewCount(viewCount)
-                .hasSchedule(post.getHasSchedule())
-                .scheduleId(post.getScheduleId())
-                .build();
+    ){
+            Member writer = post.getMember();
+
+            return PostDetailResDTO.builder()
+                    .postId(post.getId())
+                    .title(post.getTitle())
+                    .content(post.getContent())
+                    .pinned(post.isPinned())
+                    .postedAt(post.getPostedAt())
+                    .boardId(post.getBoard().getId())
+                    .categoryId(post.getCategory().getId())
+                    .scrappedByMe(scrappedByMe)
+                    .scrapCount(post.getScrapCount())
+                    .likedByMe(likedByMe)
+                    .likeCount(post.getLikeCount())
+                    .commentCount(post.getCommentCount())
+                    .memberId(writer.getStatus() == MemberStatus.WITHDRAWN ? null : writer.getId())
+                    .nickname(writer.getName())
+                    .profileImageUrl(writer.getProfileImageUrl())
+                    .isMine(isMine)
+                    .imageUrlList(imageUrlList)
+                    .isReserved(post.isReserved())
+                    .reservedAt(reservedAt)
+                    .viewCount(viewCount)
+                    .hasSchedule(post.getHasSchedule())
+                    .scheduleId(post.getScheduleId())
+                    .build();
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/post/entity/Post.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/entity/Post.java
@@ -2,11 +2,9 @@ package com.tavemakers.surf.domain.post.entity;
 
 import com.tavemakers.surf.domain.board.entity.Board;
 import com.tavemakers.surf.domain.board.entity.BoardCategory;
-import com.tavemakers.surf.domain.comment.entity.Comment;
 import com.tavemakers.surf.domain.member.entity.Member;
 import com.tavemakers.surf.domain.post.dto.req.PostCreateReqDTO;
 import com.tavemakers.surf.domain.post.dto.req.PostUpdateReqDTO;
-import com.tavemakers.surf.domain.scrap.entity.Scrap;
 import com.tavemakers.surf.global.common.entity.BaseEntity;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
@@ -16,8 +14,6 @@ import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
 
 @Entity
 @Getter

--- a/src/main/java/com/tavemakers/surf/domain/post/service/ScheduleGetService.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/service/ScheduleGetService.java
@@ -45,7 +45,7 @@ public class ScheduleGetService {
         LocalDateTime startOfMonth = yearMonth.atDay(1).atStartOfDay();
         LocalDateTime endOfMonth = yearMonth.atEndOfMonth().atTime(23, 59, 59);
 
-        List<String> categories = List.of("정규행사", "기타일정");
+        List<String> categories = List.of("regular", "other");
 
         if(Objects.equals(memberRole, MemberRole.MEMBER.toString())) {
             return scheduleRepository.findByStartAtBetweenAndCategoryIn(startOfMonth, endOfMonth,categories);

--- a/src/main/java/com/tavemakers/surf/global/config/SwaggerConfig.java
+++ b/src/main/java/com/tavemakers/surf/global/config/SwaggerConfig.java
@@ -5,7 +5,6 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.servers.Server;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
-import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;


### PR DESCRIPTION
## 📄 작업 내용 요약

회원탈퇴 기능 구현하였습니다.
탈퇴 회원이 서비스에서 조회/멘션/알림/프로필 상세페이지 접근 대상에서 제외되도록 구현합니다.

탈퇴 시 데이터를 물리 삭제하지 않고 익명화 + memberStatus 변경(WITHDRAWN) 방식으로 처리하여
게시글/댓글 등의 콘텐츠 무결성을 유지하면서도 개인정보 노출을 방지합니다.

**주요 변경 사항**
1. 회원 탈퇴 처리
• Member.withdraw() 도메인 메서드 추가
• status = WITHDRAWN
• activityStatus = false
• isDeleted = true
• 개인정보 익명화 (이름, 이미지, 연락처, 이메일 등)
• RefreshToken 전체 무효화
• SecurityContext 초기화

-> 탈퇴 즉시 재인증/재접근 불가

2. 게시글 / 댓글 / 좋아요 목록에서 탈퇴 회원 처리
• 작성자 정보 응답 DTO에 memberId를 탈퇴 시 null로 반환
• nickname / profileImageUrl은 익명화된 값 그대로 유지
• 프론트에서 memberId == null 기준으로 프로필 클릭 차단 가능

 -> 프론트 수정 최소화 + API 호환성 유지

3. 멘션 기능에서 탈퇴 회원 제외
• 멘션 후보 조회 쿼리에서 MemberStatus.WITHDRAWN 제외
• 서비스 레벨에서도 동일 조건 적용

-> 탈퇴 회원을 멘션/자동완성 대상으로 노출하지 않음

4. 알림(Notification) 대상에서 탈퇴 회원 제외
• 알림 대상 조회 시 WITHDRAWN 회원 제외
• NotificationCreateService.createAndSend()에서 최종 방어 로직 추가

-> 탈퇴 회원에게 알림 생성/전송 방지

5. 회원 검색 / 목록 조회 정책 정리
• QueryDSL 기반 회원 검색 시 WITHDRAWN 제외
• Repository / Service 계층에서 동일한 정책 유지

## 📎 Issue 번호
<!-- closed #74  -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 회원 탈퇴 API 추가 — 탈퇴 시 계정 익명화 및 세션·토큰 정리로 처리됩니다.

* **개선사항**
  * 탈퇴한 회원은 검색·멘션·좋아요 목록·알림 대상에서 자동 제외됩니다.
  * 게시물·댓글에서 탈퇴 회원의 식별 정보는 노출되지 않습니다.
  * 대량 알림 처리와 알림 페이로드에 게시물 식별자(postId) 포함이 개선되었습니다.

* **버그 수정**
  * 인증 흐름을 강화해 탈퇴 계정 접근을 차단합니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->