### PR TITLE
[Feat] 가입신청한 회원 목록 API 구현

### DIFF
--- a/src/main/java/com/tavemakers/surf/domain/member/controller/AdminController.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/controller/AdminController.java
@@ -4,6 +4,7 @@ import com.tavemakers.surf.domain.member.dto.request.AdminPageLoginReqDto;
 import com.tavemakers.surf.domain.member.dto.request.PasswordReqDto;
 import com.tavemakers.surf.domain.member.dto.request.RoleChangeRequestDto;
 import com.tavemakers.surf.domain.member.dto.response.AdminPageLoginResDto;
+import com.tavemakers.surf.domain.member.dto.response.MemberRegistrationSliceResDTO;
 import com.tavemakers.surf.domain.member.usecase.MemberAdminUsecase;
 import io.swagger.v3.oas.annotations.Operation;
 import com.tavemakers.surf.global.common.response.ApiResponse;
@@ -14,8 +15,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
-import static com.tavemakers.surf.domain.member.controller.ResponseMessage.ADMIN_PAGE_LOGIN_SUCCESS;
-import static com.tavemakers.surf.domain.member.controller.ResponseMessage.MANAGER_PASSWORD_SET_UP_SUCCESS;
+import static com.tavemakers.surf.domain.member.controller.ResponseMessage.*;
 
 @Tag(name = "관리자", description = "관리자용 API")
 @RestController
@@ -50,6 +50,16 @@ public class AdminController {
     ) {
         AdminPageLoginResDto data = memberAdminUsecase.loginAdminHomePage(dto, response);
         return ApiResponse.response(HttpStatus.OK, ADMIN_PAGE_LOGIN_SUCCESS.getMessage(),data);
+    }
+
+    @Operation(summary = "가입신청 목록", description = "가입신청 목록을 조회합니다.")
+    @GetMapping("/v1/manager/registration-list")
+    public ApiResponse<MemberRegistrationSliceResDTO> readRegistrationList (
+            @RequestParam int pageSize,
+            @RequestParam int pageNum
+    ) {
+        MemberRegistrationSliceResDTO data = memberAdminUsecase.readRegistrationList(pageSize, pageNum);
+        return ApiResponse.response(HttpStatus.OK, REGISTRATION_LIST_READ.getMessage(), data);
     }
 
 }

