### PR TITLE
예약 게시글 연동 일정 캘린더 노출 제외

### DIFF
--- a/src/main/java/com/tavemakers/surf/domain/post/repository/ScheduleRepository.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/repository/ScheduleRepository.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -33,4 +34,23 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
             LocalDateTime now
     );
 
+    // 관리자용: 모든 카테고리, 예약글 제외
+    @Query("SELECT s FROM Schedule s LEFT JOIN s.post p " +
+           "WHERE s.startAt BETWEEN :startOfMonth AND :endOfMonth " +
+           "AND (p IS NULL OR p.isReserved = false)")
+    List<Schedule> findByStartAtBetweenExcludingReserved(
+            @Param("startOfMonth") LocalDateTime startOfMonth,
+            @Param("endOfMonth") LocalDateTime endOfMonth
+    );
+
+    // 일반 회원용: 특정 카테고리만, 예약글 제외
+    @Query("SELECT s FROM Schedule s LEFT JOIN s.post p " +
+           "WHERE s.startAt BETWEEN :startOfMonth AND :endOfMonth " +
+           "AND s.category IN :categories " +
+           "AND (p IS NULL OR p.isReserved = false)")
+    List<Schedule> findByStartAtBetweenAndCategoryInExcludingReserved(
+            @Param("startOfMonth") LocalDateTime startOfMonth,
+            @Param("endOfMonth") LocalDateTime endOfMonth,
+            @Param("categories") List<String> categories
+    );
 }

--- a/src/main/java/com/tavemakers/surf/domain/post/service/ScheduleGetService.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/service/ScheduleGetService.java
@@ -38,7 +38,7 @@ public class ScheduleGetService {
         return getScheduleMonthlyResDTOs(year, month, scheduleResDTOS);
     }
 
-    //특정 월의 일정 조회
+    //특정 월의 일정 조회 (예약글과 연동된 일정은 제외)
     @Transactional(readOnly = true)
     public List<Schedule> getSchedulesByMonth(String memberRole,  int year, int month) {
         YearMonth yearMonth = YearMonth.of(year, month);
@@ -48,9 +48,11 @@ public class ScheduleGetService {
         List<String> categories = List.of("regular", "other");
 
         if(Objects.equals(memberRole, MemberRole.MEMBER.toString())) {
-            return scheduleRepository.findByStartAtBetweenAndCategoryIn(startOfMonth, endOfMonth,categories);
-        }else {
-            return scheduleRepository.findByStartAtBetween(startOfMonth, endOfMonth);
+            return scheduleRepository.findByStartAtBetweenAndCategoryInExcludingReserved(
+                    startOfMonth, endOfMonth, categories);
+        } else {
+            return scheduleRepository.findByStartAtBetweenExcludingReserved(
+                    startOfMonth, endOfMonth);
         }
     }
 


### PR DESCRIPTION
## Summary
- 예약글(`isReserved=true`)과 연동된 일정이 캘린더에 노출되지 않도록 수정
- `ScheduleRepository`에 예약글 필터링 JPQL 쿼리 추가
- `ScheduleGetService.getSchedulesByMonth()`에서 새 쿼리 사용

## 변경 사항
| 조건 | 캘린더 노출 |
|------|------------|
| Post 없음 (독립 일정) | ✅ 노출 |
| Post 있음 + isReserved=false (발행됨) | ✅ 노출 |
| Post 있음 + isReserved=true (예약글) | ❌ 미노출 |

## Test plan
- [ ] 예약글 + 일정 생성 → 캘린더 조회 → 일정 미노출 확인
- [ ] 예약글 발행 후 → 캘린더 조회 → 일정 노출 확인
- [ ] 독립 일정 → 캘린더 조회 → 정상 노출 확인

Closes #250

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 월별 일정 조회 시 예약된 항목이 제외되도록 개선되었습니다. 일반 사용자의 카테고리별 일정 조회 및 관리자의 전체 일정 조회 모두에서 예약된 게시물이 자동으로 필터링됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->