### PR TITLE
[Refact] Facade 구조로 리팩토링

### DIFF
--- a/src/main/java/com/tavemakers/surf/domain/activity/controller/ActivityRecordController.java
+++ b/src/main/java/com/tavemakers/surf/domain/activity/controller/ActivityRecordController.java
@@ -3,7 +3,7 @@ package com.tavemakers.surf.domain.activity.controller;
 import com.tavemakers.surf.domain.activity.dto.request.ActivityRecordReqDTO;
 import com.tavemakers.surf.domain.activity.dto.response.ActivityRecordSliceResDTO;
 import com.tavemakers.surf.domain.activity.entity.enums.ScoreType;
-import com.tavemakers.surf.domain.activity.usecase.ActivityRecordUsecase;
+import com.tavemakers.surf.domain.activity.facade.ActivityRecordFacade;
 import com.tavemakers.surf.global.common.response.ApiResponse;
 import com.tavemakers.surf.global.util.SecurityUtils;
 import io.swagger.v3.oas.annotations.Operation;
@@ -20,12 +20,12 @@ import static com.tavemakers.surf.domain.activity.controller.ResponseMessage.*;
 @Tag(name = "활동기록")
 public class ActivityRecordController {
 
-    private final ActivityRecordUsecase activityRecordUsecase;
+    private final ActivityRecordFacade activityRecordFacade;
 
     @Operation(summary = "활동 점수(기록) 부여")
     @PostMapping("/v1/admin/activity-records")
     public ApiResponse<Void> createActivityRecord(@RequestBody @Valid ActivityRecordReqDTO dto) {
-        activityRecordUsecase.createActivityRecordList(dto);
+        activityRecordFacade.createActivityRecordList(dto);
         return ApiResponse.response(HttpStatus.CREATED, ACTIVITY_RECORD_CREATED.getMessage(), null);
     }
 
@@ -38,7 +38,7 @@ public class ActivityRecordController {
     ) {
         Long memberId = SecurityUtils.getCurrentMemberId();
         ActivityRecordSliceResDTO response =
-                activityRecordUsecase.getActivityRecordList(memberId, scoreType, pageSize, pageNum);
+                activityRecordFacade.getActivityRecordList(memberId, scoreType, pageSize, pageNum);
         return ApiResponse.response(HttpStatus.OK, ACTIVITY_RECORD_READ.getMessage(), response);
     }
 

--- a/src/main/java/com/tavemakers/surf/domain/activity/facade/ActivityRecordFacade.java
+++ b/src/main/java/com/tavemakers/surf/domain/activity/facade/ActivityRecordFacade.java
@@ -1,10 +1,9 @@
-package com.tavemakers.surf.domain.activity.usecase;
+package com.tavemakers.surf.domain.activity.facade;
 
 import com.tavemakers.surf.domain.activity.dto.request.ActivityRecordReqDTO;
 import com.tavemakers.surf.domain.activity.dto.response.ActivityRecordResDTO;
 import com.tavemakers.surf.domain.activity.dto.response.ActivityRecordSliceResDTO;
 import com.tavemakers.surf.domain.activity.entity.ActivityRecord;
-import com.tavemakers.surf.domain.activity.entity.enums.ActivityType;
 import com.tavemakers.surf.domain.activity.entity.enums.ScoreType;
 import com.tavemakers.surf.domain.activity.service.ActivityRecordGetService;
 import com.tavemakers.surf.domain.activity.service.ActivityRecordSaveService;
@@ -16,15 +15,15 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
-import org.springframework.stereotype.Service;
+import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.util.List;
 
-@Service
+@Component
 @RequiredArgsConstructor
-public class ActivityRecordUsecase {
+public class ActivityRecordFacade {
 
     private final ActivityRecordSaveService activityRecordSaveService;
     private final ActivityRecordGetService activityRecordGetService;
@@ -33,7 +32,6 @@ public class ActivityRecordUsecase {
 
     @Transactional
     public void createActivityRecordList(ActivityRecordReqDTO dto) {
-        // 다수의 활동 점수 -> 감점 + 가점 -> 누적합과 함께 활동기록 생성
         List<PersonalActivityScore> scoreList = personalScoreGetService.getPersonalScoreList(dto.memberIdList());
         List<ActivityRecord> recordList = scoreList.stream()
                 .map(personalScore -> {

--- a/src/main/java/com/tavemakers/surf/domain/badge/controller/MemberBadgeController.java
+++ b/src/main/java/com/tavemakers/surf/domain/badge/controller/MemberBadgeController.java
@@ -2,7 +2,7 @@ package com.tavemakers.surf.domain.badge.controller;
 
 import com.tavemakers.surf.domain.badge.dto.request.MemberBadgeReqDTO;
 import com.tavemakers.surf.domain.badge.dto.response.MemberBadgeSliceResDTO;
-import com.tavemakers.surf.domain.badge.usecase.MemberBadgeUsecase;
+import com.tavemakers.surf.domain.badge.facade.MemberBadgeFacade;
 import com.tavemakers.surf.global.common.response.ApiResponse;
 import com.tavemakers.surf.global.util.SecurityUtils;
 import io.swagger.v3.oas.annotations.Operation;
@@ -19,7 +19,7 @@ import static com.tavemakers.surf.domain.badge.controller.ResponseMessage.*;
 @Tag(name = "활동뱃지")
 public class MemberBadgeController {
 
-    private final MemberBadgeUsecase memberBadgeusecase;
+    private final MemberBadgeFacade memberBadgeFacade;
 
     @Operation(
             summary = "활동 뱃지 부여 API",
@@ -27,7 +27,7 @@ public class MemberBadgeController {
     )
     @PostMapping("/v1/admin/members/badges")
     public ApiResponse<Void> createBadge(@RequestBody @Valid MemberBadgeReqDTO dto) {
-        memberBadgeusecase.saveMemberBadgeList(dto);
+        memberBadgeFacade.saveMemberBadgeList(dto);
         return ApiResponse.response(HttpStatus.CREATED, MEMBER_BADGE_LIST_CREATED.getMessage(), null);
     }
 
@@ -42,7 +42,7 @@ public class MemberBadgeController {
             @RequestParam int pageNum
     ) {
         memberId = (memberId == null ? SecurityUtils.getCurrentMemberId() : memberId);
-        MemberBadgeSliceResDTO response = memberBadgeusecase.getMemberBadgeWithSlice(memberId, pageSize, pageNum);
+        MemberBadgeSliceResDTO response = memberBadgeFacade.getMemberBadgeWithSlice(memberId, pageSize, pageNum);
         return ApiResponse.response(HttpStatus.OK, MEMBER_BADGE_LIST_READ.getMessage(), response);
     }
 

--- a/src/main/java/com/tavemakers/surf/domain/badge/facade/MemberBadgeFacade.java
+++ b/src/main/java/com/tavemakers/surf/domain/badge/facade/MemberBadgeFacade.java
@@ -1,4 +1,4 @@
-package com.tavemakers.surf.domain.badge.usecase;
+package com.tavemakers.surf.domain.badge.facade;
 
 import com.tavemakers.surf.domain.badge.dto.request.MemberBadgeReqDTO;
 import com.tavemakers.surf.domain.badge.dto.response.MemberBadgeResDTO;
@@ -11,11 +11,11 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
-import org.springframework.stereotype.Service;
+import org.springframework.stereotype.Component;
 
-@Service
+@Component
 @RequiredArgsConstructor
-public class MemberBadgeUsecase {
+public class MemberBadgeFacade {
 
     private final MemberBadgeSaveService memberBadgeSaveService;
     private final MemberBadgeGetService memberBadgeGetService;

--- a/src/main/java/com/tavemakers/surf/domain/board/controller/BoardController.java
+++ b/src/main/java/com/tavemakers/surf/domain/board/controller/BoardController.java
@@ -3,7 +3,7 @@ package com.tavemakers.surf.domain.board.controller;
 import com.tavemakers.surf.domain.board.dto.request.BoardCreateReqDTO;
 import com.tavemakers.surf.domain.board.dto.request.BoardUpdateReqDTO;
 import com.tavemakers.surf.domain.board.dto.response.BoardResDTO;
-import com.tavemakers.surf.domain.board.service.BoardService;
+import com.tavemakers.surf.domain.board.facade.BoardFacade;
 import com.tavemakers.surf.global.common.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -21,20 +21,20 @@ import static com.tavemakers.surf.domain.board.controller.ResponseMessage.*;
 @RequestMapping
 @Tag(name = "게시판", description = "추후 MVP를 통해 디벨롭 될 예정")
 public class BoardController {
-    private final BoardService boardService;
+    private final BoardFacade boardFacade;
 
     @Operation(summary = "게시판 생성", description = "새로운 게시판을 생성합니다.")
     @PostMapping("/v1/admin/boards")
     public ApiResponse<BoardResDTO> createBoard(
             @Valid @RequestBody BoardCreateReqDTO req) {
-        BoardResDTO response = boardService.createBoard(req);
+        BoardResDTO response = boardFacade.createBoard(req);
         return ApiResponse.response(HttpStatus.CREATED, BOARD_CREATED.getMessage(), response);
     }
 
     @Operation(summary = "게시판 목록 조회", description = "모든 게시판을 조회합니다.")
     @GetMapping("/v1/user/boards")
     public ApiResponse<List<BoardResDTO>> getBoards() {
-        List<BoardResDTO> response = boardService.getBoards();
+        List<BoardResDTO> response = boardFacade.getBoards();
         return ApiResponse.response(HttpStatus.OK, BOARD_READ.getMessage(), response);
     }
 
@@ -42,7 +42,7 @@ public class BoardController {
     @GetMapping("/v1/admin/boards/{boardId}")
     public ApiResponse<BoardResDTO> getBoard(
             @PathVariable Long boardId) {
-        BoardResDTO response = boardService.getBoard(boardId);
+        BoardResDTO response = boardFacade.getBoard(boardId);
         return ApiResponse.response(HttpStatus.OK, BOARD_READ.getMessage(), response);
     }
 
@@ -51,7 +51,7 @@ public class BoardController {
     public ApiResponse<BoardResDTO> updateBoard(
             @PathVariable Long boardId,
             @Valid @RequestBody BoardUpdateReqDTO req) {
-        BoardResDTO response = boardService.updateBoard(boardId, req);
+        BoardResDTO response = boardFacade.updateBoard(boardId, req);
         return ApiResponse.response(HttpStatus.OK, BOARD_UPDATED.getMessage(), response);
     }
 
@@ -59,7 +59,7 @@ public class BoardController {
     @DeleteMapping("/v1/admin/boards/{boardId}")
     public ApiResponse<Void> deleteBoard(
             @PathVariable Long boardId) {
-        boardService.deleteBoard(boardId);
+        boardFacade.deleteBoard(boardId);
         return ApiResponse.response(HttpStatus.NO_CONTENT, BOARD_DELETED.getMessage());
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/board/facade/BoardFacade.java
+++ b/src/main/java/com/tavemakers/surf/domain/board/facade/BoardFacade.java
@@ -1,0 +1,36 @@
+package com.tavemakers.surf.domain.board.facade;
+
+import com.tavemakers.surf.domain.board.dto.request.BoardCreateReqDTO;
+import com.tavemakers.surf.domain.board.dto.request.BoardUpdateReqDTO;
+import com.tavemakers.surf.domain.board.dto.response.BoardResDTO;
+import com.tavemakers.surf.domain.board.service.BoardService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class BoardFacade {
+    private final BoardService boardService;
+
+    public BoardResDTO createBoard(BoardCreateReqDTO req) {
+        return boardService.createBoard(req);
+    }
+
+    public List<BoardResDTO> getBoards() {
+        return boardService.getBoards();
+    }
+
+    public BoardResDTO getBoard(Long id) {
+        return boardService.getBoard(id);
+    }
+
+    public BoardResDTO updateBoard(Long id, BoardUpdateReqDTO req) {
+        return boardService.updateBoard(id, req);
+    }
+
+    public void deleteBoard(Long id) {
+        boardService.deleteBoard(id);
+    }
+}

--- a/src/main/java/com/tavemakers/surf/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/tavemakers/surf/domain/comment/controller/CommentController.java
@@ -3,7 +3,7 @@ package com.tavemakers.surf.domain.comment.controller;
 import com.tavemakers.surf.domain.comment.dto.req.CommentCreateReqDTO;
 import com.tavemakers.surf.domain.comment.dto.res.CommentListResDTO;
 import com.tavemakers.surf.domain.comment.dto.res.CommentResDTO;
-import com.tavemakers.surf.domain.comment.service.CommentService;
+import com.tavemakers.surf.domain.comment.facade.CommentFacade;
 import com.tavemakers.surf.global.common.response.ApiResponse;
 import com.tavemakers.surf.global.logging.LogEvent;
 import com.tavemakers.surf.global.logging.LogParam;
@@ -27,7 +27,7 @@ import static com.tavemakers.surf.domain.comment.controller.ResponseMessage.*;
 @Tag(name = "댓글", description = "댓글 및 대댓글 관련 CRUD API")
 public class CommentController {
 
-    private final CommentService commentService;
+    private final CommentFacade commentFacade;
 
     @Operation(summary = "댓글 생성 (루트/대댓글)", description = "rootId가 null이면 루트 댓글")
     @PostMapping("/v1/user/posts/{postId}/comments")
@@ -35,7 +35,7 @@ public class CommentController {
             @PathVariable Long postId,
             @Valid @RequestBody CommentCreateReqDTO req) {
         Long memberId = SecurityUtils.getCurrentMemberId();
-        CommentResDTO response = commentService.createComment(postId, memberId, req);
+        CommentResDTO response = commentFacade.createComment(postId, memberId, req);
         return ApiResponse.response(HttpStatus.CREATED, COMMENT_CREATED.getMessage(), response);
     }
 
@@ -49,7 +49,7 @@ public class CommentController {
             Pageable pageable
     ){
         Long memberId = SecurityUtils.getCurrentMemberId();
-        CommentListResDTO data = commentService.getComments(postId, pageable, memberId);
+        CommentListResDTO data = commentFacade.getComments(postId, pageable, memberId);
         return ApiResponse.response(HttpStatus.OK, COMMENT_READ.getMessage(), data);
     }
 
@@ -58,7 +58,7 @@ public class CommentController {
     public ApiResponse<Void> deleteComment(@PathVariable Long postId,
                                            @PathVariable Long commentId) {
         Long memberId = SecurityUtils.getCurrentMemberId();
-        commentService.deleteComment(postId, commentId, memberId);
+        commentFacade.deleteComment(postId, commentId, memberId);
         return ApiResponse.response(HttpStatus.NO_CONTENT, COMMENT_DELETED.getMessage());
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/comment/controller/CommentLikeController.java
+++ b/src/main/java/com/tavemakers/surf/domain/comment/controller/CommentLikeController.java
@@ -1,7 +1,7 @@
 package com.tavemakers.surf.domain.comment.controller;
 
 import com.tavemakers.surf.domain.comment.dto.res.CommentLikeMemberResDTO;
-import com.tavemakers.surf.domain.comment.service.CommentLikeService;
+import com.tavemakers.surf.domain.comment.facade.CommentFacade;
 import com.tavemakers.surf.global.common.response.ApiResponse;
 import com.tavemakers.surf.global.util.SecurityUtils;
 import io.swagger.v3.oas.annotations.Operation;
@@ -21,20 +21,20 @@ import static com.tavemakers.surf.domain.comment.controller.ResponseMessage.*;
 @Tag(name = "댓글 좋아요", description = "댓글 좋아요 / 취소 / 상태 관련 API")
 public class CommentLikeController {
 
-    private final CommentLikeService commentLikeService;
+    private final CommentFacade commentFacade;
 
     @Operation(summary = "댓글 좋아요 토글", description = "이미 누른 경우 취소, 안 누른 경우 좋아요로 변경")
     @PostMapping("/v1/user/comments/{commentId}/like")
     public ApiResponse<Map<String, Object>> toggleLike(@PathVariable Long commentId) {
         Long memberId = SecurityUtils.getCurrentMemberId();
-        boolean liked = commentLikeService.toggleLike(commentId, memberId);
+        boolean liked = commentFacade.toggleLike(commentId, memberId);
         return ApiResponse.response(HttpStatus.OK, COMMENT_LIKE_TOGGLED.getMessage(), Map.of("liked", liked));
     }
 
     @Operation(summary = "댓글 좋아요 개수 조회", description = "특정 댓글의 좋아요 개수 조회")
     @GetMapping("/v1/user/comments/{commentId}/like/count")
     public ApiResponse<Long> getLikeCount(@PathVariable Long commentId) {
-        long count = commentLikeService.countLikes(commentId);
+        long count = commentFacade.countLikes(commentId);
         return ApiResponse.response(HttpStatus.OK, COMMENT_LIKE_COUNT_READ.getMessage(), count);
     }
 
@@ -42,14 +42,14 @@ public class CommentLikeController {
     @GetMapping("/v1/user/comments/{commentId}/like/me")
     public ApiResponse<Boolean> isLiked(@PathVariable Long commentId) {
         Long memberId = SecurityUtils.getCurrentMemberId();
-        boolean liked = commentLikeService.isLikedByMe(commentId, memberId);
+        boolean liked = commentFacade.isLikedByMe(commentId, memberId);
         return ApiResponse.response(HttpStatus.OK, COMMENT_LIKE_STATUS_READ.getMessage(), liked);
     }
 
     @Operation(summary = "댓글 좋아요 누른 회원 목록 조회", description = "특정 댓글에 좋아요 누른 회원들의 ID, 이름, 프로필 이미지를 반환")
     @GetMapping("/v1/user/comments/{commentId}/like/members")
     public ApiResponse<List<CommentLikeMemberResDTO>> getLikedMembers(@PathVariable Long commentId) {
-        List<CommentLikeMemberResDTO> likedMembers = commentLikeService.getMembersWhoLiked(commentId);
+        List<CommentLikeMemberResDTO> likedMembers = commentFacade.getMembersWhoLiked(commentId);
         return ApiResponse.response(HttpStatus.OK, COMMENT_LIKE_MEMBER_LIST_READ.getMessage(), likedMembers);
     }
 

--- a/src/main/java/com/tavemakers/surf/domain/comment/controller/CommentMentionController.java
+++ b/src/main/java/com/tavemakers/surf/domain/comment/controller/CommentMentionController.java
@@ -1,7 +1,7 @@
 package com.tavemakers.surf.domain.comment.controller;
 
 import com.tavemakers.surf.domain.comment.dto.res.MentionSearchResDTO;
-import com.tavemakers.surf.domain.comment.service.CommentMentionService;
+import com.tavemakers.surf.domain.comment.facade.CommentFacade;
 import com.tavemakers.surf.global.common.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -19,14 +19,14 @@ import static com.tavemakers.surf.domain.comment.controller.ResponseMessage.*;
 @RequiredArgsConstructor
 public class CommentMentionController {
 
-    private final CommentMentionService commentMentionService;
+    private final CommentFacade commentFacade;
 
     @Operation(summary = "멘션할 회원 검색", description = "이름 두 글자 이상 입력 시 회원 검색")
     @GetMapping("/v1/user/comments/mentions/search")
     public ApiResponse<List<MentionSearchResDTO>> searchMentionableMembers(
             @RequestParam("keyword") String keyword
     ) {
-        List<MentionSearchResDTO> result = commentMentionService.searchMentionableMembers(keyword);
+        List<MentionSearchResDTO> result = commentFacade.searchMentionableMembers(keyword);
         return ApiResponse.response(HttpStatus.OK, COMMENT_MENTION_SEARCH_SUCCESS.getMessage(), result);
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/comment/facade/CommentFacade.java
+++ b/src/main/java/com/tavemakers/surf/domain/comment/facade/CommentFacade.java
@@ -1,0 +1,59 @@
+package com.tavemakers.surf.domain.comment.facade;
+
+import com.tavemakers.surf.domain.comment.dto.req.CommentCreateReqDTO;
+import com.tavemakers.surf.domain.comment.dto.res.CommentLikeMemberResDTO;
+import com.tavemakers.surf.domain.comment.dto.res.CommentListResDTO;
+import com.tavemakers.surf.domain.comment.dto.res.CommentResDTO;
+import com.tavemakers.surf.domain.comment.dto.res.MentionSearchResDTO;
+import com.tavemakers.surf.domain.comment.service.CommentLikeService;
+import com.tavemakers.surf.domain.comment.service.CommentMentionService;
+import com.tavemakers.surf.domain.comment.service.CommentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class CommentFacade {
+
+    private final CommentService commentService;
+    private final CommentLikeService commentLikeService;
+    private final CommentMentionService commentMentionService;
+
+    // CommentService
+    public CommentResDTO createComment(Long postId, Long memberId, CommentCreateReqDTO req) {
+        return commentService.createComment(postId, memberId, req);
+    }
+
+    public CommentListResDTO getComments(Long postId, Pageable pageable, Long memberId) {
+        return commentService.getComments(postId, pageable, memberId);
+    }
+
+    public void deleteComment(Long postId, Long commentId, Long memberId) {
+        commentService.deleteComment(postId, commentId, memberId);
+    }
+
+    // CommentLikeService
+    public boolean toggleLike(Long commentId, Long memberId) {
+        return commentLikeService.toggleLike(commentId, memberId);
+    }
+
+    public long countLikes(Long commentId) {
+        return commentLikeService.countLikes(commentId);
+    }
+
+    public boolean isLikedByMe(Long commentId, Long memberId) {
+        return commentLikeService.isLikedByMe(commentId, memberId);
+    }
+
+    public List<CommentLikeMemberResDTO> getMembersWhoLiked(Long commentId) {
+        return commentLikeService.getMembersWhoLiked(commentId);
+    }
+
+    // CommentMentionService
+    public List<MentionSearchResDTO> searchMentionableMembers(String keyword) {
+        return commentMentionService.searchMentionableMembers(keyword);
+    }
+}

--- a/src/main/java/com/tavemakers/surf/domain/feedback/controller/FeedbackController.java
+++ b/src/main/java/com/tavemakers/surf/domain/feedback/controller/FeedbackController.java
@@ -2,7 +2,7 @@ package com.tavemakers.surf.domain.feedback.controller;
 
 import com.tavemakers.surf.domain.feedback.dto.req.FeedbackCreateReqDTO;
 import com.tavemakers.surf.domain.feedback.dto.res.FeedbackResDTO;
-import com.tavemakers.surf.domain.feedback.service.FeedbackService;
+import com.tavemakers.surf.domain.feedback.facade.FeedbackFacade;
 import com.tavemakers.surf.global.common.response.ApiResponse;
 import com.tavemakers.surf.global.util.SecurityUtils;
 import io.swagger.v3.oas.annotations.Operation;
@@ -26,7 +26,7 @@ import static com.tavemakers.surf.domain.feedback.controller.ResponseMessage.FEE
 @Tag(name = "피드백")
 public class FeedbackController {
 
-    private final FeedbackService feedbackService;
+    private final FeedbackFacade feedbackFacade;
 
     /** 피드백 생성 (로그인 사용자) */
     @Operation(summary = "피드백 생성", description = "익명의 피드백을 생성합니다. (하루 3회 제한)")
@@ -35,7 +35,7 @@ public class FeedbackController {
             @Valid @RequestBody FeedbackCreateReqDTO req
     ) {
         Long memberId = SecurityUtils.getCurrentMemberId();
-        FeedbackResDTO response = feedbackService.createFeedback(req, memberId);
+        FeedbackResDTO response = feedbackFacade.createFeedback(req, memberId);
         return ApiResponse.response(HttpStatus.CREATED, FEEDBACK_CREATED.getMessage(), response);
     }
 
@@ -47,7 +47,7 @@ public class FeedbackController {
             @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC)
             Pageable pageable
     ) {
-        Slice<FeedbackResDTO> response = feedbackService.getFeedbacks(pageable);
+        Slice<FeedbackResDTO> response = feedbackFacade.getFeedbacks(pageable);
         return ApiResponse.response(HttpStatus.OK, FEEDBACK_READ.getMessage(), response);
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/feedback/facade/FeedbackFacade.java
+++ b/src/main/java/com/tavemakers/surf/domain/feedback/facade/FeedbackFacade.java
@@ -1,0 +1,23 @@
+package com.tavemakers.surf.domain.feedback.facade;
+
+import com.tavemakers.surf.domain.feedback.dto.req.FeedbackCreateReqDTO;
+import com.tavemakers.surf.domain.feedback.dto.res.FeedbackResDTO;
+import com.tavemakers.surf.domain.feedback.service.FeedbackService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class FeedbackFacade {
+    private final FeedbackService feedbackService;
+
+    public FeedbackResDTO createFeedback(FeedbackCreateReqDTO req, Long memberId) {
+        return feedbackService.createFeedback(req, memberId);
+    }
+
+    public Slice<FeedbackResDTO> getFeedbacks(Pageable pageable) {
+        return feedbackService.getFeedbacks(pageable);
+    }
+}

--- a/src/main/java/com/tavemakers/surf/domain/home/controller/HomeBannerAdminController.java
+++ b/src/main/java/com/tavemakers/surf/domain/home/controller/HomeBannerAdminController.java
@@ -5,7 +5,7 @@ import com.tavemakers.surf.domain.home.dto.request.HomeBannerCreateReqDTO;
 import com.tavemakers.surf.domain.home.dto.request.HomeBannerReorderReqDTO;
 import com.tavemakers.surf.domain.home.dto.request.HomeBannerUpdateReqDTO;
 import com.tavemakers.surf.domain.home.dto.response.HomeBannerResDTO;
-import com.tavemakers.surf.domain.home.service.HomeBannerService;
+import com.tavemakers.surf.domain.home.facade.HomeFacade;
 import com.tavemakers.surf.global.common.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -24,12 +24,12 @@ import static com.tavemakers.surf.domain.home.controller.ResponseMessage.*;
 @Tag(name = "홈 배너 관리", description = "홈 배너 관리 API")
 public class HomeBannerAdminController {
 
-    private final HomeBannerService homeBannerService;
+    private final HomeFacade homeFacade;
 
     @Operation(summary = "홈 배너 목록 조회", description = "홈 배너 목록을 조회합니다.")
     @GetMapping("/v1/admin/home/banners")
     public ApiResponse<List<HomeBannerResDTO>> getBanners() {
-        List<HomeBannerResDTO> response = homeBannerService.getBanners();
+        List<HomeBannerResDTO> response = homeFacade.getBanners();
         return ApiResponse.response(HttpStatus.OK, HOME_BANNERS_READ.getMessage(), response);
     }
 
@@ -38,7 +38,7 @@ public class HomeBannerAdminController {
     public ApiResponse<HomeBannerResDTO> createBanner(
             @RequestBody @Valid HomeBannerCreateReqDTO req
     ) {
-        HomeBannerResDTO response = homeBannerService.createBanner(req);
+        HomeBannerResDTO response = homeFacade.createBanner(req);
         return ApiResponse.response(HttpStatus.CREATED, HOME_BANNER_CREATED.getMessage(), response);
     }
 
@@ -47,7 +47,7 @@ public class HomeBannerAdminController {
     public ApiResponse<Void> deleteBanner(
             @PathVariable Long bannerId
     ) {
-        homeBannerService.deleteBanner(bannerId);
+        homeFacade.deleteBanner(bannerId);
         return ApiResponse.response(HttpStatus.NO_CONTENT, HOME_BANNER_DELETED.getMessage());
     }
 
@@ -56,7 +56,7 @@ public class HomeBannerAdminController {
     public ApiResponse<List<HomeBannerResDTO>> reorderBanners(
             @RequestBody @Valid HomeBannerReorderReqDTO req
     ) {
-        List<HomeBannerResDTO> response = homeBannerService.reorderBanners(req);
+        List<HomeBannerResDTO> response = homeFacade.reorderBanners(req);
         return ApiResponse.response(HttpStatus.OK, HOME_BANNER_REORDERED.getMessage(), response);
     }
 
@@ -66,7 +66,7 @@ public class HomeBannerAdminController {
             @PathVariable Long bannerId,
             @RequestBody @Valid HomeBannerUpdateReqDTO req
     ) {
-        HomeBannerResDTO response = homeBannerService.updateBanner(bannerId, req);
+        HomeBannerResDTO response = homeFacade.updateBanner(bannerId, req);
         return ApiResponse.response(HttpStatus.OK, HOME_BANNER_UPDATED.getMessage(), response);
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/home/controller/HomeContentAdminController.java
+++ b/src/main/java/com/tavemakers/surf/domain/home/controller/HomeContentAdminController.java
@@ -2,7 +2,7 @@ package com.tavemakers.surf.domain.home.controller;
 
 import com.tavemakers.surf.domain.home.dto.request.HomeContentUpsertReqDTO;
 import com.tavemakers.surf.domain.home.dto.response.HomeContentResDTO;
-import com.tavemakers.surf.domain.home.service.HomeContentService;
+import com.tavemakers.surf.domain.home.facade.HomeFacade;
 import com.tavemakers.surf.global.common.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -20,12 +20,12 @@ import static com.tavemakers.surf.domain.home.controller.ResponseMessage.HOME_CO
 @Tag(name = "홈 문구 관리", description = "홈 문구 관리 API")
 public class HomeContentAdminController {
 
-    private final HomeContentService homeContentService;
+    private final HomeFacade homeFacade;
 
     @Operation(summary = "홈 문구 조회", description = "홈 문구를 조회합니다.")
     @GetMapping("/v1/admin/home/content")
     public ApiResponse<HomeContentResDTO> getContent() {
-        HomeContentResDTO response = homeContentService.getContent();
+        HomeContentResDTO response = homeFacade.getContent();
         return ApiResponse.response(HttpStatus.OK, HOME_CONTENT_READ.getMessage(), response);
     }
 
@@ -34,7 +34,7 @@ public class HomeContentAdminController {
     public ApiResponse<HomeContentResDTO> upsertContent(
             @RequestBody @Valid HomeContentUpsertReqDTO req
     ) {
-        HomeContentResDTO response = homeContentService.upsertContent(req);
+        HomeContentResDTO response = homeFacade.upsertContent(req);
         return ApiResponse.response(HttpStatus.OK, HOME_CONTENT_UPSERTED.getMessage(), response);
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/home/controller/HomeController.java
+++ b/src/main/java/com/tavemakers/surf/domain/home/controller/HomeController.java
@@ -1,7 +1,7 @@
 package com.tavemakers.surf.domain.home.controller;
 
 import com.tavemakers.surf.domain.home.dto.response.HomeResDTO;
-import com.tavemakers.surf.domain.home.service.HomeService;
+import com.tavemakers.surf.domain.home.facade.HomeFacade;
 import com.tavemakers.surf.global.common.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -17,12 +17,12 @@ import static com.tavemakers.surf.domain.home.controller.ResponseMessage.HOME_PA
 @Tag(name = "홈 화면 렌더링")
 public class HomeController {
 
-    private final HomeService homeService;
+    private final HomeFacade homeFacade;
 
     @Operation(summary = "홈 화면 렌더링", description = "홈 화면에 필요한 데이터를 렌더링합니다.")
     @GetMapping("/v1/user/home")
     public ApiResponse<HomeResDTO> home() {
-        HomeResDTO response = homeService.getHome();
+        HomeResDTO response = homeFacade.getHome();
         return ApiResponse.response(HttpStatus.OK, HOME_PAGE_RENDERED.getMessage(), response);
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/home/facade/HomeFacade.java
+++ b/src/main/java/com/tavemakers/surf/domain/home/facade/HomeFacade.java
@@ -1,0 +1,60 @@
+package com.tavemakers.surf.domain.home.facade;
+
+import com.tavemakers.surf.domain.home.dto.request.HomeBannerCreateReqDTO;
+import com.tavemakers.surf.domain.home.dto.request.HomeBannerReorderReqDTO;
+import com.tavemakers.surf.domain.home.dto.request.HomeBannerUpdateReqDTO;
+import com.tavemakers.surf.domain.home.dto.request.HomeContentUpsertReqDTO;
+import com.tavemakers.surf.domain.home.dto.response.HomeBannerResDTO;
+import com.tavemakers.surf.domain.home.dto.response.HomeContentResDTO;
+import com.tavemakers.surf.domain.home.dto.response.HomeResDTO;
+import com.tavemakers.surf.domain.home.service.HomeBannerService;
+import com.tavemakers.surf.domain.home.service.HomeContentService;
+import com.tavemakers.surf.domain.home.service.HomeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class HomeFacade {
+
+    private final HomeService homeService;
+    private final HomeBannerService homeBannerService;
+    private final HomeContentService homeContentService;
+
+    // HomeService
+    public HomeResDTO getHome() {
+        return homeService.getHome();
+    }
+
+    // HomeBannerService
+    public List<HomeBannerResDTO> getBanners() {
+        return homeBannerService.getBanners();
+    }
+
+    public HomeBannerResDTO createBanner(HomeBannerCreateReqDTO req) {
+        return homeBannerService.createBanner(req);
+    }
+
+    public void deleteBanner(Long bannerId) {
+        homeBannerService.deleteBanner(bannerId);
+    }
+
+    public List<HomeBannerResDTO> reorderBanners(HomeBannerReorderReqDTO req) {
+        return homeBannerService.reorderBanners(req);
+    }
+
+    public HomeBannerResDTO updateBanner(Long bannerId, HomeBannerUpdateReqDTO req) {
+        return homeBannerService.updateBanner(bannerId, req);
+    }
+
+    // HomeContentService
+    public HomeContentResDTO getContent() {
+        return homeContentService.getContent();
+    }
+
+    public HomeContentResDTO upsertContent(HomeContentUpsertReqDTO req) {
+        return homeContentService.upsertContent(req);
+    }
+}

--- a/src/main/java/com/tavemakers/surf/domain/login/controller/LogoutController.java
+++ b/src/main/java/com/tavemakers/surf/domain/login/controller/LogoutController.java
@@ -1,15 +1,13 @@
 package com.tavemakers.surf.domain.login.controller;
 
-import com.tavemakers.surf.domain.login.auth.service.RefreshTokenService;
+import com.tavemakers.surf.domain.login.facade.LoginFacade;
 import com.tavemakers.surf.global.common.response.ApiResponse;
-import com.tavemakers.surf.global.jwt.JwtService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -18,29 +16,12 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class LogoutController {
 
-    private final JwtService jwtService;
-    private final RefreshTokenService refreshTokenService;
+    private final LoginFacade loginFacade;
 
     @Operation(summary = "로그아웃", description = "현재 디바이스의 refreshToken을 무효화하고 쿠키를 삭제합니다.")
     @PostMapping("/auth/logout")
     public ApiResponse<Void> logout(HttpServletRequest request, HttpServletResponse response) {
-
-        jwtService.extractRefreshToken(request).ifPresent(refreshToken -> {
-            if (jwtService.isTokenValid(refreshToken)) {
-                Long memberId = jwtService.extractMemberId(refreshToken).orElse(null);
-                String deviceId = jwtService.extractDeviceId(refreshToken).orElse(null);
-                if (memberId != null && deviceId != null) {
-                    refreshTokenService.invalidate(memberId, deviceId);
-                }
-            }
-        });
-
-        // 쿠키 삭제는 항상 수행
-        jwtService.clearRefreshTokenCookie(response);
-
-        // 컨텍스트 정리
-        SecurityContextHolder.clearContext();
-
+        loginFacade.logout(request, response);
         return ApiResponse.response(HttpStatus.NO_CONTENT, "로그아웃 완료", null);
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/login/facade/LoginFacade.java
+++ b/src/main/java/com/tavemakers/surf/domain/login/facade/LoginFacade.java
@@ -1,0 +1,31 @@
+package com.tavemakers.surf.domain.login.facade;
+
+import com.tavemakers.surf.domain.login.auth.service.RefreshTokenService;
+import com.tavemakers.surf.global.jwt.JwtService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class LoginFacade {
+    private final JwtService jwtService;
+    private final RefreshTokenService refreshTokenService;
+
+    public void logout(HttpServletRequest request, HttpServletResponse response) {
+        jwtService.extractRefreshToken(request).ifPresent(refreshToken -> {
+            if (jwtService.isTokenValid(refreshToken)) {
+                Long memberId = jwtService.extractMemberId(refreshToken).orElse(null);
+                String deviceId = jwtService.extractDeviceId(refreshToken).orElse(null);
+                if (memberId != null && deviceId != null) {
+                    refreshTokenService.invalidate(memberId, deviceId);
+                }
+            }
+        });
+
+        jwtService.clearRefreshTokenCookie(response);
+        SecurityContextHolder.clearContext();
+    }
+}

--- a/src/main/java/com/tavemakers/surf/domain/member/controller/AdminController.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/controller/AdminController.java
@@ -1,14 +1,13 @@
 package com.tavemakers.surf.domain.member.controller;
 
 import com.tavemakers.surf.domain.member.dto.request.RoleChangeRequestDto;
-import com.tavemakers.surf.domain.member.usecase.MemberAdminUsecase;
+import com.tavemakers.surf.domain.member.facade.MemberAdminFacade;
 import io.swagger.v3.oas.annotations.Operation;
 import com.tavemakers.surf.global.common.response.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "관리자", description = "관리자용 API")
@@ -17,7 +16,7 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 public class AdminController {
 
-    private final MemberAdminUsecase memberAdminUsecase;
+    private final MemberAdminFacade memberAdminFacade;
 
     @Operation(summary = "회원 역할 변경", description = "특정 회원의 역할을 변경합니다.")
     @PatchMapping("/v1/admin/members/{memberId}/role")
@@ -25,7 +24,7 @@ public class AdminController {
             @PathVariable Long memberId,
             @RequestBody @Valid RoleChangeRequestDto request) {
 
-        memberAdminUsecase.changeRole(memberId, request.role());
+        memberAdminFacade.changeRole(memberId, request.role());
         return ApiResponse.response(HttpStatus.OK, "회원 역할이 성공적으로 변경되었습니다.",null);
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/member/controller/MemberController.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/controller/MemberController.java
@@ -4,8 +4,8 @@ import com.tavemakers.surf.domain.member.dto.request.MemberSignupReqDTO;
 import com.tavemakers.surf.domain.member.dto.response.MemberSignupResDTO;
 import com.tavemakers.surf.domain.member.exception.MemberAlreadyExistsException;
 import com.tavemakers.surf.domain.member.dto.response.OnboardingCheckResDTO;
-import com.tavemakers.surf.domain.member.usecase.MemberAdminUsecase;
-import com.tavemakers.surf.domain.member.usecase.MemberUsecase;
+import com.tavemakers.surf.domain.member.facade.MemberAdminFacade;
+import com.tavemakers.surf.domain.member.facade.MemberFacade;
 import com.tavemakers.surf.global.common.response.ApiResponse;
 import com.tavemakers.surf.global.logging.LogParam;
 import com.tavemakers.surf.global.logging.LogEventEmitter;
@@ -25,8 +25,8 @@ import jakarta.validation.Valid;
 @Tag(name = "자체 회원가입 및 관리자 승인/거절")
 public class MemberController {
 
-    private final MemberUsecase memberUsecase;
-    private final MemberAdminUsecase memberAdminUsecase;
+    private final MemberFacade memberFacade;
+    private final MemberAdminFacade memberAdminFacade;
     private final LogEventEmitter logEventEmitter;
 
     /**
@@ -48,7 +48,7 @@ public class MemberController {
             ApiResponse<MemberSignupResDTO> response = ApiResponse.response(
                     HttpStatus.CREATED,
                     "회원가입 요청 접수",
-                    memberUsecase.signup(userId, request)
+                    memberFacade.signup(userId, request)
             );
 
             return response;
@@ -88,7 +88,7 @@ public class MemberController {
     @GetMapping("/v1/user/members/valid-status")
     public ApiResponse<OnboardingCheckResDTO> checkOnboardingStatus() {
         Long userId = SecurityUtils.getCurrentMemberId();
-        OnboardingCheckResDTO dto = memberUsecase.needsOnboarding(userId);
+        OnboardingCheckResDTO dto = memberFacade.needsOnboarding(userId);
 
         logEventEmitter.emit("onboarding.valid_status", dto.buildProps());
 
@@ -112,7 +112,7 @@ public class MemberController {
             @PathVariable Long memberId
     ) {
         Long approverId = SecurityUtils.getCurrentMemberId();
-        memberAdminUsecase.approveMember(memberId, approverId);
+        memberAdminFacade.approveMember(memberId, approverId);
 
         return ApiResponse.response(HttpStatus.OK, "승인되었습니다.", null);
     }
@@ -130,7 +130,7 @@ public class MemberController {
             @PathVariable Long memberId
     ) {
         Long approverId = SecurityUtils.getCurrentMemberId();
-        memberAdminUsecase.rejectMember(memberId, approverId);
+        memberAdminFacade.rejectMember(memberId, approverId);
 
         return ApiResponse.response(HttpStatus.OK, "거절되었습니다.", null);
     }

--- a/src/main/java/com/tavemakers/surf/domain/member/controller/MemberPatchController.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/controller/MemberPatchController.java
@@ -2,7 +2,7 @@ package com.tavemakers.surf.domain.member.controller;
 
 import com.tavemakers.surf.domain.member.dto.request.ProfileUpdateReqDTO;
 import com.tavemakers.surf.domain.member.entity.CustomUserDetails;
-import com.tavemakers.surf.domain.member.usecase.MemberUsecase;
+import com.tavemakers.surf.domain.member.facade.MemberFacade;
 import com.tavemakers.surf.global.common.response.ApiResponse;
 import com.tavemakers.surf.global.util.SecurityUtils;
 import io.swagger.v3.oas.annotations.Operation;
@@ -21,7 +21,7 @@ import java.util.List;
 @Tag(name = "회원 정보 수정", description = "회원 정보 수정 관련 API")
 public class MemberPatchController {
 
-    private final MemberUsecase memberUsecase;
+    private final MemberFacade memberFacade;
 
     @Operation(
             summary = "회원 프로필 수정하기",
@@ -32,7 +32,7 @@ public class MemberPatchController {
             )
     {
         Long memberId = SecurityUtils.getCurrentMemberId();
-        memberUsecase.updateProfile(memberId, profileUpdateReqDTO);
+        memberFacade.updateProfile(memberId, profileUpdateReqDTO);
         return ApiResponse.response(
                 HttpStatus.OK,
                 ResponseMessage.MYPAGE_PROFILE_UPDATE_SUCCESS.getMessage(),

--- a/src/main/java/com/tavemakers/surf/domain/member/controller/MemberSearchController.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/controller/MemberSearchController.java
@@ -4,7 +4,7 @@ import com.tavemakers.surf.domain.member.dto.response.MemberSearchResDTO;
 import com.tavemakers.surf.domain.member.dto.response.MemberSearchSliceResDTO;
 import com.tavemakers.surf.domain.member.dto.response.MemberSimpleResDTO;
 import com.tavemakers.surf.domain.member.dto.response.MyPageProfileResDTO;
-import com.tavemakers.surf.domain.member.usecase.MemberUsecase;
+import com.tavemakers.surf.domain.member.facade.MemberFacade;
 import com.tavemakers.surf.global.common.response.ApiResponse;
 import com.tavemakers.surf.global.util.SecurityUtils;
 import io.swagger.v3.oas.annotations.Operation;
@@ -25,7 +25,7 @@ import static com.tavemakers.surf.domain.member.controller.ResponseMessage.*;
 @Tag(name = "회원 조회", description = "회원 조회 관련 API")
 public class MemberSearchController {
 
-    private final MemberUsecase memberUsecase;
+    private final MemberFacade memberFacade;
 
     //이름 기반 조회
     @Operation(
@@ -38,7 +38,7 @@ public class MemberSearchController {
         return ApiResponse.response(
                 HttpStatus.OK,
                 ResponseMessage.MEMBER_GROUP_SUCCESS.getFormattedMessage(name),
-                memberUsecase.findMemberByNameAndTrack(name));
+                memberFacade.findMemberByNameAndTrack(name));
     }
 
     //유저 전체 출력시 트랙+기수별 묶어서 출력
@@ -50,7 +50,7 @@ public class MemberSearchController {
         return ApiResponse.response(
                 HttpStatus.OK,
                 ResponseMessage.MEMBER_GROUP_SUCCESS.getMessage(),
-                memberUsecase.getMembersGroupedByTrack());
+                memberFacade.getMembersGroupedByTrack());
     }
 
     @Operation(
@@ -61,7 +61,7 @@ public class MemberSearchController {
             @RequestParam(required = false) Long memberId
     ) {
         memberId = (memberId == null ? SecurityUtils.getCurrentMemberId() : memberId);
-        MyPageProfileResDTO response = memberUsecase.getMyPageAndProfile(memberId);
+        MyPageProfileResDTO response = memberFacade.getMyPageAndProfile(memberId);
         return ApiResponse.response(HttpStatus.OK, MYPAGE_MY_PROFILE_READ.getMessage(), response);
     }
 
@@ -77,7 +77,7 @@ public class MemberSearchController {
             @RequestParam(required = false) Integer generation,
             @RequestParam(required = false) String part
     ) {
-        MemberSearchSliceResDTO response = memberUsecase.searchMembers(pageNum, pageSize, generation, part, keyword);
+        MemberSearchSliceResDTO response = memberFacade.searchMembers(pageNum, pageSize, generation, part, keyword);
         return ApiResponse.response(HttpStatus.OK, MEMBER_LIST_SEARCH_SUCCESS.getMessage(), response);
     }
 

--- a/src/main/java/com/tavemakers/surf/domain/member/facade/MemberAdminFacade.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/facade/MemberAdminFacade.java
@@ -1,4 +1,4 @@
-package com.tavemakers.surf.domain.member.usecase;
+package com.tavemakers.surf.domain.member.facade;
 
 import com.tavemakers.surf.domain.member.entity.Member;
 import com.tavemakers.surf.domain.member.entity.enums.MemberRole;
@@ -11,13 +11,13 @@ import com.tavemakers.surf.global.logging.LogEvent;
 import com.tavemakers.surf.global.logging.LogParam;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Service;
+import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
-@Service
+@Component
 @RequiredArgsConstructor
 @Slf4j
-public class MemberAdminUsecase {
+public class MemberAdminFacade {
 
     private final MemberPatchService memberPatchService;
     private final MemberGetService memberGetService;

--- a/src/main/java/com/tavemakers/surf/domain/member/facade/MemberFacade.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/facade/MemberFacade.java
@@ -1,12 +1,8 @@
-package com.tavemakers.surf.domain.member.usecase;
+package com.tavemakers.surf.domain.member.facade;
 
-import com.tavemakers.surf.domain.member.dto.request.CareerCreateReqDTO;
-import com.tavemakers.surf.domain.member.dto.request.CareerUpdateReqDTO;
 import com.tavemakers.surf.domain.member.dto.request.MemberSignupReqDTO;
-import com.tavemakers.surf.domain.member.dto.response.*;
 import com.tavemakers.surf.domain.member.dto.request.ProfileUpdateReqDTO;
-import com.tavemakers.surf.domain.member.dto.response.MyPageProfileResDTO;
-import com.tavemakers.surf.domain.member.dto.response.TrackResDTO;
+import com.tavemakers.surf.domain.member.dto.response.*;
 import com.tavemakers.surf.domain.member.entity.Member;
 import com.tavemakers.surf.domain.member.entity.Track;
 import com.tavemakers.surf.domain.member.entity.enums.MemberRole;
@@ -24,7 +20,7 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
-import org.springframework.stereotype.Service;
+import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
@@ -33,10 +29,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-@Service
+@Component
 @RequiredArgsConstructor
 @Slf4j
-public class MemberUsecase {
+public class MemberFacade {
 
     private final MemberGetService memberGetService;
     private final TrackGetService trackGetService;
@@ -49,26 +45,23 @@ public class MemberUsecase {
     private final MemberService memberService;
     private final ApplicationContext context;
 
-    /** 마이페이지 + 프로필 조회 */
     public MyPageProfileResDTO getMyPageAndProfile(Long targetId) {
         Member member = memberGetService.getMemberByStatus(targetId,MemberStatus.APPROVED);
         List<TrackResDTO> myTracks = getMyTracks(targetId);
         List<CareerResDTO> myCareers = getMyCareers(targetId);
 
-        if (member.isNotOwner()) { // SURF Rule - 타인의 활동점수는 조회 불가
+        if (member.isNotOwner()) {
             return MyPageProfileResDTO.of(member, myTracks, null, myCareers);
         }
 
         BigDecimal score = null;
-        if (member.isActive()) { // SURF Rule - 활동 중인 회원만 활동점수를 보여준다.
+        if (member.isActive()) {
             score = personalScoreGetService.getPersonalScore(targetId).getScore();
         }
 
         return MyPageProfileResDTO.of(member, myTracks, score, myCareers);
     }
 
-
-    /** 이름으로 회원 검색 후 각 회원의 트랙 정보를 DTO로 반환하는 메소드 **/
     public List<MemberSearchResDTO> findMemberByNameAndTrack(String name) {
         List<Member> members = memberGetService.getMemberByName(name);
         if (members.isEmpty()) {
@@ -79,7 +72,6 @@ public class MemberUsecase {
 
         List<Track> latestTracks = trackGetService.getTrack(memberIds);
 
-        // 조회된 최신 트랙들을 Member ID를 Key로 하는 Map으로 변환
         Map<Long, Track> trackMap = latestTracks.stream()
                 .collect(Collectors.toMap(track -> track.getMember().getId(), track -> track));
 
@@ -91,14 +83,12 @@ public class MemberUsecase {
                 throw new TrackNotFoundException ("해당 회원의 트랙을 찾을 수 없습니다. 이름/id : " + member.getName() + "/" +member.getId());
             }
 
-            //현재는 기수까지 불러오고 있는데 추후에 기수가 필요하지 않다면 삭제 가능
             result.add(MemberSearchResDTO.of(member, latestTrack.getGeneration(), latestTrack.getPart().toString()));
         }
 
         return result;
     }
 
-    /** 트랙+기수별 회원 묶기 */
     public Map<String, List<MemberSimpleResDTO>> getMembersGroupedByTrack() {
         return trackGetService.getAllTracksWithMember().stream()
                 .collect(Collectors.groupingBy(
@@ -110,7 +100,6 @@ public class MemberUsecase {
                 ));
     }
 
-    //프로필 수정
     @LogEvent(value = "member.profile_update", message = "회원 정보 수정")
     @Transactional
     public void updateProfile(@LogParam("member_id") Long memberId,
@@ -118,26 +107,21 @@ public class MemberUsecase {
 
         Member member = memberGetService.getMember(memberId);
 
-        // 프로필 정보 수정
         memberPatchService.updateProfile(member, dto);
 
-        // 경력 수정
         if (dto.careersToUpdate() != null) {
             careerPatchService.updateCareer(member, dto.careersToUpdate());
         }
 
-        // 경력 삭제
         if (dto.careerIdsToDelete() != null) {
             careerDeleteService.deleteCareer(member, dto.careerIdsToDelete());
         }
 
-        // 경력 생성
         if (dto.careersToCreate() != null) {
             careerPostService.createCareer(member, dto.careersToCreate());
         }
     }
 
-    /** 온보딩 필요 여부 확인 */
     @Transactional(readOnly = true)
     public OnboardingCheckResDTO needsOnboarding(
             Long memberId
@@ -153,7 +137,6 @@ public class MemberUsecase {
         return dto;
     }
 
-    /** 회원가입 요청 및 MemberStatus에 따른 로그 분기 */
     @Transactional
     public MemberSignupResDTO signup(
             Long memberId,
@@ -162,7 +145,7 @@ public class MemberUsecase {
         Member member = memberGetService.getMember(memberId);
         MemberStatus status = member.getStatus();
 
-        MemberUsecase proxy = context.getBean(MemberUsecase.class);
+        MemberFacade proxy = context.getBean(MemberFacade.class);
 
         if (status == MemberStatus.APPROVED) {
             MemberSignupResDTO dto = MemberSignupResDTO.from(member);
@@ -183,14 +166,12 @@ public class MemberUsecase {
 
     }
 
-    /** 회원가입 create 로그 (온보딩) */
     @Transactional
     @LogEvent(value = "signup.create", message = "회원가입 요청 처리")
     public MemberSignupResDTO signupCreate(Member member, MemberSignupReqDTO request) {
         return memberService.signup(member, request);
     }
 
-    /** 회원가입 성공 */
     @Transactional
     @LogEvent(value = "signup.succeeded", message = "회원가입 성공")
     public MemberSignupResDTO signupSucceeded(
@@ -200,7 +181,6 @@ public class MemberUsecase {
         return response;
     }
 
-    /** 회원가입 실패 */
     @Transactional
     @LogEvent(value = "signup.failed", message = "회원가입 실패")
     public MemberSignupResDTO signupFailed(
@@ -230,7 +210,7 @@ public class MemberUsecase {
         Slice<MemberSearchDetailResDTO> slice = search(generation, memberPart, keyword, pageable);
 
         Long totalCount = null;
-        if (pageNum == 0) { // FRONTEND 협의 - 0번째 페이지에서만 검색조건에 따른 전체 회원수 조회.
+        if (pageNum == 0) {
             totalCount = memberGetService.countSearchingMembers(generation, memberPart, keyword);
         }
 

--- a/src/main/java/com/tavemakers/surf/domain/notification/controller/DeviceTokenPostController.java
+++ b/src/main/java/com/tavemakers/surf/domain/notification/controller/DeviceTokenPostController.java
@@ -5,7 +5,7 @@ import static com.tavemakers.surf.domain.notification.controller.ResponseMessage
 
 import com.tavemakers.surf.domain.member.entity.CustomUserDetails;
 import com.tavemakers.surf.domain.notification.dto.req.DeviceTokenReqDTO;
-import com.tavemakers.surf.domain.notification.service.DeviceTokenRegisterService;
+import com.tavemakers.surf.domain.notification.facade.NotificationFacade;
 import com.tavemakers.surf.global.common.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -22,7 +22,7 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/v1/user/notifications")
 public class DeviceTokenPostController {
 
-    private final DeviceTokenRegisterService deviceTokenRegisterService;
+    private final NotificationFacade notificationFacade;
 
     @Operation(
             summary = "디바이스 FCM 토큰 등록",
@@ -41,7 +41,7 @@ public class DeviceTokenPostController {
             @AuthenticationPrincipal CustomUserDetails user,
             @Valid @RequestBody DeviceTokenReqDTO dto
     ) {
-        deviceTokenRegisterService.register(user.getMember().getId(), dto);
+        notificationFacade.registerDeviceToken(user.getMember().getId(), dto);
         return ApiResponse.response(
                 HttpStatus.OK,
                 DEVICE_TOKEN_SUCCESS.getMessage()

--- a/src/main/java/com/tavemakers/surf/domain/notification/controller/FcmTestController.java
+++ b/src/main/java/com/tavemakers/surf/domain/notification/controller/FcmTestController.java
@@ -3,7 +3,7 @@ package com.tavemakers.surf.domain.notification.controller;
 import static com.tavemakers.surf.domain.notification.controller.ResponseMessage.FCM_TEST_SUCCESS;
 
 import com.tavemakers.surf.domain.notification.dto.req.FcmTestReqDTO;
-import com.tavemakers.surf.domain.notification.service.FcmService;
+import com.tavemakers.surf.domain.notification.facade.NotificationFacade;
 import com.tavemakers.surf.global.common.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/v1/user/notifications")
 public class FcmTestController {
 
-    private final FcmService fcmService;
+    private final NotificationFacade notificationFacade;
 
     @Operation(
             summary = "FCM 푸시 알림 테스트",
@@ -36,7 +36,7 @@ public class FcmTestController {
             )
             @RequestBody FcmTestReqDTO req
     ) {
-        fcmService.sendToMember(req.memberId(), req.title(), req.body(), 1L);
+        notificationFacade.sendPushToMember(req.memberId(), req.title(), req.body(), 1L);
         return ApiResponse.response(
                 HttpStatus.OK,
                 FCM_TEST_SUCCESS.getMessage()

--- a/src/main/java/com/tavemakers/surf/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/tavemakers/surf/domain/notification/controller/NotificationController.java
@@ -2,7 +2,7 @@ package com.tavemakers.surf.domain.notification.controller;
 
 import com.tavemakers.surf.domain.notification.dto.res.NotificationResDTO;
 import com.tavemakers.surf.domain.notification.entity.NotificationCategory;
-import com.tavemakers.surf.domain.notification.service.NotificationService;
+import com.tavemakers.surf.domain.notification.facade.NotificationFacade;
 import com.tavemakers.surf.global.common.response.ApiResponse;
 import com.tavemakers.surf.global.util.SecurityUtils;
 import io.swagger.v3.oas.annotations.Operation;
@@ -21,7 +21,7 @@ import static com.tavemakers.surf.domain.notification.controller.ResponseMessage
 @Tag(name = "알람")
 public class NotificationController {
 
-    private final NotificationService notificationService;
+    private final NotificationFacade notificationFacade;
 
     @Operation(summary = "알람 조회", description = "category 파라미터로 카테고리별 필터링 조회합니다. null일 경우 전체 알람 조회")
     @GetMapping("/v1/user/notifications")
@@ -29,7 +29,7 @@ public class NotificationController {
             @RequestParam(required = false) NotificationCategory category
     ) {
         Long memberId = SecurityUtils.getCurrentMemberId();
-        List<NotificationResDTO> response = notificationService.getNotifications(memberId, category);
+        List<NotificationResDTO> response = notificationFacade.getNotifications(memberId, category);
         return ApiResponse.response(HttpStatus.OK, NOTIFICATION_READ.getMessage(), response);
     }
 
@@ -39,7 +39,7 @@ public class NotificationController {
             @PathVariable Long notificationId
     ) {
         Long memberId = SecurityUtils.getCurrentMemberId();
-        notificationService.markAsRead(notificationId, memberId);
+        notificationFacade.markAsRead(notificationId, memberId);
         return ApiResponse.response(HttpStatus.OK, NOTIFICATION_READ_MARK.getMessage());
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/notification/facade/NotificationFacade.java
+++ b/src/main/java/com/tavemakers/surf/domain/notification/facade/NotificationFacade.java
@@ -1,0 +1,40 @@
+package com.tavemakers.surf.domain.notification.facade;
+
+import com.tavemakers.surf.domain.notification.dto.req.DeviceTokenReqDTO;
+import com.tavemakers.surf.domain.notification.dto.res.NotificationResDTO;
+import com.tavemakers.surf.domain.notification.entity.NotificationCategory;
+import com.tavemakers.surf.domain.notification.service.DeviceTokenRegisterService;
+import com.tavemakers.surf.domain.notification.service.FcmService;
+import com.tavemakers.surf.domain.notification.service.NotificationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class NotificationFacade {
+
+    private final NotificationService notificationService;
+    private final DeviceTokenRegisterService deviceTokenRegisterService;
+    private final FcmService fcmService;
+
+    // NotificationService
+    public List<NotificationResDTO> getNotifications(Long memberId, NotificationCategory category) {
+        return notificationService.getNotifications(memberId, category);
+    }
+
+    public void markAsRead(Long notificationId, Long memberId) {
+        notificationService.markAsRead(notificationId, memberId);
+    }
+
+    // DeviceTokenRegisterService
+    public void registerDeviceToken(Long memberId, DeviceTokenReqDTO dto) {
+        deviceTokenRegisterService.register(memberId, dto);
+    }
+
+    // FcmService
+    public void sendPushToMember(Long memberId, String title, String body, Long notificationId) {
+        fcmService.sendToMember(memberId, title, body, notificationId);
+    }
+}

--- a/src/main/java/com/tavemakers/surf/domain/post/controller/PostLikeController.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/controller/PostLikeController.java
@@ -1,8 +1,8 @@
 package com.tavemakers.surf.domain.post.controller;
 
 import com.tavemakers.surf.domain.post.dto.res.PostLikeListResDTO;
+import com.tavemakers.surf.domain.post.facade.PostFacade;
 import com.tavemakers.surf.domain.post.service.PostLikeService;
-import com.tavemakers.surf.domain.post.service.PostUsecase;
 import com.tavemakers.surf.global.common.response.ApiResponse;
 import com.tavemakers.surf.global.util.SecurityUtils;
 import io.swagger.v3.oas.annotations.Operation;
@@ -24,7 +24,7 @@ import static com.tavemakers.surf.domain.post.controller.ResponseMessage.POST_LI
 public class PostLikeController {
 
     private final PostLikeService postLikeService;
-    private final PostUsecase postUsecase;
+    private final PostFacade postFacade;
 
     @Operation(summary = "좋아요 설정", description = "이미 좋아요 상태여도 200(OK) 반환")
     @PostMapping("/v1/user/posts/{postId}/like")
@@ -45,6 +45,6 @@ public class PostLikeController {
     @Operation(summary = "특정 게시글 좋아요 리스트", description = "특정 게시글에 좋아요를 누른 유저의 리스트 반환")
     @GetMapping("/v1/user/posts/{postId}/like")
     public ApiResponse<PostLikeListResDTO> likePostList(@PathVariable Long postId) {
-        return ApiResponse.response(HttpStatus.OK,POST_LIKES_READ.getMessage() ,postUsecase.getPostLikes(postId));
+        return ApiResponse.response(HttpStatus.OK,POST_LIKES_READ.getMessage() ,postFacade.getPostLikes(postId));
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/post/controller/ScheduleDeleteController.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/controller/ScheduleDeleteController.java
@@ -2,7 +2,7 @@ package com.tavemakers.surf.domain.post.controller;
 
 import static com.tavemakers.surf.domain.post.controller.ResponseMessage.SCHEDULE_DELETED;
 
-import com.tavemakers.surf.domain.post.service.ScheduleUseCase;
+import com.tavemakers.surf.domain.post.facade.ScheduleFacade;
 import com.tavemakers.surf.global.common.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -18,12 +18,12 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping
 @Tag(name = "일정", description = "일정 관련 API")
 public class ScheduleDeleteController {
-    private final ScheduleUseCase scheduleUseCase;
+    private final ScheduleFacade scheduleFacade;
 
     @Operation(summary = "개별 일정 삭제", description = "일정을 삭제합니다.")
     @DeleteMapping("/v1/admin/schedules/{scheduleId}")
     public ApiResponse<Void> deleteSchedule(@PathVariable("scheduleId") Long scheduleId) {
-        scheduleUseCase.deleteSchedule(scheduleId);
+        scheduleFacade.deleteSchedule(scheduleId);
         return ApiResponse.response(HttpStatus.OK, SCHEDULE_DELETED.getMessage(), null);
     }
 
@@ -32,7 +32,7 @@ public class ScheduleDeleteController {
     public ApiResponse<Void> deleteScheduleAtPost(
             @PathVariable("postId") Long postId,
             @PathVariable("scheduleId") Long scheduleId) {
-        scheduleUseCase.deleteScheduleAtPost(postId, scheduleId);
+        scheduleFacade.deleteScheduleAtPost(postId, scheduleId);
         return ApiResponse.response(HttpStatus.OK, SCHEDULE_DELETED.getMessage(), null);
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/post/controller/ScheduleGetController.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/controller/ScheduleGetController.java
@@ -8,8 +8,8 @@ import static com.tavemakers.surf.domain.post.controller.ResponseMessage.SCHEDUL
 import com.tavemakers.surf.domain.post.dto.req.ScheduleCreateReqDTO;
 import com.tavemakers.surf.domain.post.dto.res.ScheduleMonthlyResDTO;
 import com.tavemakers.surf.domain.post.dto.res.ScheduleResDTO;
+import com.tavemakers.surf.domain.post.facade.ScheduleFacade;
 import com.tavemakers.surf.domain.post.service.ScheduleGetService;
-import com.tavemakers.surf.domain.post.service.ScheduleUseCase;
 import com.tavemakers.surf.global.common.response.ApiResponse;
 import com.tavemakers.surf.global.util.SecurityUtils;
 import io.swagger.v3.oas.annotations.Operation;
@@ -33,7 +33,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class ScheduleGetController {
 
     private final ScheduleGetService scheduleGetService;
-    private final ScheduleUseCase scheduleUseCase;
+    private final ScheduleFacade scheduleFacade;
 
     @Operation(summary = "캘린더에 월별 일정 목록 조회", description = "캘린더 페이지에서 월별 일정을 조회합니다.")
     @GetMapping("/v1/user/calendar/schedules")
@@ -47,7 +47,7 @@ public class ScheduleGetController {
     @Operation(summary = "특정 게시글 일정 조회", description = "특정 게시글에 매핑된 일정이 있을 경우 반환")
     @GetMapping("/v1/user/post/{postId}/schedule")
     public ApiResponse<ScheduleResDTO> getScheduleByPost(@PathVariable Long postId) {
-        ScheduleResDTO dto = scheduleUseCase.getScheduleByPost(postId);
+        ScheduleResDTO dto = scheduleFacade.getScheduleByPost(postId);
         return ApiResponse.response(HttpStatus.OK, SCHEDULE_POST_READ.getMessage(),dto);
     }
 

--- a/src/main/java/com/tavemakers/surf/domain/post/controller/SchedulePatchController.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/controller/SchedulePatchController.java
@@ -3,7 +3,7 @@ package com.tavemakers.surf.domain.post.controller;
 import static com.tavemakers.surf.domain.post.controller.ResponseMessage.SCHEDULE_UPDATED;
 
 import com.tavemakers.surf.domain.post.dto.req.ScheduleUpdateReqDTO;
-import com.tavemakers.surf.domain.post.service.ScheduleUseCase;
+import com.tavemakers.surf.domain.post.facade.ScheduleFacade;
 import com.tavemakers.surf.global.common.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -21,13 +21,13 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping
 @Tag(name = "일정", description = "일정 관련 API")
 public class SchedulePatchController {
-    private final ScheduleUseCase scheduleUseCase;
+    private final ScheduleFacade scheduleFacade;
 
     @Operation(summary = "개별 일정 수정", description = "일정을 수정합니다.")
     @PatchMapping("/v1/admin/schedules/{scheduleId}")
     public ApiResponse<Void> updateSchedule(@PathVariable("scheduleId") Long scheduleId, @RequestBody @Valid
     ScheduleUpdateReqDTO reqDTO) {
-        scheduleUseCase.updateSchedule(reqDTO, scheduleId);
+        scheduleFacade.updateSchedule(reqDTO, scheduleId);
         return ApiResponse.response(HttpStatus.OK, SCHEDULE_UPDATED.getMessage(), null);
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/post/controller/SchedulePostController.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/controller/SchedulePostController.java
@@ -3,7 +3,7 @@ package com.tavemakers.surf.domain.post.controller;
 import static com.tavemakers.surf.domain.post.controller.ResponseMessage.SCHEDULE_CREATED;
 
 import com.tavemakers.surf.domain.post.dto.req.ScheduleCreateReqDTO;
-import com.tavemakers.surf.domain.post.service.ScheduleUseCase;
+import com.tavemakers.surf.domain.post.facade.ScheduleFacade;
 import com.tavemakers.surf.global.common.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -21,13 +21,13 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping
 @Tag(name = "일정", description = "일정 관련 API")
 public class SchedulePostController {
-    private final ScheduleUseCase scheduleUseCase;
+    private final ScheduleFacade scheduleFacade;
 
     @Operation(summary = "게시글 작성 시 일정 생성", description = "공지사항 게시글 작성시 일정을 생성합니다.")
     @PostMapping("/v1/admin/posts/{postId}/schedules")
     public ApiResponse<Void> createScheduleAtPost(
             @PathVariable Long postId, @RequestBody @Valid ScheduleCreateReqDTO dto) {
-        scheduleUseCase.createScheduleAtPost(dto, postId);
+        scheduleFacade.createScheduleAtPost(dto, postId);
         return ApiResponse.response(HttpStatus.CREATED, SCHEDULE_CREATED.getMessage(),null);
     }
 
@@ -35,7 +35,7 @@ public class SchedulePostController {
     @PostMapping("/v1/admin/calendar/schedules")
     public ApiResponse<Void> createScheduleAtCalendar(
          @RequestBody @Valid ScheduleCreateReqDTO dto) {
-        scheduleUseCase.createScheduleSingle(dto);
+        scheduleFacade.createScheduleSingle(dto);
         return ApiResponse.response(HttpStatus.CREATED, SCHEDULE_CREATED.getMessage(),null);
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/post/facade/PostFacade.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/facade/PostFacade.java
@@ -1,16 +1,18 @@
-package com.tavemakers.surf.domain.post.service;
+package com.tavemakers.surf.domain.post.facade;
 
 import com.tavemakers.surf.domain.post.dto.res.PostLikeListResDTO;
+import com.tavemakers.surf.domain.post.service.PostGetService;
+import com.tavemakers.surf.domain.post.service.PostLikeGetService;
 import com.tavemakers.surf.global.logging.LogEvent;
 import com.tavemakers.surf.global.logging.LogParam;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
+import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
-@Service
+@Component
 @RequiredArgsConstructor
 @Transactional
-public class PostUsecase {
+public class PostFacade {
     private final PostGetService postGetService;
     private final PostLikeGetService postLikeGetService;
 

--- a/src/main/java/com/tavemakers/surf/domain/post/facade/ScheduleFacade.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/facade/ScheduleFacade.java
@@ -1,17 +1,23 @@
-package com.tavemakers.surf.domain.post.service;
+package com.tavemakers.surf.domain.post.facade;
 
 import com.tavemakers.surf.domain.post.dto.req.ScheduleCreateReqDTO;
 import com.tavemakers.surf.domain.post.dto.req.ScheduleUpdateReqDTO;
 import com.tavemakers.surf.domain.post.dto.res.ScheduleResDTO;
 import com.tavemakers.surf.domain.post.entity.Post;
 import com.tavemakers.surf.domain.post.entity.Schedule;
+import com.tavemakers.surf.domain.post.service.PostGetService;
+import com.tavemakers.surf.domain.post.service.PostService;
+import com.tavemakers.surf.domain.post.service.ScheduleCreateService;
+import com.tavemakers.surf.domain.post.service.ScheduleDeleteService;
+import com.tavemakers.surf.domain.post.service.ScheduleGetService;
+import com.tavemakers.surf.domain.post.service.SchedulePatchService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
+import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
-@Service
+@Component
 @RequiredArgsConstructor
-public class ScheduleUseCase {
+public class ScheduleFacade {
 
     private final ScheduleCreateService scheduleCreateService;
     private final ScheduleGetService scheduleGetService;
@@ -20,7 +26,6 @@ public class ScheduleUseCase {
     private final PostService postService;
     private final PostGetService postGetService;
 
-    //게시글 생성 시 일정 생성
     @Transactional
     public void createScheduleAtPost(ScheduleCreateReqDTO dto, Long postId) {
         Post post = postService.findPostById(postId);
@@ -28,27 +33,23 @@ public class ScheduleUseCase {
         post.addScheduleId(scheduleId);
     }
 
-    //개별 일정 생성(캘린더에서)
     @Transactional
     public void createScheduleSingle(ScheduleCreateReqDTO dto){
         scheduleCreateService.createScheduleSingle(dto);
     }
 
-    //일정 수정
     @Transactional
     public void updateSchedule(ScheduleUpdateReqDTO dto, Long id) {
         Schedule schedule = scheduleGetService.getScheduleById(id);
         schedulePatchService.updateSchedule(schedule, dto);
     }
 
-    //일정 삭제 - 개별
     @Transactional
     public void deleteSchedule(Long id) {
         Schedule schedule = scheduleGetService.getScheduleById(id);
         scheduleDeleteService.deleteSchedule(schedule);
     }
 
-    //일정 삭제 - 게시글과 매핑
     @Transactional
     public void deleteScheduleAtPost(Long postId, Long scheduleId) {
         Schedule schedule = scheduleGetService.getScheduleById(scheduleId);
@@ -59,7 +60,6 @@ public class ScheduleUseCase {
         schedulePatchService.updateScheduleIdNull(post);
     }
 
-    //게시글별 일정 조회
     @Transactional(readOnly = true)
     public ScheduleResDTO getScheduleByPost(Long postId) {
            return scheduleGetService.getScheduleSingleDTO(postId);

--- a/src/main/java/com/tavemakers/surf/domain/post/service/PostService.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/service/PostService.java
@@ -28,7 +28,7 @@ import com.tavemakers.surf.domain.post.exception.PostNotFoundException;
 import com.tavemakers.surf.domain.post.repository.PostLikeRepository;
 import com.tavemakers.surf.domain.post.repository.PostRepository;
 import com.tavemakers.surf.domain.post.repository.ScheduleRepository;
-import com.tavemakers.surf.domain.reservation.usecase.ReservationUsecase;
+import com.tavemakers.surf.domain.reservation.facade.ReservationFacade;
 import com.tavemakers.surf.domain.scrap.repository.ScrapRepository;
 import com.tavemakers.surf.domain.scrap.service.ScrapService;
 import com.tavemakers.surf.global.logging.LogEvent;
@@ -64,7 +64,7 @@ public class PostService {
 
     private final ScrapService scrapService;
     private final PostLikeService postLikeService;
-    private final ReservationUsecase reservationUsecase;
+    private final ReservationFacade reservationFacade;
     private final PostImageSaveService imageSaveService;
     private final PostImageGetService imageGetService;
     private final PostImageDeleteService imageDeleteService;
@@ -92,7 +92,7 @@ public class PostService {
 
         LocalDateTime reservedAt = null;
         if (req.isReserved()) {
-            reservationUsecase.reservePost(saved.getId(), req.reservedAt());
+            reservationFacade.reservePost(saved.getId(), req.reservedAt());
             reservedAt = req.reservedAt();
         } else{
             eventPublisher.publishEvent(
@@ -121,7 +121,7 @@ public class PostService {
         int viewCount = viewCountService.increaseViewCount(post, memberId);
         LocalDateTime reservedAt = null;
         if (post.isReserved()) {
-            reservedAt = reservationUsecase.getReservedAt(postId);
+            reservedAt = reservationFacade.getReservedAt(postId);
         }
 
         return PostDetailResDTO.of(post, scrappedByMe, likedByMe, isMine, imageUrlList, reservedAt, viewCount);
@@ -229,12 +229,12 @@ public class PostService {
 
         // 예약 시간 변경 시 -> 기존의 예약 시간 조회 -> 기존의 예약 시간을 CANCELD로 수정하고 schedule 호출하면 끝.
         if (req.isReservationChanged()) {
-            reservationUsecase.updateReservationPost(post.getId(), req.reservedAt());
+            reservationFacade.updateReservationPost(post.getId(), req.reservedAt());
         }
 
         LocalDateTime reservedAt = null;
         if (post.isReserved()) {
-            reservedAt = reservationUsecase.getReservedAt(postId);
+            reservedAt = reservationFacade.getReservedAt(postId);
         }
 
         // 이미지 변경

--- a/src/main/java/com/tavemakers/surf/domain/reservation/facade/ReservationFacade.java
+++ b/src/main/java/com/tavemakers/surf/domain/reservation/facade/ReservationFacade.java
@@ -1,4 +1,4 @@
-package com.tavemakers.surf.domain.reservation.usecase;
+package com.tavemakers.surf.domain.reservation.facade;
 
 import com.tavemakers.surf.domain.reservation.entity.Reservation;
 import com.tavemakers.surf.domain.reservation.service.ReservationGetService;
@@ -6,7 +6,7 @@ import com.tavemakers.surf.domain.reservation.service.ReservationSaveService;
 import com.tavemakers.surf.domain.reservation.service.ReservationScheduleService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Service;
+import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
@@ -14,9 +14,9 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 
 @Slf4j
-@Service
+@Component
 @RequiredArgsConstructor
-public class ReservationUsecase {
+public class ReservationFacade {
 
     private final ReservationSaveService reservationSaveService;
     private final ReservationGetService reservationGetService;

--- a/src/main/java/com/tavemakers/surf/domain/score/controller/PersonalScoreController.java
+++ b/src/main/java/com/tavemakers/surf/domain/score/controller/PersonalScoreController.java
@@ -1,7 +1,7 @@
 package com.tavemakers.surf.domain.score.controller;
 
 import com.tavemakers.surf.domain.score.dto.response.PersonalScoreWithPinnedResDto;
-import com.tavemakers.surf.domain.score.usecase.PersonalScoreUsecase;
+import com.tavemakers.surf.domain.score.facade.PersonalScoreFacade;
 import com.tavemakers.surf.global.common.response.ApiResponse;
 import com.tavemakers.surf.global.util.SecurityUtils;
 import io.swagger.v3.oas.annotations.Operation;
@@ -18,7 +18,7 @@ import static com.tavemakers.surf.domain.score.controller.ResponseMessage.*;
 @Tag(name = "활동점수")
 public class PersonalScoreController {
 
-    private final PersonalScoreUsecase personalScoreUsecase;
+    private final PersonalScoreFacade personalScoreFacade;
 
     @Operation(
             summary = "[활동점수] + 고정 5개[활동기록] 조회)",
@@ -28,7 +28,7 @@ public class PersonalScoreController {
     public ApiResponse<PersonalScoreWithPinnedResDto> getScoreAndPinned5(
     ) {
         PersonalScoreWithPinnedResDto response =
-                personalScoreUsecase.findPersonalScoreAndPinned(SecurityUtils.getCurrentMemberId());
+                personalScoreFacade.findPersonalScoreAndPinned(SecurityUtils.getCurrentMemberId());
         return ApiResponse.response(HttpStatus.OK, SCORE_AND_PINNED_READ.getMessage(), response);
     }
 

--- a/src/main/java/com/tavemakers/surf/domain/score/facade/PersonalScoreFacade.java
+++ b/src/main/java/com/tavemakers/surf/domain/score/facade/PersonalScoreFacade.java
@@ -1,4 +1,4 @@
-package com.tavemakers.surf.domain.score.usecase;
+package com.tavemakers.surf.domain.score.facade;
 
 import com.tavemakers.surf.domain.activity.dto.response.ActivityRecordSummaryResDTO;
 import com.tavemakers.surf.domain.activity.entity.ActivityRecord;
@@ -8,20 +8,19 @@ import com.tavemakers.surf.domain.score.dto.response.PersonalScoreWithPinnedResD
 import com.tavemakers.surf.domain.score.entity.PersonalActivityScore;
 import com.tavemakers.surf.domain.score.service.PersonalScoreGetService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
+import org.springframework.stereotype.Component;
 
 import java.util.List;
 
-@Service
+@Component
 @RequiredArgsConstructor
-public class PersonalScoreUsecase {
+public class PersonalScoreFacade {
 
     private final PersonalScoreGetService personalScoreGetService;
     private final ActivityRecordGetService activityRecordGetService;
     private final ActivityRecordMapper activityRecordMapper;
 
     public PersonalScoreWithPinnedResDto findPersonalScoreAndPinned(Long memberId) {
-        // 개인 점수, 고정 활동기록 조회
         PersonalActivityScore personalScore = personalScoreGetService.getPersonalScore(memberId);
 
         List<ActivityRecord> list = activityRecordGetService.findAllByMemberId(memberId);

--- a/src/main/java/com/tavemakers/surf/domain/scrap/controller/ScrapController.java
+++ b/src/main/java/com/tavemakers/surf/domain/scrap/controller/ScrapController.java
@@ -1,7 +1,7 @@
 package com.tavemakers.surf.domain.scrap.controller;
 
 import com.tavemakers.surf.domain.post.dto.res.PostResDTO;
-import com.tavemakers.surf.domain.scrap.service.ScrapService;
+import com.tavemakers.surf.domain.scrap.facade.ScrapFacade;
 import com.tavemakers.surf.global.common.response.ApiResponse;
 import com.tavemakers.surf.global.util.SecurityUtils;
 import io.swagger.v3.oas.annotations.Operation;
@@ -22,14 +22,14 @@ import static com.tavemakers.surf.domain.scrap.controller.ResponseMessage.*;
 @Tag(name = "스크랩", description = "추후 MVP를 통해 디벨롭 될 예정")
 public class ScrapController {
 
-    private final ScrapService scrapService;
+    private final ScrapFacade scrapFacade;
 
     /** 스크랩 추가 (현재 로그인 사용자 기준) */
     @Operation(summary = "스크랩 추가", description = "특정 게시글을 스크랩합니다.")
     @PostMapping("/v1/user/scraps/{postId}")
     public ApiResponse<Void> addScrap(@PathVariable Long postId) {
         Long me = SecurityUtils.getCurrentMemberId();
-        scrapService.addScrap(me, postId);
+        scrapFacade.addScrap(me, postId);
         return ApiResponse.response(HttpStatus.CREATED, SCRAP_CREATED.getMessage());
     }
 
@@ -38,7 +38,7 @@ public class ScrapController {
     @DeleteMapping("/v1/user/scraps/{postId}")
     public ApiResponse<Void> removeScrap(@PathVariable Long postId) {
         Long me = SecurityUtils.getCurrentMemberId();
-        scrapService.removeScrap(me, postId);
+        scrapFacade.removeScrap(me, postId);
         return ApiResponse.response(HttpStatus.NO_CONTENT, SCRAP_DELETED.getMessage());
     }
 
@@ -50,7 +50,7 @@ public class ScrapController {
             Pageable pageable
     ) {
         Long me = SecurityUtils.getCurrentMemberId();
-        Slice<PostResDTO> response = scrapService.getMyScraps(me, pageable);
+        Slice<PostResDTO> response = scrapFacade.getMyScraps(me, pageable);
         return ApiResponse.response(HttpStatus.OK, MY_SCRAP_LIST_READ.getMessage(), response);
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/scrap/facade/ScrapFacade.java
+++ b/src/main/java/com/tavemakers/surf/domain/scrap/facade/ScrapFacade.java
@@ -1,0 +1,30 @@
+package com.tavemakers.surf.domain.scrap.facade;
+
+import com.tavemakers.surf.domain.post.dto.res.PostResDTO;
+import com.tavemakers.surf.domain.scrap.service.ScrapService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ScrapFacade {
+    private final ScrapService scrapService;
+
+    public void addScrap(Long memberId, Long postId) {
+        scrapService.addScrap(memberId, postId);
+    }
+
+    public void removeScrap(Long memberId, Long postId) {
+        scrapService.removeScrap(memberId, postId);
+    }
+
+    public Slice<PostResDTO> getMyScraps(Long memberId, Pageable pageable) {
+        return scrapService.getMyScraps(memberId, pageable);
+    }
+
+    public boolean isScrappedByMe(Long memberId, Long postId) {
+        return scrapService.isScrappedByMe(memberId, postId);
+    }
+}


### PR DESCRIPTION
## 📄 작업 내용 요약
- 도메인별 `usecase/service` 책임을 `facade` 계층으로 이관
- 컨트롤러 호출 경로를 `facade`로 정리
- 신규 `facade` 추가 및 기존 `usecase` 리네임

## 📎 Issue 번호
closed #233

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 리팩토링

* 시스템의 여러 도메인에서 내부 아키텍처를 개선했습니다.
* 활동 기록, 배지, 게시판, 댓글, 피드백, 홈, 로그인, 회원, 알림, 게시물, 점수, 스크랩 등 주요 기능들의 서비스 계층 구조를 정리했습니다.
* 모든 기존 기능은 정상 작동하며, 사용자 경험에는 변화가 없습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->