### PR TITLE
[Feat] 관리자페이지 전체회원목록 조회 API

### DIFF
--- a/src/main/java/com/tavemakers/surf/domain/member/controller/AdminMemberController.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/controller/AdminMemberController.java
@@ -1,6 +1,7 @@
 package com.tavemakers.surf.domain.member.controller;
 
 import com.tavemakers.surf.domain.member.dto.request.RoleChangeReqDTO;
+import com.tavemakers.surf.domain.member.dto.response.AdminTotalMemberListResDTO;
 import com.tavemakers.surf.domain.member.dto.response.MemberInformationResDTO;
 import com.tavemakers.surf.domain.member.dto.response.MemberRegistrationSliceResDTO;
 import com.tavemakers.surf.domain.member.usecase.MemberAdminUsecase;
@@ -50,6 +51,13 @@ public class AdminMemberController {
     ) {
         MemberInformationResDTO data = memberAdminUsecase.readMemberInformation(memberId);
         return ApiResponse.response(HttpStatus.OK, MEMBER_INFORMATION_READ.getMessage(), data);
+    }
+
+    @Operation(summary = "[전체 회원수]와 회원들의 [기수] 조회", description = "APPROVED 상태의 전체 회원수, 존재하는 모든 기수 조회")
+    @GetMapping("/v1/manager/members-count/generation")
+    public ApiResponse<AdminTotalMemberListResDTO> readAllMemberCountAndGeneration() {
+        AdminTotalMemberListResDTO data = memberAdminUsecase.readAllMemberCountAndGeneration();
+        return ApiResponse.response(HttpStatus.OK, APPROVED_MEMBER_COUNT_AND_ALL_GENERATION.getMessage(), data);
     }
 
 }

--- a/src/main/java/com/tavemakers/surf/domain/member/controller/AdminMemberController.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/controller/AdminMemberController.java
@@ -2,6 +2,7 @@ package com.tavemakers.surf.domain.member.controller;
 
 import com.tavemakers.surf.domain.member.dto.request.RoleChangeReqDTO;
 import com.tavemakers.surf.domain.member.dto.response.AdminTotalMemberListResDTO;
+import com.tavemakers.surf.domain.member.dto.response.ApprovedMemberSliceResDTO;
 import com.tavemakers.surf.domain.member.dto.response.MemberInformationResDTO;
 import com.tavemakers.surf.domain.member.dto.response.MemberRegistrationSliceResDTO;
 import com.tavemakers.surf.domain.member.usecase.MemberAdminUsecase;
@@ -58,6 +59,18 @@ public class AdminMemberController {
     public ApiResponse<AdminTotalMemberListResDTO> readAllMemberCountAndGeneration() {
         AdminTotalMemberListResDTO data = memberAdminUsecase.readAllMemberCountAndGeneration();
         return ApiResponse.response(HttpStatus.OK, APPROVED_MEMBER_COUNT_AND_ALL_GENERATION.getMessage(), data);
+    }
+
+    @Operation
+    @GetMapping("/v1/manager/approved-members")
+    public ApiResponse<ApprovedMemberSliceResDTO> readApprovedMemberList(
+            @RequestParam int generation,
+            @RequestParam(required = false) String keyword,
+            @RequestParam(defaultValue = "20") int pageSize,
+            @RequestParam(defaultValue = "0") int pageNum
+    ) {
+        ApprovedMemberSliceResDTO data = memberAdminUsecase.readApprovedMemberList(generation, keyword, pageSize, pageNum);
+        return ApiResponse.response(HttpStatus.OK, APPROVED_MEMBER_LIST.getMessage(), data);
     }
 
 }

--- a/src/main/java/com/tavemakers/surf/domain/member/controller/AdminMemberController.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/controller/AdminMemberController.java
@@ -61,7 +61,7 @@ public class AdminMemberController {
         return ApiResponse.response(HttpStatus.OK, APPROVED_MEMBER_COUNT_AND_ALL_GENERATION.getMessage(), data);
     }
 
