### PR TITLE
[Hotfix] 알림 목록 조회 시 행위자 프로필 이미지 추가

### DIFF
--- a/src/main/java/com/tavemakers/surf/domain/comment/service/CommentLikeService.java
+++ b/src/main/java/com/tavemakers/surf/domain/comment/service/CommentLikeService.java
@@ -121,6 +121,7 @@ public class CommentLikeService {
                 NotificationType.COMMENT_LIKE,
                 Map.of(
                         "actorName", member.getName(),
+                        "actorId", member.getId(),
                         "boardId", boardId,
                         "postId", postId
                 )

--- a/src/main/java/com/tavemakers/surf/domain/comment/service/CommentService.java
+++ b/src/main/java/com/tavemakers/surf/domain/comment/service/CommentService.java
@@ -69,6 +69,7 @@ public class CommentService {
                         NotificationType.POST_COMMENT,
                         Map.of(
                                 "actorName", member.getName(),
+                                "actorId", member.getId(),
                                 "boardId", post.getBoard().getId(),
                                 "postId", postId
                         )
@@ -105,6 +106,7 @@ public class CommentService {
                         NotificationType.COMMENT_REPLY,
                         Map.of(
                                 "actorName", member.getName(),
+                                "actorId", member.getId(),
                                 "boardId", post.getBoard().getId(),
                                 "postId", postId
                         )

--- a/src/main/java/com/tavemakers/surf/domain/letter/facade/LetterFacade.java
+++ b/src/main/java/com/tavemakers/surf/domain/letter/facade/LetterFacade.java
@@ -102,7 +102,8 @@ public class LetterFacade {
                 recipient.getId(),
                 NotificationType.MESSAGE,
                 Map.of(
-                        "actorName", sender.getName()
+                        "actorName", sender.getName(),
+                        "actorId", sender.getId()
                 )
         );
     }

--- a/src/main/java/com/tavemakers/surf/domain/notification/dto/res/NotificationResDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/notification/dto/res/NotificationResDTO.java
@@ -25,6 +25,9 @@ public record NotificationResDTO (
         boolean read,
 
         @Schema(description = "알람 생성 일시", example = "2023-10-05T14:48:00")
-        LocalDateTime createdAt
+        LocalDateTime createdAt,
+
+        @Schema(description = "행위자 프로필 이미지 URL", example = "https://s3.amazonaws.com/surf/profiles/123.jpg")
+        String actorProfileImageUrl
 ){
 }

--- a/src/main/java/com/tavemakers/surf/domain/notification/service/NotificationQueryService.java
+++ b/src/main/java/com/tavemakers/surf/domain/notification/service/NotificationQueryService.java
@@ -1,16 +1,28 @@
 package com.tavemakers.surf.domain.notification.service;
 
+import com.tavemakers.surf.domain.member.entity.Member;
+import com.tavemakers.surf.domain.member.repository.MemberRepository;
 import com.tavemakers.surf.domain.notification.dto.res.NotificationResDTO;
 import com.tavemakers.surf.domain.notification.entity.Notification;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Service
 public class NotificationQueryService {
 
     private final NotificationRenderService renderer;
+    private final MemberRepository memberRepository;
 
+    /**
+     * 단건 변환 (프로필 이미지 없이)
+     */
     public NotificationResDTO toDto(Notification n) {
         return new NotificationResDTO(
                 n.getId(),
@@ -19,7 +31,53 @@ public class NotificationQueryService {
                 renderer.renderBody(n),
                 renderer.renderDeeplink(n),
                 n.isRead(),
-                n.getCreatedAt()
+                n.getCreatedAt(),
+                null
+        );
+    }
+
+    /**
+     * 배치 변환 (N+1 방지, 프로필 이미지 포함)
+     */
+    public List<NotificationResDTO> toDtoList(List<Notification> notifications) {
+        // 1. actorId 수집
+        Set<Long> actorIds = notifications.stream()
+                .map(renderer::extractActorId)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toSet());
+
+        // 2. 일괄 조회 (IN 쿼리)
+        Map<Long, String> profileImageMap = memberRepository.findAllById(actorIds).stream()
+                .collect(Collectors.toMap(
+                        Member::getId,
+                        m -> m.getProfileImageUrl() != null ? m.getProfileImageUrl() : "",
+                        (a, b) -> a
+                ));
+
+        // 3. DTO 변환
+        return notifications.stream()
+                .map(n -> toDto(n, profileImageMap))
+                .toList();
+    }
+
+    private NotificationResDTO toDto(Notification n, Map<Long, String> profileImageMap) {
+        Long actorId = renderer.extractActorId(n);
+        String profileImageUrl = null;
+
+        if (actorId != null && profileImageMap.containsKey(actorId)) {
+            String url = profileImageMap.get(actorId);
+            profileImageUrl = url.isEmpty() ? null : url;
+        }
+
+        return new NotificationResDTO(
+                n.getId(),
+                n.getType(),
+                n.getType().getCategory().name(),
+                renderer.renderBody(n),
+                renderer.renderDeeplink(n),
+                n.isRead(),
+                n.getCreatedAt(),
+                profileImageUrl
         );
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/notification/service/NotificationRenderService.java
+++ b/src/main/java/com/tavemakers/surf/domain/notification/service/NotificationRenderService.java
@@ -22,6 +22,19 @@ public class NotificationRenderService {
         return replaceTemplate(notification.getType().getDeeplink(), payload);
     }
 
+    /**
+     * payload에서 actorId 추출
+     * 기존 알림(actorId 없음)이나 시스템 알림의 경우 null 반환
+     */
+    public Long extractActorId(Notification notification) {
+        Map<String, Object> payload = parsePayload(notification.getPayload());
+        Object actorId = payload.get("actorId");
+        if (actorId == null) {
+            return null;
+        }
+        return ((Number) actorId).longValue();
+    }
+
     private Map<String, Object> parsePayload(String payloadJson) {
         try {
             return objectMapper.readValue(payloadJson, new TypeReference<>() {});

--- a/src/main/java/com/tavemakers/surf/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/tavemakers/surf/domain/notification/service/NotificationService.java
@@ -37,9 +37,7 @@ public class NotificationService {
             notifications = notificationRepository.findByMemberIdAndTypeInOrderByIdDesc(memberId, types);
         }
 
-        return notifications.stream()
-                .map(notificationQueryService::toDto)
-                .toList();
+        return notificationQueryService.toDtoList(notifications);
     }
 
     @Transactional

--- a/src/main/java/com/tavemakers/surf/domain/post/service/PostLikeService.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/service/PostLikeService.java
@@ -117,6 +117,7 @@ public class PostLikeService {
                 NotificationType.POST_LIKE,
                 Map.of(
                         "actorName", member.getName(),
+                        "actorId", member.getId(),
                         "boardId", boardId,
                         "postId", postId
                 )


### PR DESCRIPTION
## Summary
- 알림 목록 조회 API에서 행위자(좋아요 누른 사람, 댓글 작성자 등)의 프로필 이미지를 함께 반환
- `NotificationResDTO`에 `actorProfileImageUrl` 필드 추가
- 알림 생성 시 payload에 `actorId` 추가 (POST_LIKE, POST_COMMENT, COMMENT_REPLY, COMMENT_LIKE, MESSAGE)
- 배치 조회(IN 쿼리)로 N+1 문제 방지

## 변경 파일
| 파일 | 변경 내용 |
|------|----------|
| `NotificationResDTO.java` | `actorProfileImageUrl` 필드 추가 |
| `NotificationRenderService.java` | `extractActorId()` 메서드 추가 |
| `NotificationQueryService.java` | `toDtoList()` 배치 메서드 구현 |
| `NotificationService.java` | `toDtoList()` 사용 |
| `PostLikeService.java` | payload에 `actorId` 추가 |
| `CommentService.java` | payload에 `actorId` 추가 (2곳) |
| `CommentLikeService.java` | payload에 `actorId` 추가 |
| `LetterFacade.java` | payload에 `actorId` 추가 |

## 마이그레이션 전략
- 신규 알림만 `actorId` 포함
- 기존 알림(actorId 없음) → `actorProfileImageUrl: null`
- 탈퇴 회원 → `actorProfileImageUrl: null`

## Test plan
- [ ] 빌드 확인 (`./gradlew build`)
- [ ] 알림 생성 후 목록 조회 API 호출 시 `actorProfileImageUrl` 필드 확인
- [ ] 기존 알림 조회 시 `actorProfileImageUrl: null` 반환 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 모든 알림에 행동자의 프로필 이미지 정보 추가
  * 댓글, 좋아요, 메시지 관련 알림에 행동자 식별 정보 포함으로 사용자 경험 개선
  * 알림 조회 시 성능 최적화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->