### PR TITLE
[Feat] Admin Page 로그인 기능

### DIFF
--- a/src/main/java/com/tavemakers/surf/domain/member/controller/AdminController.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/controller/AdminController.java
@@ -1,5 +1,7 @@
 package com.tavemakers.surf.domain.member.controller;
 
+import com.tavemakers.surf.domain.member.dto.request.AdminPageLoginReqDto;
+import com.tavemakers.surf.domain.member.dto.request.PasswordReqDto;
 import com.tavemakers.surf.domain.member.dto.request.RoleChangeRequestDto;
 import com.tavemakers.surf.domain.member.usecase.MemberAdminUsecase;
 import io.swagger.v3.oas.annotations.Operation;
@@ -8,8 +10,10 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
+
+import static com.tavemakers.surf.domain.member.controller.ResponseMessage.ADMIN_PAGE_LOGIN_SUCCESS;
+import static com.tavemakers.surf.domain.member.controller.ResponseMessage.MANAGER_PASSWORD_SET_UP_SUCCESS;
 
 @Tag(name = "관리자", description = "관리자용 API")
 @RestController
@@ -28,4 +32,12 @@ public class AdminController {
         memberAdminUsecase.changeRole(memberId, request.role());
         return ApiResponse.response(HttpStatus.OK, "회원 역할이 성공적으로 변경되었습니다.",null);
     }
+
+    @Operation(summary = "비밀번호 설정", description = "관리자의 비밀번호를 설정합니다.")
+    @PatchMapping("/v1/manager/password")
+    public ApiResponse<Void> setUpPassword(@RequestBody PasswordReqDto dto) {
+        memberAdminUsecase.setUpPassword(dto);
+        return ApiResponse.response(HttpStatus.OK, MANAGER_PASSWORD_SET_UP_SUCCESS.getMessage(),null);
+    }
+
 }

--- a/src/main/java/com/tavemakers/surf/domain/member/controller/AdminController.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/controller/AdminController.java
@@ -3,10 +3,12 @@ package com.tavemakers.surf.domain.member.controller;
 import com.tavemakers.surf.domain.member.dto.request.AdminPageLoginReqDto;
 import com.tavemakers.surf.domain.member.dto.request.PasswordReqDto;
 import com.tavemakers.surf.domain.member.dto.request.RoleChangeRequestDto;
+import com.tavemakers.surf.domain.member.dto.response.AdminPageLoginResDto;
 import com.tavemakers.surf.domain.member.usecase.MemberAdminUsecase;
 import io.swagger.v3.oas.annotations.Operation;
 import com.tavemakers.surf.global.common.response.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -38,6 +40,16 @@ public class AdminController {
     public ApiResponse<Void> setUpPassword(@RequestBody PasswordReqDto dto) {
         memberAdminUsecase.setUpPassword(dto);
         return ApiResponse.response(HttpStatus.OK, MANAGER_PASSWORD_SET_UP_SUCCESS.getMessage(),null);
+    }
+
+    @Operation(summary = "관리자 페이지 로그인", description = "관리자 페이지에 로그인합니다.")
+    @PostMapping("/v1/manager/sign-in")
+    public ApiResponse<AdminPageLoginResDto> loginAdminPage(
+            @RequestBody AdminPageLoginReqDto dto,
+            HttpServletResponse response
+    ) {
+        AdminPageLoginResDto data = memberAdminUsecase.loginAdminHomePage(dto, response);
+        return ApiResponse.response(HttpStatus.OK, ADMIN_PAGE_LOGIN_SUCCESS.getMessage(),data);
     }
 
 }

