### PR TITLE
[REFACT] 홈 배너 관리 api 리팩터링

### DIFF
--- a/src/main/java/com/tavemakers/surf/domain/home/controller/HomeBannerAdminController.java
+++ b/src/main/java/com/tavemakers/surf/domain/home/controller/HomeBannerAdminController.java
@@ -70,6 +70,7 @@ public class HomeBannerAdminController {
         return ApiResponse.response(HttpStatus.OK, HOME_BANNER_UPDATED.getMessage(), response);
     }
 
+    @Operation(summary = "홈 배너 활성화", description = "특정 ID의 홈 배너를 활성화합니다.")
     @PatchMapping("/v1/admin/home/banners/{id}/activate")
     public ApiResponse<HomeBannerResDTO> activate(
             @PathVariable Long id) {
@@ -77,6 +78,7 @@ public class HomeBannerAdminController {
         return ApiResponse.response(HttpStatus.OK, HOME_BANNER_STATUS_ACTIVATED.getMessage(), response);
     }
 
+    @Operation(summary = "홈 배너 비활성화", description = "특정 ID의 홈 배너를 비활성화합니다.")
     @PatchMapping("/v1/admin/home/banners/{id}/deactivate")
     public ApiResponse<HomeBannerResDTO> deactivate(
             @PathVariable Long id) {

--- a/src/main/java/com/tavemakers/surf/domain/home/controller/HomeBannerAdminController.java
+++ b/src/main/java/com/tavemakers/surf/domain/home/controller/HomeBannerAdminController.java
@@ -69,4 +69,18 @@ public class HomeBannerAdminController {
         HomeBannerResDTO response = homeBannerService.updateBanner(bannerId, req);
         return ApiResponse.response(HttpStatus.OK, HOME_BANNER_UPDATED.getMessage(), response);
     }
+
+    @PatchMapping("/v1/admin/home/banners/{id}/activate")
+    public ApiResponse<HomeBannerResDTO> activate(
+            @PathVariable Long id) {
+        HomeBannerResDTO response = homeBannerService.activateBanner(id);
+        return ApiResponse.response(HttpStatus.OK, HOME_BANNER_STATUS_ACTIVATED.getMessage(), response);
+    }
+
+    @PatchMapping("/v1/admin/home/banners/{id}/deactivate")
+    public ApiResponse<HomeBannerResDTO> deactivate(
+            @PathVariable Long id) {
+        HomeBannerResDTO response = homeBannerService.deactivateBanner(id);
+        return ApiResponse.response(HttpStatus.OK, HOME_BANNER_STATUS_DEACTIVATED.getMessage(), response);
+    }
 }

--- a/src/main/java/com/tavemakers/surf/domain/home/controller/ResponseMessage.java
+++ b/src/main/java/com/tavemakers/surf/domain/home/controller/ResponseMessage.java
@@ -15,7 +15,10 @@ public enum ResponseMessage {
     HOME_BANNER_CREATED("[홈 배너]를 생성했습니다."),
     HOME_BANNER_DELETED("[홈 배너]를 삭제했습니다."),
     HOME_BANNER_REORDERED("[홈 배너] 순서를 변경했습니다."),
-    HOME_BANNER_UPDATED("[홈 배너]를 수정했습니다.");
+    HOME_BANNER_UPDATED("[홈 배너]를 수정했습니다."),
+
+    HOME_BANNER_STATUS_ACTIVATED("[홈 배너]를 활성화했습니다."),
+    HOME_BANNER_STATUS_DEACTIVATED("[홈 배너]를 비활성화했습니다.");
 
     private final String message;
 }

--- a/src/main/java/com/tavemakers/surf/domain/home/dto/request/HomeBannerCreateReqDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/home/dto/request/HomeBannerCreateReqDTO.java
@@ -14,6 +14,7 @@ public record HomeBannerCreateReqDTO(
         String imageUrl,   // S3 업로드 완료 후 URL
 
         @Schema(description = "배너 링크 URL", example = "https://www.example.com/promotion")
+        @NotBlank
         String linkUrl
 ) {
 

--- a/src/main/java/com/tavemakers/surf/domain/home/dto/request/HomeBannerCreateReqDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/home/dto/request/HomeBannerCreateReqDTO.java
@@ -5,6 +5,10 @@ import jakarta.validation.constraints.NotBlank;
 
 public record HomeBannerCreateReqDTO(
 
+        @Schema(description = "배너 이름", example = "새로운 17기 환영 배너")
+        @NotBlank
+        String name,
+
         @Schema(description = "배너 이미지 URL", example = "https://example-bucket.s3.amazonaws.com/banner1.png")
         @NotBlank
         String imageUrl,   // S3 업로드 완료 후 URL

--- a/src/main/java/com/tavemakers/surf/domain/home/dto/request/HomeBannerUpdateReqDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/home/dto/request/HomeBannerUpdateReqDTO.java
@@ -5,11 +5,16 @@ import jakarta.validation.constraints.NotBlank;
 
 public record HomeBannerUpdateReqDTO(
 
+        @Schema(description = "배너 이름", example = "새로운 17기 환영 배너")
+        @NotBlank
+        String name,
+
         @Schema(description = "배너 이미지 URL", example = "https://example-bucket.s3.amazonaws.com/banner1.png")
         @NotBlank
         String imageUrl,   // S3 업로드 완료 후 URL
 
         @Schema(description = "배너 링크 URL", example = "https://www.example.com/promotion")
+        @NotBlank
         String linkUrl
 ) {
 }

--- a/src/main/java/com/tavemakers/surf/domain/home/entity/HomeBanner.java
+++ b/src/main/java/com/tavemakers/surf/domain/home/entity/HomeBanner.java
@@ -68,7 +68,7 @@ public class HomeBanner {
         if (imageUrl == null || imageUrl.isBlank()) {
             throw new IllegalArgumentException("imageUrl은 null이거나 빈 값일 수 없습니다.");
         }
-        if (linkUrl != null && linkUrl.isBlank()) {
+        if (linkUrl == null || linkUrl.isBlank()) {
             throw new IllegalArgumentException("linkUrl은 null이거나 빈 값일 수 없습니다.");
         }
     }

--- a/src/main/java/com/tavemakers/surf/domain/home/entity/HomeBanner.java
+++ b/src/main/java/com/tavemakers/surf/domain/home/entity/HomeBanner.java
@@ -42,15 +42,7 @@ public class HomeBanner {
     }
 
     public void updateBanner(String name, String imageUrl, String linkUrl) {
-        if (name == null || name.isBlank()) {
-            throw new IllegalArgumentException("name은 null이거나 빈 값일 수 없습니다.");
-        }
-        if (imageUrl == null || imageUrl.isBlank()) {
-            throw new IllegalArgumentException("imageUrl은 null이거나 빈 값일 수 없습니다.");
-        }
-        if (linkUrl != null && linkUrl.isBlank()) {
-            throw new IllegalArgumentException("linkUrl은 빈 값일 수 없습니다.");
-        }
+        validateUpdate(name, imageUrl, linkUrl);
 
         this.name = name;
         this.imageUrl = imageUrl;
@@ -67,5 +59,17 @@ public class HomeBanner {
 
     public void deactivate() {
         this.status = false;
+    }
+
+    private void validateUpdate(String name, String imageUrl, String linkUrl) {
+        if (name == null || name.isBlank()) {
+            throw new IllegalArgumentException("name은 null이거나 빈 값일 수 없습니다.");
+        }
+        if (imageUrl == null || imageUrl.isBlank()) {
+            throw new IllegalArgumentException("imageUrl은 null이거나 빈 값일 수 없습니다.");
+        }
+        if (linkUrl != null && linkUrl.isBlank()) {
+            throw new IllegalArgumentException("linkUrl은 빈 값일 수 없습니다.");
+        }
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/home/entity/HomeBanner.java
+++ b/src/main/java/com/tavemakers/surf/domain/home/entity/HomeBanner.java
@@ -52,6 +52,10 @@ public class HomeBanner {
         this.displayOrder = displayOrder;
     }
 
+    public void activate() {
+        this.status = true;
+    }
+
     public void deactivate() {
         this.status = false;
     }

--- a/src/main/java/com/tavemakers/surf/domain/home/entity/HomeBanner.java
+++ b/src/main/java/com/tavemakers/surf/domain/home/entity/HomeBanner.java
@@ -69,7 +69,7 @@ public class HomeBanner {
             throw new IllegalArgumentException("imageUrl은 null이거나 빈 값일 수 없습니다.");
         }
         if (linkUrl != null && linkUrl.isBlank()) {
-            throw new IllegalArgumentException("linkUrl은 빈 값일 수 없습니다.");
+            throw new IllegalArgumentException("linkUrl은 null이거나 빈 값일 수 없습니다.");
         }
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/home/entity/HomeBanner.java
+++ b/src/main/java/com/tavemakers/surf/domain/home/entity/HomeBanner.java
@@ -22,7 +22,7 @@ public class HomeBanner {
     @Column(nullable = false, length = 1000)
     private String imageUrl;
 
-    @Column(length = 1000)
+    @Column(nullable = false, length = 1000)
     private String linkUrl;
 
     @Column(nullable = false)

--- a/src/main/java/com/tavemakers/surf/domain/home/entity/HomeBanner.java
+++ b/src/main/java/com/tavemakers/surf/domain/home/entity/HomeBanner.java
@@ -25,11 +25,15 @@ public class HomeBanner {
     @Column(nullable = false)
     private Integer displayOrder;
 
+    @Column(nullable = false)
+    private boolean status = true; // 활성화 여부
+
     public static HomeBanner of(String imageUrl, String linkUrl, Integer displayOrder) {
         return HomeBanner.builder()
                 .imageUrl(imageUrl)
                 .linkUrl(linkUrl)
                 .displayOrder(displayOrder)
+                .status(true)
                 .build();
     }
 
@@ -46,5 +50,9 @@ public class HomeBanner {
 
     public void changeDisplayOrder(Integer displayOrder) {
         this.displayOrder = displayOrder;
+    }
+
+    public void deactivate() {
+        this.status = false;
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/home/entity/HomeBanner.java
+++ b/src/main/java/com/tavemakers/surf/domain/home/entity/HomeBanner.java
@@ -16,6 +16,9 @@ public class HomeBanner {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(nullable = false, length = 100)
+    private String name;
+
     @Column(nullable = false, length = 1000)
     private String imageUrl;
 
@@ -28,8 +31,9 @@ public class HomeBanner {
     @Column(nullable = false)
     private boolean status = true; // 활성화 여부
 
-    public static HomeBanner of(String imageUrl, String linkUrl, Integer displayOrder) {
+    public static HomeBanner of(String name, String imageUrl, String linkUrl, Integer displayOrder) {
         return HomeBanner.builder()
+                .name(name)
                 .imageUrl(imageUrl)
                 .linkUrl(linkUrl)
                 .displayOrder(displayOrder)
@@ -37,14 +41,19 @@ public class HomeBanner {
                 .build();
     }
 
-    public void changeImageUrl(String imageUrl) {
+    public void updateBanner(String name, String imageUrl, String linkUrl) {
+        if (name == null || name.isBlank()) {
+            throw new IllegalArgumentException("name은 null이거나 빈 값일 수 없습니다.");
+        }
         if (imageUrl == null || imageUrl.isBlank()) {
             throw new IllegalArgumentException("imageUrl은 null이거나 빈 값일 수 없습니다.");
         }
-        this.imageUrl = imageUrl;
-    }
+        if (linkUrl != null && linkUrl.isBlank()) {
+            throw new IllegalArgumentException("linkUrl은 빈 값일 수 없습니다.");
+        }
 
-    public void changeLinkUrl(String linkUrl) {
+        this.name = name;
+        this.imageUrl = imageUrl;
         this.linkUrl = linkUrl;
     }
 

--- a/src/main/java/com/tavemakers/surf/domain/home/repository/HomeBannerRepository.java
+++ b/src/main/java/com/tavemakers/surf/domain/home/repository/HomeBannerRepository.java
@@ -14,4 +14,6 @@ public interface HomeBannerRepository extends JpaRepository<HomeBanner, Long> {
 
     @Query("select max(b.displayOrder) from HomeBanner b")
     Optional<Integer> findMaxDisplayOrder();
+
+    List<HomeBanner> findAllByStatusTrueOrderByDisplayOrderAsc();
 }

--- a/src/main/java/com/tavemakers/surf/domain/home/service/HomeBannerService.java
+++ b/src/main/java/com/tavemakers/surf/domain/home/service/HomeBannerService.java
@@ -133,4 +133,23 @@ public class HomeBannerService {
 
         return banners;
     }
+
+    @Transactional
+    public HomeBannerResDTO activateBanner(Long bannerId) {
+        HomeBanner banner = findBanner(bannerId);
+        banner.activate();
+        return HomeBannerResDTO.from(banner);
+    }
+
+    @Transactional
+    public HomeBannerResDTO deactivateBanner(Long bannerId) {
+        HomeBanner banner = findBanner(bannerId);
+        banner.deactivate();
+        return HomeBannerResDTO.from(banner);
+    }
+
+    private HomeBanner findBanner(Long id) {
+        return homeBannerRepository.findById(id)
+                .orElseThrow(HomeBannerNotFoundException::new);
+    }
 }

--- a/src/main/java/com/tavemakers/surf/domain/home/service/HomeBannerService.java
+++ b/src/main/java/com/tavemakers/surf/domain/home/service/HomeBannerService.java
@@ -29,6 +29,7 @@ public class HomeBannerService {
         int nextOrder = homeBannerRepository.findMaxDisplayOrder().orElse(0) + 1;
 
         HomeBanner banner = HomeBanner.builder()
+                .name(req.name())
                 .imageUrl(req.imageUrl())
                 .linkUrl(req.linkUrl())
                 .displayOrder(nextOrder)
@@ -90,10 +91,7 @@ public class HomeBannerService {
         HomeBanner banner = homeBannerRepository.findById(bannerId)
                 .orElseThrow(HomeBannerNotFoundException::new);
 
-        banner.changeImageUrl(req.imageUrl());
-
-        if (req.linkUrl() != null)
-            banner.changeLinkUrl(req.linkUrl());
+        banner.updateBanner(req.name(), req.imageUrl(), req.linkUrl());
 
         return HomeBannerResDTO.from(banner);
     }

--- a/src/main/java/com/tavemakers/surf/domain/home/service/HomeService.java
+++ b/src/main/java/com/tavemakers/surf/domain/home/service/HomeService.java
@@ -46,7 +46,7 @@ public class HomeService {
         }
 
         // 2) banners
-        List<HomeBannerResDTO> banners = homeBannerRepository.findAllByOrderByDisplayOrderAsc()
+        List<HomeBannerResDTO> banners = homeBannerRepository.findAllByStatusTrueOrderByDisplayOrderAsc()
                 .stream()
                 .map(HomeBannerResDTO::from)
                 .toList();


### PR DESCRIPTION
## 📄 작업 내용 요약

홈 배너 관리에 대해 리팩터링만 진행하려고 하였으나, 
프론트엔드 요청에 따라 HomeBanner 엔티티에 name(이름)과 status(게시 상태)를 추가하였습니다.

status는 activate/inactivate api 로 상태 변경하도록 하였으며, 따라서 banner 조회 시 status가 true인 것들만 조회하도록 수정하였습니다.

`List<HomeBanner> findAllByStatusTrueOrderByDisplayOrderAsc();`

## 📎 Issue 번호
<!-- closed #247 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 관리자가 홈 배너를 활성화/비활성화할 수 있는 API 추가
  * 배너에 상태 필드 추가 및 활성 상태만 사용자에게 표시되도록 개선
  * 배너 생성/수정 시 이름 필드 추가 및 입력 검증 강화
  * 활성화/비활성화 결과를 나타내는 응답 메시지 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->