-    @Operation
+    @Operation(summary = "승인된 [전체 회원 목록] 조회", description = "APPROVED 상태의 전체 회원 목록을 스크롤 조회")
     @GetMapping("/v1/manager/approved-members")
     public ApiResponse<ApprovedMemberSliceResDTO> readApprovedMemberList(
             @RequestParam int generation,

--- a/src/main/java/com/tavemakers/surf/domain/member/controller/ResponseMessage.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/controller/ResponseMessage.java
@@ -12,6 +12,7 @@ public enum ResponseMessage {
     ADMIN_PAGE_LOGIN_SUCCESS("[관리자 페이지]에 성공적으로 로그인했습니다."),
     REGISTRATION_LIST_READ("[가입신청 목록]을 조회합니다."),
     MEMBER_INFORMATION_READ("[관리자 페이지]에서 유저 정보를 조회합니다."),
+    APPROVED_MEMBER_COUNT_AND_ALL_GENERATION("[전체 회원수]와 회원들의 모든 [기수]를 조회합니다."),
 
     //회원가입 온보딩 확인 여부 체크
     MEMBER_ONBOARDING_STATUS_CHECK_SUCCESS("[회원]의 추가 회원가입 정보 입력 필요 여부를 확인했습니다."),

--- a/src/main/java/com/tavemakers/surf/domain/member/controller/ResponseMessage.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/controller/ResponseMessage.java
@@ -13,6 +13,7 @@ public enum ResponseMessage {
     REGISTRATION_LIST_READ("[가입신청 목록]을 조회합니다."),
     MEMBER_INFORMATION_READ("[관리자 페이지]에서 유저 정보를 조회합니다."),
     APPROVED_MEMBER_COUNT_AND_ALL_GENERATION("[전체 회원수]와 회원들의 모든 [기수]를 조회합니다."),
+    APPROVED_MEMBER_LIST("승인된 [전체 회원 목록]을 조회합니다."),
 
     //회원가입 온보딩 확인 여부 체크
     MEMBER_ONBOARDING_STATUS_CHECK_SUCCESS("[회원]의 추가 회원가입 정보 입력 필요 여부를 확인했습니다."),

--- a/src/main/java/com/tavemakers/surf/domain/member/dto/response/AdminTotalMemberListResDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/dto/response/AdminTotalMemberListResDTO.java
@@ -1,0 +1,22 @@
+package com.tavemakers.surf.domain.member.dto.response;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record AdminTotalMemberListResDTO(
+        long totalMemberCount,
+        List<GenerationResDTO> generations
+) {
+    public static AdminTotalMemberListResDTO of(long totalMemberCount, List<Integer> generations) {
+        List<GenerationResDTO> generationResDTOList = generations.stream()
+                .map(GenerationResDTO::from)
+                .toList();
+
+        return AdminTotalMemberListResDTO.builder()
+                .totalMemberCount(totalMemberCount)
+                .generations(generationResDTOList)
+                .build();
+    }
+}

--- a/src/main/java/com/tavemakers/surf/domain/member/dto/response/ApprovedMemberSliceResDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/dto/response/ApprovedMemberSliceResDTO.java
@@ -1,0 +1,25 @@
+package com.tavemakers.surf.domain.member.dto.response;
+
+import lombok.Builder;
+import org.springframework.data.domain.Slice;
+
+import java.util.List;
+
+@Builder
+public record ApprovedMemberSliceResDTO(
+        List<MemberRegistrationDetailResDTO> content,
+        int pageNumber,
+        int pageSize,
+        int numberOfElements,
+        boolean isLast
+) {
+    public static ApprovedMemberSliceResDTO from(Slice<MemberRegistrationDetailResDTO> slice) {
+        return ApprovedMemberSliceResDTO.builder()
+                .content(slice.getContent())
+                .pageNumber(slice.getNumber())
+                .pageSize(slice.getSize())
+                .numberOfElements(slice.getNumberOfElements())
+                .isLast(slice.isLast())
+                .build();
+    }
+}

--- a/src/main/java/com/tavemakers/surf/domain/member/dto/response/GenerationResDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/dto/response/GenerationResDTO.java
@@ -1,0 +1,18 @@
+package com.tavemakers.surf.domain.member.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record GenerationResDTO(
+        int generation,
+        String name
+) {
+    public static final String GENERATION_UI_SUFFIX = "기";
+
+    public static GenerationResDTO from(Integer generation) {
+        return GenerationResDTO.builder()
+                .generation(generation)
+                .name(generation + GENERATION_UI_SUFFIX)
+                .build();
+    }
+}

--- a/src/main/java/com/tavemakers/surf/domain/member/dto/response/MemberInformationResDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/dto/response/MemberInformationResDTO.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 import java.math.BigDecimal;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 @Builder
@@ -20,6 +21,7 @@ public record MemberInformationResDTO(
         String graduateSchool,
         String role,
         BigDecimal activityScore,
+        String createdAt,
 
         @Schema(
                 description = "가입 상태 (REGISTERING: 가입중, WAITING: 대기, APPROVED: 승인, REJECTED: 거절, WITHDRAWN: 탈퇴)",
@@ -31,6 +33,8 @@ public record MemberInformationResDTO(
         List<TrackResDTO> trackList,
         List<CareerResDTO> careerList
 ) {
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yy.MM.dd HH:mm");
+
     public static MemberInformationResDTO of(Member member, List<TrackResDTO> trackList, BigDecimal activityScore, List<CareerResDTO> careerList) {
         return MemberInformationResDTO.builder()
                 .username(member.getName())
@@ -44,6 +48,7 @@ public record MemberInformationResDTO(
                 .graduateSchool(member.getGraduateSchool())
                 .role(member.getRole().name())
                 .activityScore(activityScore)
+                .createdAt(member.getCreatedAt().format(FORMATTER))
                 .memberStatus(member.getStatus().name())
                 .isActive((member.isActivityStatus()))
                 .trackList(trackList)

--- a/src/main/java/com/tavemakers/surf/domain/member/dto/response/MemberRegistrationDetailResDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/dto/response/MemberRegistrationDetailResDTO.java
@@ -19,6 +19,7 @@ public record MemberRegistrationDetailResDTO(
                 example = "APPROVED",
                 allowableValues = {"REGISTERING", "WAITING", "APPROVED", "REJECTED", "WITHDRAWN"}
         )
+        String role,
         String memberStatus,
         String createdAt
 ) {
@@ -33,6 +34,7 @@ public record MemberRegistrationDetailResDTO(
                 .trackList(member.getTracks().stream()
                         .map(TrackResDTO::from)
                         .toList())
+                .role(member.getRole().name())
                 .memberStatus(member.getStatus().name())
                 .createdAt(member.getCreatedAt().format(FORMATTER))
                 .build();

--- a/src/main/java/com/tavemakers/surf/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/repository/MemberRepository.java
@@ -63,4 +63,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
             "where m.id = :memberId")
     Optional<Member> findByIdWithTracks(@Param("memberId") Long memberId);
 
+    long countByStatusAndIsDeletedFalse(MemberStatus status);
+
 }

--- a/src/main/java/com/tavemakers/surf/domain/member/repository/MemberSearchRepository.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/repository/MemberSearchRepository.java
@@ -61,6 +61,32 @@ public class MemberSearchRepository {
         return new SliceImpl<>(results, pageable, hasNext);
     }
 
+    public Slice<Member> searchMemberInAdminPage(Integer generation, String keyword, Pageable pageable) {
+        BooleanBuilder builder = createAdminPageMemberSearchBuilder(generation, keyword);
+        builder.and(member.status.eq(MemberStatus.APPROVED));
+
+        List<Member> results = queryFactory
+                .selectFrom(member)
+                .distinct()
+                .leftJoin(member.tracks, track)
+                .where(builder)
+                .orderBy(
+                        member.name.asc(),
+                        member.createdAt.asc()
+                )
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize() + 1)
+                .fetch();
+
+        boolean hasNext = false;
+        if (results.size() > pageable.getPageSize()) {
+            hasNext = true;
+            results.remove(results.size() - 1);
+        }
+
+        return new SliceImpl<>(results, pageable, hasNext);
+    }
+
     public Long countMembers(Integer generation, Part part, String keyword) {
         BooleanBuilder builder = createSearchBuilder(generation, part, keyword);
         builder.and(member.status.eq(MemberStatus.APPROVED));
@@ -90,6 +116,21 @@ public class MemberSearchRepository {
             builder.and(member.name.containsIgnoreCase(keyword)
                     .or(member.university.containsIgnoreCase(keyword))
                     .or(member.graduateSchool.containsIgnoreCase(keyword)));
+        }
+
+        return builder;
+    }
+
+    private BooleanBuilder createAdminPageMemberSearchBuilder(Integer generation,String keyword) {
+        BooleanBuilder builder = new BooleanBuilder();
+        builder.and(member.status.ne(MemberStatus.WITHDRAWN));
+
+        if (generation != null) {
+            builder.and(member.tracks.any().generation.eq(generation));
+        }
+
+        if (keyword != null && !keyword.isBlank()) {
+            builder.and(member.name.containsIgnoreCase(keyword));
         }
 
         return builder;

--- a/src/main/java/com/tavemakers/surf/domain/member/repository/TrackRepository.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/repository/TrackRepository.java
@@ -29,4 +29,8 @@ public interface TrackRepository extends JpaRepository<Track, Long> {
     List<Track> findAllWithActiveMember();
 
     List<Track> findByMemberId(Long memberId);
+
+    @Query("SELECT DISTINCT t.generation FROM Track t ORDER BY t.generation DESC")
+    List<Integer> findAllDistinctGenerations();
+
 }

--- a/src/main/java/com/tavemakers/surf/domain/member/service/MemberGetService.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/service/MemberGetService.java
@@ -125,4 +125,8 @@ public class MemberGetService {
         return memberRepository.countByStatusAndIsDeletedFalse(MemberStatus.APPROVED);
     }
 
+    public Slice<Member> getApprovedMemberList(Integer generation, String keyword, Pageable pageable) {
+        return memberSearchRepository.searchMemberInAdminPage(generation, keyword, pageable);
+    }
+
 }

--- a/src/main/java/com/tavemakers/surf/domain/member/service/MemberGetService.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/service/MemberGetService.java
@@ -121,4 +121,8 @@ public class MemberGetService {
         return memberRepository.existsByIdAndStatusNot(memberId, status);
     }
 
+    public long getApprovedMemberCount() {
+        return memberRepository.countByStatusAndIsDeletedFalse(MemberStatus.APPROVED);
+    }
+
 }

--- a/src/main/java/com/tavemakers/surf/domain/member/service/TrackGetService.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/service/TrackGetService.java
@@ -38,4 +38,8 @@ public class TrackGetService {
         return trackRepository.findAllWithActiveMember();
     }
 
+    public List<Integer> getExistsAllGenerations() {
+        return trackRepository.findAllDistinctGenerations();
+    }
+
 }

--- a/src/main/java/com/tavemakers/surf/domain/member/usecase/MemberAdminUsecase.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/usecase/MemberAdminUsecase.java
@@ -3,20 +3,12 @@ package com.tavemakers.surf.domain.member.usecase;
 import com.tavemakers.surf.domain.login.auth.service.RefreshTokenService;
 import com.tavemakers.surf.domain.member.dto.request.AdminPageLoginReqDto;
 import com.tavemakers.surf.domain.member.dto.request.PasswordReqDto;
-import com.tavemakers.surf.domain.member.dto.response.AdminPageLoginResDto;
-import com.tavemakers.surf.domain.member.dto.response.CareerResDTO;
-import com.tavemakers.surf.domain.member.dto.response.MemberInformationResDTO;
-import com.tavemakers.surf.domain.member.dto.response.TrackResDTO;
-import com.tavemakers.surf.domain.member.dto.response.MemberRegistrationDetailResDTO;
-import com.tavemakers.surf.domain.member.dto.response.MemberRegistrationSliceResDTO;
+import com.tavemakers.surf.domain.member.dto.response.*;
 import com.tavemakers.surf.domain.member.entity.Member;
 import com.tavemakers.surf.domain.member.entity.enums.MemberRole;
 import com.tavemakers.surf.domain.member.entity.enums.MemberStatus;
 import com.tavemakers.surf.domain.member.exception.AdminPageRoleException;
-import com.tavemakers.surf.domain.member.service.CareerGetService;
-import com.tavemakers.surf.domain.member.service.MemberGetService;
-import com.tavemakers.surf.domain.member.service.MemberPatchService;
-import com.tavemakers.surf.domain.member.service.MemberService;
+import com.tavemakers.surf.domain.member.service.*;
 import com.tavemakers.surf.domain.score.entity.PersonalActivityScore;
 import com.tavemakers.surf.domain.score.service.PersonalScoreGetService;
 import com.tavemakers.surf.domain.score.service.PersonalScoreCreateService;
@@ -50,6 +42,7 @@ public class MemberAdminUsecase {
     private final PersonalScoreGetService scoreGetService;
     private final JwtService jwtService;
     private final RefreshTokenService refreshTokenService;
+    private final TrackGetService trackGetService;
 
     /** 회원 권한 변경 */
     @Transactional
@@ -128,6 +121,13 @@ public class MemberAdminUsecase {
         }
 
         return MemberInformationResDTO.of(member, memberTracks, null, memberCareers);
+    }
+
+    /** 승인된 전체 회원수와 모든 기수를 구함. */
+    public AdminTotalMemberListResDTO readAllMemberCountAndGeneration() {
+        long approvedMemberCount = memberGetService.getApprovedMemberCount();
+        List<Integer> existsAllGenerations = trackGetService.getExistsAllGenerations();
+        return AdminTotalMemberListResDTO.of(approvedMemberCount, existsAllGenerations);
     }
 
     private void validateLoginMemberRole(Member member) {

--- a/src/main/java/com/tavemakers/surf/domain/member/usecase/MemberAdminUsecase.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/usecase/MemberAdminUsecase.java
@@ -130,6 +130,14 @@ public class MemberAdminUsecase {
         return AdminTotalMemberListResDTO.of(approvedMemberCount, existsAllGenerations);
     }
 
+    /** 승인된 회원 목록 스크롤 조회 */
+    public ApprovedMemberSliceResDTO readApprovedMemberList(Integer generation, String keyword, int pageSize, int pageNum) {
+        Pageable pageable = PageRequest.of(pageNum, pageSize, Sort.by("createdAt").descending());
+        Slice<MemberRegistrationDetailResDTO> approvedMemberSlice = memberGetService.getApprovedMemberList(generation, keyword, pageable)
+                .map(MemberRegistrationDetailResDTO::from);
+        return ApprovedMemberSliceResDTO.from(approvedMemberSlice);
+    }
+
     private void validateLoginMemberRole(Member member) {
         if(member.isMember()){
             throw new AdminPageRoleException();


### PR DESCRIPTION
## 📄 작업 내용 요약

1. 승인된 전체 회원 수 & 존재하는 모든 기수 목록 조회 API
2. 승인된 전체 회원 목록 스크롤 조회 API 

### 승인된 전체 회원수 & 존재하는 모든 기수 목록 조회 API

다음과 같이 관리자 페이지에서 회원 목록을 불러올 때,
- 첫 UI에 필요한 `전체 회원수` 그리고 모든 기수 목록을 불러옵니다.
- 프론트 편의를 위해 `16`과 `16기` 모두 반환

<img width="250" height="550" alt="image" src="https://github.com/user-attachments/assets/9fd301a6-bf80-459b-992b-5890170ce5f3" />

### 승인된 전체 회원 목록 스크롤 조회 API

다음 UI를 참고하시길 바랍니다. 

- `기수`를 기준으로 스크롤 조회를 구현합니다.
- ex 16기, 15기 별로 따로 스크롤.
- 검색어는 `회원이름 `

<img width="250" height="550" alt="image" src="https://github.com/user-attachments/assets/44455671-0480-4848-899d-2079245a9cd5" />

### 승인된 전체 회원수 & 존재하는 모든 기수 목록 조회 응답 JSON
```json
{
    "code": 200,
    "message": "[전체 회원수]와 회원들의 모든 [기수]를 조회합니다.",
    "data": {
        "totalMemberCount": 8,
        "generations": [
            {
                "generation": 16,
                "name": "16기"
            },
            {
                "generation": 15,
                "name": "15기"
            },
            {
                "generation": 14,
                "name": "14기"
            },
            {
                "generation": 13,
                "name": "13기"
            }
        ]
    }
}
```


### 승인된 전체 회원 목록 스크롤 조회 응답 JSON

```json
{
    "code": 200,
    "message": "승인된 [전체 회원 목록]을 조회합니다.",
    "data": {
        "content": [
            {
                "memberId": 8,
                "username": "김철수",
                "university": "홍익대학교",
                "profileImageUrl": "http://k.kakaocdn.net/dn/cyqMaV/btsQUkzahNj/xbNYCRDY8NOmcBDNB69z31/img_640x640.jpg",
                "trackList": [
                    {
                        "generation": 15,
                        "part": "BACKEND"
                    },
                    {
                        "generation": 14,
                        "part": "DESIGN"
                    }
                ],
                "role": "MANAGER",
                "memberStatus": "APPROVED",
                "createdAt": "25.09.28 15:50"
            },
            {
                "memberId": 7,
                "username": "이영미",
                "university": null,
                "profileImageUrl": "http://k.kakaocdn.net/dn/b2zau5/btsM4KP9nIl/R4aIKt1TkBk2BJeVW8NMMk/img_640x640.jpg",
                "trackList": [
                    {
                        "generation": 14,
                        "part": "BACKEND"
                    }
                ],
                "role": "MEMBER",
                "memberStatus": "APPROVED",
                "createdAt": "25.10.08 14:00"
            }
        ],
        "pageNumber": 0,
        "pageSize": 10,
        "numberOfElements": 2,
        "isLast": true,
        "totalMemberCount": null
    }
}
```

## 📎 Issue #253
<!-- closed #253 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 관리자용 멤버 통계 조회 기능 추가: 전체 멤버 수 및 가입 세대 정보 조회 가능
  * 관리자용 멤버 검색 기능 추가: 승인된 멤버 목록을 세대 및 검색어로 필터링하고 페이지네이션을 통해 조회 가능
  * 멤버 생성 시각 정보를 멤버 상세 정보에 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->