### PR TITLE
[FEAT] 회원가입 승인거절 보강

### DIFF
--- a/src/main/java/com/tavemakers/surf/domain/home/dto/request/HomeContentUpsertReqDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/home/dto/request/HomeContentUpsertReqDTO.java
@@ -8,5 +8,9 @@ public record HomeContentUpsertReqDTO(
 
         @Schema(description = "홈 문구", example = "TAVE 신규 회원을 환영합니다.")
         @NotBlank @Size(max = 2000)
-        String message
+        String message,
+
+        @Schema(description = "홈 문구 작성자", example = "TAVE 운영진")
+        @NotBlank @Size(max = 200)
+        String sender
 ) {}

--- a/src/main/java/com/tavemakers/surf/domain/home/dto/request/HomeContentUpsertReqDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/home/dto/request/HomeContentUpsertReqDTO.java
@@ -8,5 +8,5 @@ public record HomeContentUpsertReqDTO(
 
         @Schema(description = "홈 문구", example = "TAVE 신규 회원을 환영합니다.")
         @NotBlank @Size(max = 2000)
-        String mainText
+        String message
 ) {}

--- a/src/main/java/com/tavemakers/surf/domain/home/dto/response/HomeContentResDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/home/dto/response/HomeContentResDTO.java
@@ -12,12 +12,16 @@ public record HomeContentResDTO(
         Long id,
 
         @Schema(description = "홈 문구", example = "TAVE 신규 회원을 환영합니다.")
-        String message
+        String message,
+
+        @Schema(description = "홈 문구 작성자", example = "TAVE 운영진")
+        String sender
 ) {
     public static HomeContentResDTO from(HomeContent hc) {
         return HomeContentResDTO.builder()
                 .id(hc.getId())
                 .message(hc.getMessage())
+                .sender(hc.getSender())
                 .build();
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/home/dto/response/HomeContentResDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/home/dto/response/HomeContentResDTO.java
@@ -12,12 +12,12 @@ public record HomeContentResDTO(
         Long id,
 
         @Schema(description = "홈 문구", example = "TAVE 신규 회원을 환영합니다.")
-        String mainText
+        String message
 ) {
     public static HomeContentResDTO from(HomeContent hc) {
         return HomeContentResDTO.builder()
                 .id(hc.getId())
-                .mainText(hc.getMainText())
+                .message(hc.getMessage())
                 .build();
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/home/dto/response/HomeResDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/home/dto/response/HomeResDTO.java
@@ -8,7 +8,7 @@ import java.util.List;
 public record HomeResDTO(
 
         @Schema(description = "홈 문구", example = "TAVE 신규 회원을 환영합니다.")
-        String mainText,
+        String message,
 
         @Schema(description = "홈 배너 목록")
         List<HomeBannerResDTO> banners,

--- a/src/main/java/com/tavemakers/surf/domain/home/dto/response/HomeResDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/home/dto/response/HomeResDTO.java
@@ -10,6 +10,9 @@ public record HomeResDTO(
         @Schema(description = "홈 문구", example = "TAVE 신규 회원을 환영합니다.")
         String message,
 
+        @Schema(description = "홈 문구 작성자", example = "TAVE 운영진")
+        String sender,
+
         @Schema(description = "홈 배너 목록")
         List<HomeBannerResDTO> banners,
 

--- a/src/main/java/com/tavemakers/surf/domain/home/entity/HomeContent.java
+++ b/src/main/java/com/tavemakers/surf/domain/home/entity/HomeContent.java
@@ -19,16 +19,16 @@ public class HomeContent extends BaseEntity {
     private Long id;
 
     @Column(nullable = false, length = 2000)
-    private String mainText;
+    private String message;
 
-    public static HomeContent of(String mainText) {
+    public static HomeContent of(String message) {
         return HomeContent.builder()
                 .id(1L)
-                .mainText(mainText)
+                .message(message)
                 .build();
     }
 
-    public void changeMainText(String mainText) {
-        this.mainText = mainText;
+    public void changeMessage(String message) {
+        this.message = message;
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/home/entity/HomeContent.java
+++ b/src/main/java/com/tavemakers/surf/domain/home/entity/HomeContent.java
@@ -21,14 +21,19 @@ public class HomeContent extends BaseEntity {
     @Column(nullable = false, length = 2000)
     private String message;
 
-    public static HomeContent of(String message) {
+    @Column(nullable = false, length = 200)
+    private String sender;
+
+    public static HomeContent of(String message, String sender) {
         return HomeContent.builder()
                 .id(1L)
                 .message(message)
+                .sender(sender)
                 .build();
     }
 
-    public void changeMessage(String message) {
+    public void changeHomeContent(String message, String sender) {
         this.message = message;
+        this.sender = sender;
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/home/repository/HomeContentRepository.java
+++ b/src/main/java/com/tavemakers/surf/domain/home/repository/HomeContentRepository.java
@@ -10,6 +10,6 @@ import java.util.Optional;
 @Repository
 public interface HomeContentRepository extends JpaRepository<HomeContent, Long> {
 
-    @Query("select hc.mainText from HomeContent hc where hc.id = 1")
-    Optional<String> findMainText();
+    @Query("select hc.message from HomeContent hc where hc.id = 1")
+    Optional<String> findMessage();
 }

--- a/src/main/java/com/tavemakers/surf/domain/home/repository/HomeContentRepository.java
+++ b/src/main/java/com/tavemakers/surf/domain/home/repository/HomeContentRepository.java
@@ -2,14 +2,8 @@ package com.tavemakers.surf.domain.home.repository;
 
 import com.tavemakers.surf.domain.home.entity.HomeContent;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
-
-import java.util.Optional;
 
 @Repository
 public interface HomeContentRepository extends JpaRepository<HomeContent, Long> {
-
-    @Query("select hc.message from HomeContent hc where hc.id = 1")
-    Optional<String> findMessage();
 }

--- a/src/main/java/com/tavemakers/surf/domain/home/service/HomeContentService.java
+++ b/src/main/java/com/tavemakers/surf/domain/home/service/HomeContentService.java
@@ -21,10 +21,10 @@ public class HomeContentService {
 
         HomeContent content = homeContentRepository.findById(HOME_CONTENT_ID)
                 .map(existing -> {
-                    existing.changeMainText(req.mainText());
+                    existing.changeMessage(req.message());
                     return existing;
                 })
-                .orElseGet(() -> homeContentRepository.save(HomeContent.of(req.mainText())));
+                .orElseGet(() -> homeContentRepository.save(HomeContent.of(req.message())));
 
         return HomeContentResDTO.from(content);
     }

--- a/src/main/java/com/tavemakers/surf/domain/home/service/HomeContentService.java
+++ b/src/main/java/com/tavemakers/surf/domain/home/service/HomeContentService.java
@@ -21,10 +21,10 @@ public class HomeContentService {
 
         HomeContent content = homeContentRepository.findById(HOME_CONTENT_ID)
                 .map(existing -> {
-                    existing.changeMessage(req.message());
+                    existing.changeHomeContent(req.message(), req.sender());
                     return existing;
                 })
-                .orElseGet(() -> homeContentRepository.save(HomeContent.of(req.message())));
+                .orElseGet(() -> homeContentRepository.save(HomeContent.of(req.message(), req.sender())));
 
         return HomeContentResDTO.from(content);
     }
@@ -33,6 +33,6 @@ public class HomeContentService {
     public HomeContentResDTO getContent() {
         return homeContentRepository.findById(HOME_CONTENT_ID)
                 .map(HomeContentResDTO::from)
-                .orElse(new HomeContentResDTO(HOME_CONTENT_ID, ""));
+                .orElse(new HomeContentResDTO(HOME_CONTENT_ID, "", ""));
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/home/service/HomeService.java
+++ b/src/main/java/com/tavemakers/surf/domain/home/service/HomeService.java
@@ -2,6 +2,7 @@ package com.tavemakers.surf.domain.home.service;
 
 import com.tavemakers.surf.domain.home.dto.response.HomeBannerResDTO;
 import com.tavemakers.surf.domain.home.dto.response.HomeResDTO;
+import com.tavemakers.surf.domain.home.entity.HomeContent;
 import com.tavemakers.surf.domain.home.repository.HomeBannerRepository;
 import com.tavemakers.surf.domain.home.repository.HomeContentRepository;
 import com.tavemakers.surf.domain.member.entity.Member;
@@ -33,7 +34,14 @@ public class HomeService {
     @Transactional(readOnly = true)
     public HomeResDTO getHome() {
         // 1) main message
-        String message = homeContentRepository.findMessage().orElse("");
+        String message = "";
+        String sender = "";
+
+        HomeContent hc = homeContentRepository.findById(1L).orElse(null);
+        if (hc != null) {
+            message = hc.getMessage();
+            sender = hc.getSender();
+        }
 
         // 2) banners
         List<HomeBannerResDTO> banners = homeBannerRepository.findAllByOrderByDisplayOrderAsc()
@@ -96,6 +104,7 @@ public class HomeService {
 
         return new HomeResDTO(
                 message,
+                sender,
                 banners,
                 memberName,
                 memberGeneration,

--- a/src/main/java/com/tavemakers/surf/domain/home/service/HomeService.java
+++ b/src/main/java/com/tavemakers/surf/domain/home/service/HomeService.java
@@ -32,8 +32,8 @@ public class HomeService {
 
     @Transactional(readOnly = true)
     public HomeResDTO getHome() {
-        // 1) main text
-        String mainText = homeContentRepository.findMainText().orElse("");
+        // 1) main message
+        String message = homeContentRepository.findMessage().orElse("");
 
         // 2) banners
         List<HomeBannerResDTO> banners = homeBannerRepository.findAllByOrderByDisplayOrderAsc()
@@ -95,7 +95,7 @@ public class HomeService {
         }
 
         return new HomeResDTO(
-                mainText,
+                message,
                 banners,
                 memberName,
                 memberGeneration,

--- a/src/main/java/com/tavemakers/surf/domain/member/controller/MemberController.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/controller/MemberController.java
@@ -19,6 +19,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import jakarta.validation.Valid;
 
+import java.util.List;
+
 @Slf4j
 @RestController
 @RequiredArgsConstructor
@@ -107,12 +109,12 @@ public class MemberController {
             summary = "회원가입 승인",
             description = "관리자가 회원의 회원가입을 승인합니다."
     )
-    @PatchMapping("/v1/admin/members/{memberId}/approve")
+    @PatchMapping("/v1/admin/members/approve")
     public ApiResponse<Void> approveMember(
-            @PathVariable Long memberId
+            @RequestBody List<Long> memberIds
     ) {
         Long approverId = SecurityUtils.getCurrentMemberId();
-        memberAdminUsecase.approveMember(memberId, approverId);
+        memberAdminUsecase.approveMember(memberIds, approverId);
 
         return ApiResponse.response(HttpStatus.OK, "승인되었습니다.", null);
     }
@@ -125,12 +127,12 @@ public class MemberController {
             summary = "회원가입 거절",
             description = "관리자가 회원의 회원가입을 거절합니다."
     )
-    @PatchMapping("/v1/admin/members/{memberId}/reject")
+    @PatchMapping("/v1/admin/members/reject")
     public ApiResponse<Void> rejectMember(
-            @PathVariable Long memberId
+            @RequestBody List<Long> memberIds
     ) {
         Long approverId = SecurityUtils.getCurrentMemberId();
-        memberAdminUsecase.rejectMember(memberId, approverId);
+        memberAdminUsecase.rejectMember(memberIds, approverId);
 
         return ApiResponse.response(HttpStatus.OK, "거절되었습니다.", null);
     }

--- a/src/main/java/com/tavemakers/surf/domain/member/exception/ErrorMessage.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/exception/ErrorMessage.java
@@ -18,6 +18,8 @@ public enum ErrorMessage {
     PASSWORD_NOT_SETTING(HttpStatus.BAD_REQUEST, "비밀번호가 설정되지 않았습니다."),
     MIS_MATCH_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
     ADMIN_PAGE_ROLE_EXCEPTION(HttpStatus.BAD_REQUEST, "관리자만 접근 가능합니다."),
+
+    INVALID_SIGNUP_LIST(HttpStatus.BAD_REQUEST, "[회원 가입 요청 목록]이 올바르지 않습니다.")
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/tavemakers/surf/domain/member/exception/InvalidSignupListException.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/exception/InvalidSignupListException.java
@@ -1,0 +1,11 @@
+package com.tavemakers.surf.domain.member.exception;
+
+import com.tavemakers.surf.global.common.exception.BaseException;
+
+import static com.tavemakers.surf.domain.member.exception.ErrorMessage.INVALID_SIGNUP_LIST;
+
+public class InvalidSignupListException extends BaseException {
+    public InvalidSignupListException() {
+        super(INVALID_SIGNUP_LIST.getStatus(), INVALID_SIGNUP_LIST.getMessage());
+    }
+}

--- a/src/main/java/com/tavemakers/surf/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/repository/MemberRepository.java
@@ -16,6 +16,8 @@ import java.util.Optional;
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByIdAndStatus(Long memberId, MemberStatus status);
+
+    List<Member> findAllByIdInAndStatus(List<Long> ids, MemberStatus status);
   
     boolean existsByEmail(String email);
   

--- a/src/main/java/com/tavemakers/surf/domain/member/service/MemberGetService.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/service/MemberGetService.java
@@ -38,10 +38,13 @@ public class MemberGetService {
         }
 
         List<Long> distinctIds = memberIds.stream().distinct().toList();
-        List<Member> members = memberRepository.findAllByIdInAndStatus(distinctIds, status);
-
-        if (members.size() != distinctIds.size()) {
+        if (distinctIds.size() != memberIds.size()) {
             throw new InvalidSignupListException();
+        }
+
+        List<Member> members = memberRepository.findAllByIdInAndStatus(distinctIds, status);
+        if (members.size() != distinctIds.size()) {
+            throw new MemberNotFoundException();
         }
 
         return members;

--- a/src/main/java/com/tavemakers/surf/domain/member/service/MemberGetService.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/service/MemberGetService.java
@@ -14,6 +14,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -27,6 +29,21 @@ public class MemberGetService {
     public Member getMemberByStatus(Long memberId, MemberStatus memberStatus) {
         return memberRepository.findByIdAndStatus(memberId, memberStatus)
                 .orElseThrow(MemberNotFoundException::new);
+    }
+
+    public List<Member> getMembersByStatus(List<Long> memberIds, MemberStatus status) {
+        if (memberIds == null || memberIds.isEmpty()) {
+            throw new IllegalArgumentException("memberIds is empty");
+        }
+
+        List<Long> distinctIds = memberIds.stream().distinct().toList();
+        List<Member> members = memberRepository.findAllByIdInAndStatus(distinctIds, status);
+
+        if (members.size() != distinctIds.size()) {
+            throw new IllegalStateException("Not found or status mismatch.");
+        }
+
+        return members;
     }
 
     public Member getMember(Long memberId) {

--- a/src/main/java/com/tavemakers/surf/domain/member/service/MemberGetService.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/service/MemberGetService.java
@@ -3,6 +3,7 @@ package com.tavemakers.surf.domain.member.service;
 import com.tavemakers.surf.domain.member.entity.Member;
 import com.tavemakers.surf.domain.member.entity.enums.MemberStatus;
 import com.tavemakers.surf.domain.member.entity.enums.Part;
+import com.tavemakers.surf.domain.member.exception.InvalidSignupListException;
 import com.tavemakers.surf.domain.member.exception.MemberNotFoundException;
 import com.tavemakers.surf.domain.member.repository.MemberRepository;
 import com.tavemakers.surf.domain.member.repository.MemberSearchRepository;
@@ -33,14 +34,14 @@ public class MemberGetService {
 
     public List<Member> getMembersByStatus(List<Long> memberIds, MemberStatus status) {
         if (memberIds == null || memberIds.isEmpty()) {
-            throw new IllegalArgumentException("memberIds is empty");
+            throw new MemberNotFoundException();
         }
 
         List<Long> distinctIds = memberIds.stream().distinct().toList();
         List<Member> members = memberRepository.findAllByIdInAndStatus(distinctIds, status);
 
         if (members.size() != distinctIds.size()) {
-            throw new IllegalStateException("Not found or status mismatch.");
+            throw new InvalidSignupListException();
         }
 
         return members;

--- a/src/main/java/com/tavemakers/surf/domain/member/service/MemberService.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/service/MemberService.java
@@ -5,13 +5,15 @@ import com.tavemakers.surf.domain.member.dto.response.MemberSignupResDTO;
 import com.tavemakers.surf.domain.member.entity.Member;
 import com.tavemakers.surf.domain.member.entity.enums.MemberStatus;
 
+import java.util.List;
+
 public interface MemberService {
 
     /** 회원 승인 (관리자) */
-    void approveMember(Member member);
+    void approveMembers(List<Member> member);
 
     /** 회원 거절 (관리자) */
-    void rejectMember(Member member);
+    void rejectMembers(List<Member> member);
 
     /** 자체 회원가입 신청 완료 */
     MemberSignupResDTO signup(Member member, MemberSignupReqDTO request);

--- a/src/main/java/com/tavemakers/surf/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/service/MemberServiceImpl.java
@@ -7,6 +7,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import com.tavemakers.surf.domain.member.entity.enums.MemberStatus;
+
+import java.util.List;
 import java.util.Locale;
 import lombok.extern.slf4j.Slf4j;
 
@@ -36,15 +38,19 @@ public class MemberServiceImpl implements MemberService {
     /** 회원 승인 */
     @Override
     @Transactional
-    public void approveMember(Member member) {
-        member.approve();
+    public void approveMembers(List<Member> members) {
+        for (Member member : members) {
+            member.approve();
+        }
     }
 
     /** 회원 거절 */
     @Override
     @Transactional
-    public void rejectMember(Member member) {
-        member.reject();
+    public void rejectMembers(List<Member> members) {
+        for (Member member : members) {
+            member.reject();
+        }
     }
 
     /** 온보딩 필요 여부 확인 */

--- a/src/main/java/com/tavemakers/surf/domain/member/usecase/MemberAdminUsecase.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/usecase/MemberAdminUsecase.java
@@ -7,7 +7,6 @@ import com.tavemakers.surf.domain.member.dto.response.AdminPageLoginResDto;
 import com.tavemakers.surf.domain.member.dto.response.MemberRegistrationDetailResDTO;
 import com.tavemakers.surf.domain.member.dto.response.MemberRegistrationSliceResDTO;
 import com.tavemakers.surf.domain.member.entity.Member;
-import com.tavemakers.surf.domain.member.entity.Password;
 import com.tavemakers.surf.domain.member.entity.enums.MemberRole;
 import com.tavemakers.surf.domain.member.entity.enums.MemberStatus;
 import com.tavemakers.surf.domain.member.exception.AdminPageRoleException;
@@ -53,22 +52,22 @@ public class MemberAdminUsecase {
     @Transactional
     @LogEvent(value = "signup.approve", message = "회원가입 승인 처리")
     public void approveMember(
-            @LogParam("member_id") Long memberId,
+            @LogParam("member_ids") List<Long> memberIds,
             @LogParam("approver_id") Long approverId
     ) {
-        Member member = memberGetService.getMemberByStatus(memberId, MemberStatus.WAITING);
-        memberService.approveMember(member);
-        personalScoreSaveService.savePersonalScore(member);
+        List<Member> members = memberGetService.getMembersByStatus(memberIds, MemberStatus.WAITING);
+        memberService.approveMembers(members);
+        personalScoreSaveService.savePersonalScores(members);
     }
 
     @Transactional
     @LogEvent(value = "signup.reject", message = "회원가입 거절 처리")
     public void rejectMember(
-            @LogParam("member_id") Long memberId,
+            @LogParam("member_ids") List<Long> memberIds,
             @LogParam("approver_id") Long approverId
     ) {
-        Member member = memberGetService.getMemberByStatus(memberId, MemberStatus.WAITING);
-        memberService.rejectMember(member);
+        List<Member> members = memberGetService.getMembersByStatus(memberIds, MemberStatus.WAITING);
+        memberService.rejectMembers(members);
     }
 
     @Transactional
@@ -102,5 +101,4 @@ public class MemberAdminUsecase {
             throw new AdminPageRoleException();
         }
     }
-
 }

--- a/src/main/java/com/tavemakers/surf/domain/notification/dto/res/NotificationResDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/notification/dto/res/NotificationResDTO.java
@@ -1,6 +1,5 @@
 package com.tavemakers.surf.domain.notification.dto.res;
 
-import com.tavemakers.surf.domain.notification.entity.Notification;
 import com.tavemakers.surf.domain.notification.entity.NotificationType;
 import io.swagger.v3.oas.annotations.media.Schema;
 

--- a/src/main/java/com/tavemakers/surf/domain/notification/service/NotificationUseCase.java
+++ b/src/main/java/com/tavemakers/surf/domain/notification/service/NotificationUseCase.java
@@ -47,6 +47,7 @@ public class NotificationUseCase {
                     memberId,                   // 알림 받는 사람
                     NotificationType.NOTICE,            // 공지 알림 타입
                     Map.of(
+                            "boardName", post.getBoard().getName(),
                             "boardId", post.getBoard().getId(),
                             "postId", post.getId()
                     )

--- a/src/main/java/com/tavemakers/surf/domain/post/repository/ScheduleRepository.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/repository/ScheduleRepository.java
@@ -25,5 +25,12 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
 
     Optional<Schedule> findFirstByCategoryAndStartAtAfterOrderByStartAtAsc(
             String category,
-            LocalDateTime now);
+            LocalDateTime now
+    );
+
+    Optional<Schedule> findFirstByCategoryAndStartAtLessThanEqualOrderByStartAtDesc(
+            String category,
+            LocalDateTime now
+    );
+
 }


### PR DESCRIPTION
## 📄 작업 내용 요약

기존의 회원가입 승인/거절 api 가 단건 회원에 대해서만 가능한 상태에서, 파라미터를 List<Long>으로 받아서 한번에 처리 가능하도록 수정하였습니다.

승인/거절 api 호출 시에 파라미터에 enum(승인/거절) 값을 추가하여 하나의 api로 통합하려고 하였으나, 현재 수집 중인 로그가 승인/거절 로 분리되어있어 별개의 api로 유지해두었습니다.

승인 이후에 이루어지는 활동점수 부여 메서드도 List 로 받아 한 번에 처리하도록 수정하였습니다.

Status가 WAITING인 member를 List로 가져오기 위해 getMembersByStatus를 작성하였습니다.
빈 리스트나 중복된 id 값이 넘어오는 경우를 방지하기 위해 커스텀 에러 추가해두었습니다.
```
public List<Member> getMembersByStatus(List<Long> memberIds, MemberStatus status) {
        if (memberIds == null || memberIds.isEmpty()) {
            throw new MemberNotFoundException();
        }

        List<Long> distinctIds = memberIds.stream().distinct().toList();
        List<Member> members = memberRepository.findAllByIdInAndStatus(distinctIds, status);

        if (members.size() != distinctIds.size()) {
            throw new InvalidSignupListException();
        }

        return members;
    }
```

추가적으로, 알람 발생시 payload에 boardName이 누락되어 프론트엔드 측에서 렌더링이 되지 않는 오류가 있었습니다. boardName 추가해두었습니다.


---

### 추가 수정 사항

프론트엔드 측의 수정 요청으로, home 화면 표시 정보들의 수정이 있었습니다.

1. 기존 mainText만 표시하던 홈 메시지를, message + sender로 분리하여 입력받아 동시에 조회/출력합니다.
2. 현재 시점 이후의 schedule만을 조회하여 표시하던 방식에서, 이후의 schedule이 없을 때는 가장 최근 schedule을 표시하도록 수정하였습니다.


## 📎 Issue 번호
<!-- closed #231  -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 관리자 회원 승인/거절을 다수 대상 일괄 처리로 지원
  * 알림 페이로드에 게시판 이름(boardName) 추가

* **개선사항**
  * 회원 가입 요청 목록 유효성 검증 및 전용 예외 추가
  * 개인 점수 저장과 회원 승인/거절의 배치 처리로 효율 개선
  * 홈 콘텐츠 요청/응답 필드명이 mainText → message로 변경되고 sender 필드 추가하여 API 응답/요청 통일

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->