--- a/src/main/java/com/tavemakers/surf/domain/member/controller/AdminController.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/controller/AdminController.java
@@ -55,10 +55,11 @@ public class AdminController {
     @Operation(summary = "가입신청 목록", description = "가입신청 목록을 조회합니다.")
     @GetMapping("/v1/manager/registration-list")
     public ApiResponse<MemberRegistrationSliceResDTO> readRegistrationList (
+            @RequestParam(required = false) String keyword,
             @RequestParam int pageSize,
             @RequestParam int pageNum
     ) {
-        MemberRegistrationSliceResDTO data = memberAdminUsecase.readRegistrationList(pageSize, pageNum);
+        MemberRegistrationSliceResDTO data = memberAdminUsecase.readRegistrationList(keyword, pageSize, pageNum);
         return ApiResponse.response(HttpStatus.OK, REGISTRATION_LIST_READ.getMessage(), data);
     }
 

--- a/src/main/java/com/tavemakers/surf/domain/member/controller/ResponseMessage.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/controller/ResponseMessage.java
@@ -10,6 +10,7 @@ public enum ResponseMessage {
     // ADMIN
     MANAGER_PASSWORD_SET_UP_SUCCESS("[비밀번호 설정]을 완료했습니다."),
     ADMIN_PAGE_LOGIN_SUCCESS("[관리자 페이지]에 성공적으로 로그인했습니다."),
+    REGISTRATION_LIST_READ("[가입신청 목록]을 조회합니다."),
 
     //회원가입 온보딩 확인 여부 체크
     MEMBER_ONBOARDING_STATUS_CHECK_SUCCESS("[회원]의 추가 회원가입 정보 입력 필요 여부를 확인했습니다."),

--- a/src/main/java/com/tavemakers/surf/domain/member/dto/response/MemberRegistrationDetailResDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/dto/response/MemberRegistrationDetailResDTO.java
@@ -1,0 +1,32 @@
+package com.tavemakers.surf.domain.member.dto.response;
+
+import com.tavemakers.surf.domain.member.entity.Member;
+import lombok.Builder;
+
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+@Builder
+public record MemberRegistrationDetailResDTO(
+        Long memberId,
+        String username,
+        String university,
+        String profileImageUrl,
+        List<TrackResDTO> trackList,
+        String createdAt
+) {
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yy.MM.dd HH:mm");
+
+    public static MemberRegistrationDetailResDTO from(Member member) {
+        return MemberRegistrationDetailResDTO.builder()
+                .memberId(member.getId())
+                .username(member.getName())
+                .university(member.getUniversity())
+                .profileImageUrl(member.getProfileImageUrl())
+                .trackList(member.getTracks().stream()
+                        .map(TrackResDTO::from)
+                        .toList())
+                .createdAt(member.getCreatedAt().format(FORMATTER))
+                .build();
+    }
+}

--- a/src/main/java/com/tavemakers/surf/domain/member/dto/response/MemberRegistrationSliceResDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/dto/response/MemberRegistrationSliceResDTO.java
@@ -1,0 +1,25 @@
+package com.tavemakers.surf.domain.member.dto.response;
+
+import lombok.Builder;
+import org.springframework.data.domain.Slice;
+
+import java.util.List;
+
+@Builder
+public record MemberRegistrationSliceResDTO(
+        List<MemberRegistrationDetailResDTO> content,
+        int pageNumber,
+        int pageSize,
+        int numberOfElements,
+        boolean isLast
+) {
+    public static MemberRegistrationSliceResDTO from(Slice<MemberRegistrationDetailResDTO> slice) {
+        return MemberRegistrationSliceResDTO.builder()
+                .content(slice.getContent())
+                .pageNumber(slice.getNumber())
+                .pageSize(slice.getSize())
+                .numberOfElements(slice.getNumberOfElements())
+                .isLast(slice.isLast())
+                .build();
+    }
+}

--- a/src/main/java/com/tavemakers/surf/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/repository/MemberRepository.java
@@ -2,6 +2,8 @@ package com.tavemakers.surf.domain.member.repository;
 
 import com.tavemakers.surf.domain.member.entity.Member;
 import com.tavemakers.surf.domain.member.entity.enums.MemberStatus;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
@@ -49,4 +51,8 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     List<Long> findActiveMemberIdsExcludeStatus(@Param("status") MemberStatus status);
 
     boolean existsByIdAndStatusNot(Long id, MemberStatus status);
+
+    @Query("select m from Member m where m.status = :status")
+    Slice<Member> findByMemberListStatus(@Param("status") MemberStatus status, Pageable pageable);
+
 }

--- a/src/main/java/com/tavemakers/surf/domain/member/service/MemberGetService.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/service/MemberGetService.java
@@ -54,6 +54,10 @@ public class MemberGetService {
         return memberSearchRepository.searchMembers(generation, part, keyword, pageable);
     }
 
+    public Slice<Member> searchMembers(MemberStatus status, Pageable pageable) {
+        return memberRepository.findByMemberListStatus(status, pageable);
+    }
+
     public Long countSearchingMembers(Integer generation, Part memberPart, String keyword) {
         return memberSearchRepository.countMembers(generation, memberPart, keyword);
     }

--- a/src/main/java/com/tavemakers/surf/domain/member/service/MemberGetService.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/service/MemberGetService.java
@@ -61,4 +61,9 @@ public class MemberGetService {
     public Long countSearchingMembers(Integer generation, Part memberPart, String keyword) {
         return memberSearchRepository.countMembers(generation, memberPart, keyword);
     }
+
+    public Slice<Member> searchWaitingMembers(String keyword, Pageable pageable) {
+        return memberSearchRepository.findWaitingMembersByName(keyword, pageable);
+    }
+
 }

--- a/src/main/java/com/tavemakers/surf/domain/member/usecase/MemberAdminUsecase.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/usecase/MemberAdminUsecase.java
@@ -4,6 +4,8 @@ import com.tavemakers.surf.domain.login.auth.service.RefreshTokenService;
 import com.tavemakers.surf.domain.member.dto.request.AdminPageLoginReqDto;
 import com.tavemakers.surf.domain.member.dto.request.PasswordReqDto;
 import com.tavemakers.surf.domain.member.dto.response.AdminPageLoginResDto;
+import com.tavemakers.surf.domain.member.dto.response.MemberRegistrationDetailResDTO;
+import com.tavemakers.surf.domain.member.dto.response.MemberRegistrationSliceResDTO;
 import com.tavemakers.surf.domain.member.entity.Member;
 import com.tavemakers.surf.domain.member.entity.Password;
 import com.tavemakers.surf.domain.member.entity.enums.MemberRole;
@@ -20,9 +22,14 @@ import com.tavemakers.surf.global.util.SecurityUtils;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.UUID;
 
 @Service
@@ -80,6 +87,14 @@ public class MemberAdminUsecase {
         refreshTokenService.issue(response, member.getId(), deviceId);
 
         return AdminPageLoginResDto.of(accessToken, member);
+    }
+
+    public MemberRegistrationSliceResDTO readRegistrationList(int pageSize, int pageNum) {
+        Pageable pageable = PageRequest.of(pageNum, pageSize, Sort.by("createdAt").descending());
+        Slice<MemberRegistrationDetailResDTO> registrationList = memberGetService.searchMembers(MemberStatus.WAITING, pageable)
+                .map(MemberRegistrationDetailResDTO::from);
+
+        return MemberRegistrationSliceResDTO.from(registrationList);
     }
 
     private void validateLoginMemberRole(Member member) {

--- a/src/main/java/com/tavemakers/surf/domain/member/usecase/MemberAdminUsecase.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/usecase/MemberAdminUsecase.java
@@ -89,9 +89,9 @@ public class MemberAdminUsecase {
         return AdminPageLoginResDto.of(accessToken, member);
     }
 
-    public MemberRegistrationSliceResDTO readRegistrationList(int pageSize, int pageNum) {
+    public MemberRegistrationSliceResDTO readRegistrationList(String keyword, int pageSize, int pageNum) {
         Pageable pageable = PageRequest.of(pageNum, pageSize, Sort.by("createdAt").descending());
-        Slice<MemberRegistrationDetailResDTO> registrationList = memberGetService.searchMembers(MemberStatus.WAITING, pageable)
+        Slice<MemberRegistrationDetailResDTO> registrationList = memberGetService.searchWaitingMembers(keyword, pageable)
                 .map(MemberRegistrationDetailResDTO::from);
 
         return MemberRegistrationSliceResDTO.from(registrationList);


### PR DESCRIPTION
## 📄 작업 내용 요약
가입신청한 회원 목록 API 구현

## Offset기반
Offset과 Cursor 방식 중 `Offset` 방식을 택했습니다.

이유는 두 가지입니다.

### 1. Offset의 단점을 고려하지 않아도 됨.

가입신청은 주로 매 기수 OT에만 사용합니다.
매 신규 회원은 60명 정도로 매우 적기 때문에, 뒤 페이지로 갈 수록 성능이 떨어지는 Offset의 단점을 고려하지 않아도 됩니다.
물론 데이터가 추가될 때 다음 페이지로 넘어가는 경우, 데이터가 밀려나는 현상이 있습니다. 
그러나 단순히, 회원가입을 수락하고 거절하기 위한 시나리오에서 사용되는 API이기 때문에, 데이터가 밀려나는 경우가 심각한 엣지케이스가 아닙니다.

### 2. 구현 난이도가 쉬움
pageSize와 pageNum 그리고 정렬 조건만 있으면 간단히 구현되기 때문에, 컨퍼런스(`1월 24일`)가 얼마 남지 않은 시점에서 빠르게 구현할 수 있는 방법을 택했습니다.


## 응답 예시 JSON
Local Database를 기반으로 나온 응답이기 때문에 track이 null이지만, 실제로 null인 경우는 없습니다...

```json
{
    "code": 200,
    "message": "[가입신청 목록]을 조회합니다.",
    "data": {
        "content": [
            {
                "memberId": 3,
                "username": "김철철",
                "university": "숙명여자대학교",
                "profileImageUrl": "http://img1.kakaocdn.net/thumb/R640x640.q70/?fname=http://t1.kakaocdn.net/account_images/default_profile.jpeg",
                "trackList": [],
                "createdAt": "25.09.27 16:33"
            },
            {
                "memberId": 2,
                "username": "김희희",
                "university": "아주대학교",
                "profileImageUrl": "http://img1.kakaocdn.net/thumb/R640x640.q70/?fname=http://t1.kakaocdn.net/account_images/default_profile.jpeg",
                "trackList": [],
                "createdAt": "25.09.27 00:38"
            },
            {
                "memberId": 1,
                "username": "홍길동",
                "university": "가천대학교",
                "profileImageUrl": null,
                "trackList": [
                    {
                        "generation": 13,
                        "part": "BACKEND"
                    },
                    {
                        "generation": 16,
                        "part": "DESIGN"
                    }
                ],
                "createdAt": "25.09.25 02:32"
            }
        ],
        "pageNumber": 0,
        "pageSize": 20,
        "numberOfElements": 3,
        "isLast": true
    }
}
```


## 📎 Issue #237 
<!-- closed #237  -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 가입 신청 목록의 페이지별 조회 기능 추가 — 관리자는 이름(키워드)으로 검색해 페이지 단위로 신청자 목록을 조회할 수 있습니다.
  * 각 신청자에 대해 회원 ID, 이름, 대학, 프로필 이미지, 선택 종목 목록, 신청 시간 등 상세 정보를 제공합니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->