--- a/src/main/java/com/tavemakers/surf/domain/member/controller/ResponseMessage.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/controller/ResponseMessage.java
@@ -9,6 +9,7 @@ public enum ResponseMessage {
 
     // ADMIN
     MANAGER_PASSWORD_SET_UP_SUCCESS("[비밀번호 설정]을 완료했습니다."),
+    ADMIN_PAGE_LOGIN_SUCCESS("[관리자 페이지]에 성공적으로 로그인했습니다."),
 
     //회원가입 온보딩 확인 여부 체크
     MEMBER_ONBOARDING_STATUS_CHECK_SUCCESS("[회원]의 추가 회원가입 정보 입력 필요 여부를 확인했습니다."),

--- a/src/main/java/com/tavemakers/surf/domain/member/controller/ResponseMessage.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/controller/ResponseMessage.java
@@ -7,6 +7,9 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ResponseMessage {
 
+    // ADMIN
+    MANAGER_PASSWORD_SET_UP_SUCCESS("[비밀번호 설정]을 완료했습니다."),
+
     //회원가입 온보딩 확인 여부 체크
     MEMBER_ONBOARDING_STATUS_CHECK_SUCCESS("[회원]의 추가 회원가입 정보 입력 필요 여부를 확인했습니다."),
 

--- a/src/main/java/com/tavemakers/surf/domain/member/dto/request/AdminPageLoginReqDto.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/dto/request/AdminPageLoginReqDto.java
@@ -1,0 +1,7 @@
+package com.tavemakers.surf.domain.member.dto.request;
+
+public record AdminPageLoginReqDto(
+        String email,
+        String password
+) {
+}

--- a/src/main/java/com/tavemakers/surf/domain/member/dto/request/PasswordReqDto.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/dto/request/PasswordReqDto.java
@@ -1,0 +1,6 @@
+package com.tavemakers.surf.domain.member.dto.request;
+
+public record PasswordReqDto(
+        String password
+) {
+}

--- a/src/main/java/com/tavemakers/surf/domain/member/dto/response/AdminPageLoginResDto.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/dto/response/AdminPageLoginResDto.java
@@ -1,0 +1,19 @@
+package com.tavemakers.surf.domain.member.dto.response;
+
+import com.tavemakers.surf.domain.member.entity.Member;
+import lombok.Builder;
+
+@Builder
+public record AdminPageLoginResDto(
+        String accessToken,
+        String username,
+        String role
+) {
+    public static AdminPageLoginResDto of(final String accessToken, Member member) {
+        return AdminPageLoginResDto.builder()
+                .accessToken(accessToken)
+                .username(member.getName())
+                .role(member.getRole().name())
+                .build();
+    }
+}

--- a/src/main/java/com/tavemakers/surf/domain/member/entity/Member.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/entity/Member.java
@@ -2,6 +2,8 @@ package com.tavemakers.surf.domain.member.entity;
 
 import com.tavemakers.surf.domain.login.kakao.dto.KakaoUserInfoDto;
 import com.tavemakers.surf.domain.member.dto.request.ProfileUpdateReqDTO;
+import com.tavemakers.surf.domain.member.exception.MisMatchPasswordException;
+import com.tavemakers.surf.domain.member.exception.PasswordNotSettingException;
 import com.tavemakers.surf.global.common.entity.BaseEntity;
 import com.tavemakers.surf.domain.member.dto.request.MemberSignupReqDTO;
 import com.tavemakers.surf.domain.member.entity.enums.MemberType;
@@ -52,6 +54,9 @@ public class Member extends BaseEntity {
 
     @Column(nullable = false, unique = true) // 이메일은 고유해야 함
     private String email;
+
+    @Embedded
+    private Password password;
 
     private String phoneNumber;
 
@@ -261,5 +266,20 @@ public class Member extends BaseEntity {
         this.activityStatus = false;
         this.status = MemberStatus.WITHDRAWN;
     }
+
+    public void updatePassword(String password) {
+        this.password = Password.from(password);
+    }
+
+    public void checkPassword(String password) {
+        try {
+            this.password.validateMatches(password);
+        } catch (NullPointerException e) {
+            throw new PasswordNotSettingException();
+        } catch (MisMatchPasswordException e) {
+            throw new MisMatchPasswordException();
+        }
+    }
+
 }
 

--- a/src/main/java/com/tavemakers/surf/domain/member/entity/Password.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/entity/Password.java
@@ -1,0 +1,55 @@
+package com.tavemakers.surf.domain.member.entity;
+
+import com.tavemakers.surf.domain.member.exception.ErrorMessage;
+import com.tavemakers.surf.domain.member.exception.MisMatchPasswordException;
+import com.tavemakers.surf.domain.member.exception.PasswordEncryptionException;
+import com.tavemakers.surf.global.common.encoder.HexEncoder;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+@Getter
+@EqualsAndHashCode
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Embeddable
+public class Password {
+
+    @Column(name = "password")
+    private final String value;
+
+    protected Password() {
+        this.value = null;
+    }
+
+    public static Password from(String password) {
+        return new Password(encrypt(password));
+    }
+
+    private static String encrypt(String password) {
+        try {
+            final String algorithm = "SHA-256";
+            MessageDigest md = MessageDigest.getInstance(algorithm);
+            byte[] bytes = password.getBytes();
+            byte[] digest = md.digest(bytes);
+            return HexEncoder.convertHex(digest);
+        } catch (NoSuchAlgorithmException e) {
+            throw new PasswordEncryptionException();
+        }
+    }
+
+    public void validateMatches(String password) {
+        if (isNotMatches(password)) {
+            throw new MisMatchPasswordException();
+        }
+    }
+
+    private boolean isNotMatches(String password) {
+        return !encrypt(password).equals(this.value);
+    }
+}

--- a/src/main/java/com/tavemakers/surf/domain/member/exception/AdminPageRoleException.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/exception/AdminPageRoleException.java
@@ -1,0 +1,11 @@
+package com.tavemakers.surf.domain.member.exception;
+
+import com.tavemakers.surf.global.common.exception.BaseException;
+
+import static com.tavemakers.surf.domain.member.exception.ErrorMessage.ADMIN_PAGE_ROLE_EXCEPTION;
+
+public class AdminPageRoleException extends BaseException {
+    public AdminPageRoleException() {
+        super(ADMIN_PAGE_ROLE_EXCEPTION.getStatus(), ADMIN_PAGE_ROLE_EXCEPTION.getMessage());
+    }
+}

--- a/src/main/java/com/tavemakers/surf/domain/member/exception/ErrorMessage.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/exception/ErrorMessage.java
@@ -12,7 +12,12 @@ public enum ErrorMessage {
     MEMBER_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 존재하는 [회원]입니다."),
     INVALID_MEMBER_INFO(HttpStatus.BAD_REQUEST, "유효하지 않은 [회원 정보]입니다."),
     TRACK_NOT_FOUND(HttpStatus.NOT_FOUND, "회원의 [트랙]이 존재하지 않습니다."),
-    CAREER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않은 [경력]입니다.");
+    CAREER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않은 [경력]입니다."),
+
+    PASSWORD_ENCRYPTION_FAILED(HttpStatus.BAD_REQUEST ,"비밀번호 암호화에 실패했습니다."),
+    PASSWORD_NOT_SETTING(HttpStatus.BAD_REQUEST, "비밀번호가 설정되지 않았습니다."),
+    MIS_MATCH_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
+    ;
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/tavemakers/surf/domain/member/exception/ErrorMessage.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/exception/ErrorMessage.java
@@ -17,6 +17,7 @@ public enum ErrorMessage {
     PASSWORD_ENCRYPTION_FAILED(HttpStatus.BAD_REQUEST ,"비밀번호 암호화에 실패했습니다."),
     PASSWORD_NOT_SETTING(HttpStatus.BAD_REQUEST, "비밀번호가 설정되지 않았습니다."),
     MIS_MATCH_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
+    ADMIN_PAGE_ROLE_EXCEPTION(HttpStatus.BAD_REQUEST, "관리자만 접근 가능합니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/tavemakers/surf/domain/member/exception/MisMatchPasswordException.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/exception/MisMatchPasswordException.java
@@ -1,0 +1,11 @@
+package com.tavemakers.surf.domain.member.exception;
+
+import com.tavemakers.surf.global.common.exception.BaseException;
+
+import static com.tavemakers.surf.domain.member.exception.ErrorMessage.MIS_MATCH_PASSWORD;
+
+public class MisMatchPasswordException extends BaseException {
+    public MisMatchPasswordException() {
+        super(MIS_MATCH_PASSWORD.getStatus(), MIS_MATCH_PASSWORD.getMessage());
+    }
+}

--- a/src/main/java/com/tavemakers/surf/domain/member/exception/PasswordEncryptionException.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/exception/PasswordEncryptionException.java
@@ -1,0 +1,12 @@
+package com.tavemakers.surf.domain.member.exception;
+
+import com.tavemakers.surf.global.common.exception.BaseException;
+
+import static com.tavemakers.surf.domain.member.exception.ErrorMessage.PASSWORD_ENCRYPTION_FAILED;
+
+public class PasswordEncryptionException extends BaseException {
+    public PasswordEncryptionException() {
+        super(PASSWORD_ENCRYPTION_FAILED.getStatus(), PASSWORD_ENCRYPTION_FAILED.getMessage());
+
+    }
+}

--- a/src/main/java/com/tavemakers/surf/domain/member/exception/PasswordNotSettingException.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/exception/PasswordNotSettingException.java
@@ -1,0 +1,11 @@
+package com.tavemakers.surf.domain.member.exception;
+
+import com.tavemakers.surf.global.common.exception.BaseException;
+
+import static com.tavemakers.surf.domain.member.exception.ErrorMessage.PASSWORD_NOT_SETTING;
+
+public class PasswordNotSettingException extends BaseException {
+    public PasswordNotSettingException() {
+        super(PASSWORD_NOT_SETTING.getStatus(), PASSWORD_NOT_SETTING.getMessage());
+    }
+}

--- a/src/main/java/com/tavemakers/surf/domain/member/service/MemberGetService.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/service/MemberGetService.java
@@ -34,6 +34,11 @@ public class MemberGetService {
                 .orElseThrow(MemberNotFoundException::new);
     }
 
+    public Member getMemberByEmail(String email) {
+        return memberRepository.findByEmail(email)
+                .orElseThrow(MemberNotFoundException::new);
+    }
+
     //회원 조회 - 이름 기반 - ID 리스트 반환
     public List<Member> getMemberByName(String name) {
         return memberRepository.findByActivityStatusAndName(true, name);

--- a/src/main/java/com/tavemakers/surf/domain/member/usecase/MemberAdminUsecase.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/usecase/MemberAdminUsecase.java
@@ -1,14 +1,19 @@
 package com.tavemakers.surf.domain.member.usecase;
 
+import com.tavemakers.surf.domain.member.dto.request.AdminPageLoginReqDto;
+import com.tavemakers.surf.domain.member.dto.request.PasswordReqDto;
 import com.tavemakers.surf.domain.member.entity.Member;
+import com.tavemakers.surf.domain.member.entity.Password;
 import com.tavemakers.surf.domain.member.entity.enums.MemberRole;
 import com.tavemakers.surf.domain.member.entity.enums.MemberStatus;
 import com.tavemakers.surf.domain.member.service.MemberGetService;
 import com.tavemakers.surf.domain.member.service.MemberPatchService;
 import com.tavemakers.surf.domain.member.service.MemberService;
 import com.tavemakers.surf.domain.score.service.PersonalScoreSaveService;
+import com.tavemakers.surf.global.jwt.JwtService;
 import com.tavemakers.surf.global.logging.LogEvent;
 import com.tavemakers.surf.global.logging.LogParam;
+import com.tavemakers.surf.global.util.SecurityUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -23,6 +28,7 @@ public class MemberAdminUsecase {
     private final MemberGetService memberGetService;
     private final MemberService memberService;
     private final PersonalScoreSaveService personalScoreSaveService;
+    private final JwtService jwtService;
 
     @Transactional
     public void changeRole (Long memberId, MemberRole role) {
@@ -50,4 +56,11 @@ public class MemberAdminUsecase {
         Member member = memberGetService.getMemberByStatus(memberId, MemberStatus.WAITING);
         memberService.rejectMember(member);
     }
+
+    @Transactional
+    public void setUpPassword(PasswordReqDto dto) {
+        Member member = memberGetService.getMember(SecurityUtils.getCurrentMemberId());
+        member.updatePassword(dto.password());
+    }
+
 }

--- a/src/main/java/com/tavemakers/surf/domain/member/usecase/MemberAdminUsecase.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/usecase/MemberAdminUsecase.java
@@ -1,11 +1,14 @@
 package com.tavemakers.surf.domain.member.usecase;
 
+import com.tavemakers.surf.domain.login.auth.service.RefreshTokenService;
 import com.tavemakers.surf.domain.member.dto.request.AdminPageLoginReqDto;
 import com.tavemakers.surf.domain.member.dto.request.PasswordReqDto;
+import com.tavemakers.surf.domain.member.dto.response.AdminPageLoginResDto;
 import com.tavemakers.surf.domain.member.entity.Member;
 import com.tavemakers.surf.domain.member.entity.Password;
 import com.tavemakers.surf.domain.member.entity.enums.MemberRole;
 import com.tavemakers.surf.domain.member.entity.enums.MemberStatus;
+import com.tavemakers.surf.domain.member.exception.AdminPageRoleException;
 import com.tavemakers.surf.domain.member.service.MemberGetService;
 import com.tavemakers.surf.domain.member.service.MemberPatchService;
 import com.tavemakers.surf.domain.member.service.MemberService;
@@ -14,10 +17,13 @@ import com.tavemakers.surf.global.jwt.JwtService;
 import com.tavemakers.surf.global.logging.LogEvent;
 import com.tavemakers.surf.global.logging.LogParam;
 import com.tavemakers.surf.global.util.SecurityUtils;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -29,6 +35,7 @@ public class MemberAdminUsecase {
     private final MemberService memberService;
     private final PersonalScoreSaveService personalScoreSaveService;
     private final JwtService jwtService;
+    private final RefreshTokenService refreshTokenService;
 
     @Transactional
     public void changeRole (Long memberId, MemberRole role) {
@@ -61,6 +68,24 @@ public class MemberAdminUsecase {
     public void setUpPassword(PasswordReqDto dto) {
         Member member = memberGetService.getMember(SecurityUtils.getCurrentMemberId());
         member.updatePassword(dto.password());
+    }
+
+    public AdminPageLoginResDto loginAdminHomePage(AdminPageLoginReqDto dto, HttpServletResponse response) {
+        Member member = memberGetService.getMemberByEmail(dto.email());
+        member.checkPassword(dto.password());
+        validateLoginMemberRole(member);
+
+        String accessToken = jwtService.createAccessToken(member.getId(), member.getRole().name());
+        String deviceId = UUID.randomUUID().toString();
+        refreshTokenService.issue(response, member.getId(), deviceId);
+
+        return AdminPageLoginResDto.of(accessToken, member);
+    }
+
+    private void validateLoginMemberRole(Member member) {
+        if(member.isMember()){
+            throw new AdminPageRoleException();
+        }
     }
 
 }

--- a/src/main/java/com/tavemakers/surf/global/common/encoder/HexEncoder.java
+++ b/src/main/java/com/tavemakers/surf/global/common/encoder/HexEncoder.java
@@ -1,0 +1,17 @@
+package com.tavemakers.surf.global.common.encoder;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class HexEncoder {
+
+    public static String convertHex(byte[] rawHmac) {
+        StringBuilder sb = new StringBuilder();
+        for (byte byteData : rawHmac) {
+            sb.append(String.format("%02x", byteData));
+        }
+        return sb.toString();
+    }
+
+}


### PR DESCRIPTION
## 📄 작업 내용 요약

- Admin Page 로그인을 위해, 비밀번호 필드 추가
- Admin Page 로그인 API 구현

## Password
- HexEncoder를 기반으로 단방향 암호화만 진행합니다.
- 비밀번호는 복호화할 수 없으며, 암호화 결과를 비교하여 로그인 여부를 판단합니다.
- Password 객체에 @Embedded를 사용하여, 비밀번호 관련 로직을 도메인 내부에 두었습니다.

```java
@Getter
@EqualsAndHashCode
@AllArgsConstructor(access = AccessLevel.PRIVATE)
@Embeddable
public class Password {

    @Column(name = "password")
    private final String value;

    protected Password() {
        this.value = null;
    }

    public static Password from(String password) {
        return new Password(encrypt(password));
    }

    private static String encrypt(String password) {
        // 암호화
    }

    public void validateMatches(String password) {
        // 검증
    }

    private boolean isNotMatches(String password) {
        return !encrypt(password).equals(this.value);
    }
}
```

## 로그인
- 로그인 시 필요한 정보는 email과 password입니다. (전화번호로 변경될 수 있을거같습니다.)
- 빠른 개발을 위해 기존의 JwtServiceimpl를 사용했지만, HttpServletResponse가 서비스 레이어까지 내려가게 되어, 추후 리팩토링이 필요합니다.

## 📎 Issue 번호
<!-- closed #번호 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **새로운 기능**
  * 관리자 페이지 로그인 기능: 이메일과 비밀번호를 통한 관리자 인증 추가
  * 관리자 비밀번호 설정: 초기 비밀번호 설정 기능 구현
  * 향상된 보안: SHA-256 기반 비밀번호 암호화 및 검증 메커니즘 적용

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->