### PR TITLE
[FIX] 게시글 본문 글자 수 제한 해제 (#257)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,8 +43,8 @@ dependencies {
     annotationProcessor("org.projectlombok:lombok")
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
-
     testImplementation ("org.junit.jupiter:junit-jupiter-api:5.10.1")
+    testRuntimeOnly("com.h2database:h2")
 
     implementation ("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2")
 

--- a/src/main/java/com/tavemakers/surf/domain/member/entity/Member.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/entity/Member.java
@@ -99,6 +99,10 @@ public class Member extends BaseEntity {
         return status == MemberStatus.APPROVED;
     }
 
+    public boolean isRegistering() {
+        return status == MemberStatus.REGISTERING;
+    }
+
     @Builder
     public Member(Long kakaoId,
                   String name,

--- a/src/main/java/com/tavemakers/surf/domain/member/service/MemberService.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/service/MemberService.java
@@ -6,9 +6,7 @@ import com.tavemakers.surf.domain.member.entity.Member;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import com.tavemakers.surf.domain.member.entity.enums.MemberStatus;
 
-import java.util.List;
 import java.util.Locale;
 import lombok.extern.slf4j.Slf4j;
 
@@ -35,31 +33,4 @@ public class MemberService {
         return MemberSignupResDTO.from(member);
     }
 
-    /** 회원 승인 (관리자) */
-    @Transactional
-    public void approveMembers(List<Member> members) {
-        for (Member member : members) {
-            member.approve();
-        }
-    }
-
-    /** 회원 거절 (관리자) */
-    @Transactional
-    public void rejectMembers(List<Member> members) {
-        for (Member member : members) {
-            member.reject();
-        }
-    }
-
-    /** 온보딩 필요 여부 확인 */
-    @Transactional(readOnly = true)
-    public Boolean needsOnboarding(Member member) {
-        return member.getStatus().equals(MemberStatus.REGISTERING);
-    }
-
-    /** 회원 상태 조회 */
-    @Transactional(readOnly = true)
-    public MemberStatus memberStatusCheck(Member member) {
-        return member.getStatus();
-    }
 }

--- a/src/main/java/com/tavemakers/surf/domain/member/usecase/MemberAdminUsecase.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/usecase/MemberAdminUsecase.java
@@ -36,7 +36,6 @@ public class MemberAdminUsecase {
 
     private final MemberPatchService memberPatchService;
     private final MemberGetService memberGetService;
-    private final MemberService memberService;
     private final CareerGetService careerGetService;
     private final PersonalScoreCreateService personalScoreCreateService;
     private final PersonalScoreGetService scoreGetService;
@@ -59,7 +58,7 @@ public class MemberAdminUsecase {
             @LogParam("approver_id") Long approverId
     ) {
         List<Member> members = memberGetService.getMembersByStatus(memberIds, MemberStatus.WAITING);
-        memberService.approveMembers(members);
+        members.forEach(Member::approve);
         personalScoreCreateService.savePersonalScores(members);
     }
 
@@ -71,7 +70,7 @@ public class MemberAdminUsecase {
             @LogParam("approver_id") Long approverId
     ) {
         List<Member> members = memberGetService.getMembersByStatus(memberIds, MemberStatus.WAITING);
-        memberService.rejectMembers(members);
+        members.forEach(Member::reject);
     }
 
     /** 관리자 비밀번호 설정 */

--- a/src/main/java/com/tavemakers/surf/domain/member/usecase/MemberUsecase.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/usecase/MemberUsecase.java
@@ -157,13 +157,12 @@ public class MemberUsecase {
     ) {
         Member member = memberGetService.getMember(memberId);
 
-        Boolean needOnboarding = memberService.needsOnboarding(member);
-        MemberStatus memberStatus = memberService.memberStatusCheck(member);
+        Boolean needOnboarding = member.isRegistering();
+        MemberStatus memberStatus = member.getStatus();
 
         MemberRole memberRole = SecurityUtils.getCurrentMember().getRole();
 
-        OnboardingCheckResDTO dto = OnboardingCheckResDTO.of(memberId, needOnboarding, memberStatus, memberRole);
-        return dto;
+        return OnboardingCheckResDTO.of(memberId, needOnboarding, memberStatus, memberRole);
     }
 
     /** 회원가입 요청 및 MemberStatus에 따른 로그 분기 */

--- a/src/main/java/com/tavemakers/surf/domain/post/entity/Post.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/entity/Post.java
@@ -32,6 +32,7 @@ public class Post extends BaseEntity {
     private String title;
 
     @NotBlank
+    @Column(columnDefinition = "LONGTEXT")
     private String content;
 
     private LocalDateTime postedAt;

--- a/src/test/java/com/tavemakers/surf/domain/post/entity/PostContentLongTextTest.java
+++ b/src/test/java/com/tavemakers/surf/domain/post/entity/PostContentLongTextTest.java
@@ -1,0 +1,173 @@
+package com.tavemakers.surf.domain.post.entity;
+
+import com.tavemakers.surf.domain.board.entity.Board;
+import com.tavemakers.surf.domain.board.entity.BoardCategory;
+import com.tavemakers.surf.domain.board.entity.BoardType;
+import com.tavemakers.surf.domain.member.entity.Member;
+import com.tavemakers.surf.domain.member.entity.enums.MemberRole;
+import com.tavemakers.surf.domain.member.entity.enums.MemberStatus;
+import com.tavemakers.surf.domain.member.entity.enums.MemberType;
+import com.tavemakers.surf.domain.post.repository.PostRepository;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@ActiveProfiles("test")
+class PostContentLongTextTest {
+
+    @Autowired
+    private PostRepository postRepository;
+
+    @Autowired
+    private EntityManager em;
+
+    private Member member;
+    private Board board;
+    private BoardCategory category;
+
+    @BeforeEach
+    void setUp() {
+        // Member 생성
+        member = Member.builder()
+                .kakaoId(123456789L)
+                .name("테스트유저")
+                .email("test@test.com")
+                .status(MemberStatus.APPROVED)
+                .role(MemberRole.MEMBER)
+                .memberType(MemberType.YB)
+                .activityStatus(true)
+                .build();
+        em.persist(member);
+
+        // Board 생성 (type 필수)
+        board = Board.builder()
+                .name("테스트게시판")
+                .type(BoardType.NOTICE)
+                .build();
+        em.persist(board);
+
+        // BoardCategory 생성 (slug 필수)
+        category = BoardCategory.builder()
+                .name("테스트카테고리")
+                .slug("test-category")
+                .board(board)
+                .build();
+        em.persist(category);
+
+        em.flush();
+        em.clear();
+    }
+
+    @Test
+    @DisplayName("255자 이상의 긴 본문 저장 테스트")
+    void savePostWithLongContent() {
+        // given: 1000자 이상의 긴 본문 생성
+        String longContent = "가".repeat(1000);
+        assertThat(longContent.length()).isEqualTo(1000);
+
+        Post post = Post.builder()
+                .title("테스트 제목")
+                .content(longContent)
+                .postedAt(LocalDateTime.now())
+                .board(em.find(Board.class, board.getId()))
+                .boardName(board.getName())
+                .category(em.find(BoardCategory.class, category.getId()))
+                .categoryName(category.getName())
+                .member(em.find(Member.class, member.getId()))
+                .scrapCount(0L)
+                .likeCount(0L)
+                .commentCount(0L)
+                .isReserved(false)
+                .hasSchedule(false)
+                .viewCount(0)
+                .build();
+
+        // when
+        Post savedPost = postRepository.save(post);
+        em.flush();
+        em.clear();
+
+        // then
+        Post foundPost = postRepository.findById(savedPost.getId()).orElseThrow();
+        assertThat(foundPost.getContent()).isEqualTo(longContent);
+        assertThat(foundPost.getContent().length()).isEqualTo(1000);
+    }
+
+    @Test
+    @DisplayName("10,000자 긴 본문 저장 테스트")
+    void savePostWith10000CharContent() {
+        // given: 10,000자의 매우 긴 본문
+        String veryLongContent = "테스트내용입니다.".repeat(1000);
+        assertThat(veryLongContent.length()).isGreaterThan(5000);
+
+        Post post = Post.builder()
+                .title("매우 긴 본문 테스트")
+                .content(veryLongContent)
+                .postedAt(LocalDateTime.now())
+                .board(em.find(Board.class, board.getId()))
+                .boardName(board.getName())
+                .category(em.find(BoardCategory.class, category.getId()))
+                .categoryName(category.getName())
+                .member(em.find(Member.class, member.getId()))
+                .scrapCount(0L)
+                .likeCount(0L)
+                .commentCount(0L)
+                .isReserved(false)
+                .hasSchedule(false)
+                .viewCount(0)
+                .build();
+
+        // when
+        Post savedPost = postRepository.save(post);
+        em.flush();
+        em.clear();
+
+        // then
+        Post foundPost = postRepository.findById(savedPost.getId()).orElseThrow();
+        assertThat(foundPost.getContent()).isEqualTo(veryLongContent);
+    }
+
+    @Test
+    @DisplayName("100,000자 초대형 본문 저장 테스트 (LONGTEXT 검증)")
+    void savePostWith100000CharContent() {
+        // given: 100,000자의 초대형 본문 (VARCHAR로는 불가능한 크기)
+        String hugeContent = "A".repeat(100_000);
+        assertThat(hugeContent.length()).isEqualTo(100_000);
+
+        Post post = Post.builder()
+                .title("초대형 본문 테스트")
+                .content(hugeContent)
+                .postedAt(LocalDateTime.now())
+                .board(em.find(Board.class, board.getId()))
+                .boardName(board.getName())
+                .category(em.find(BoardCategory.class, category.getId()))
+                .categoryName(category.getName())
+                .member(em.find(Member.class, member.getId()))
+                .scrapCount(0L)
+                .likeCount(0L)
+                .commentCount(0L)
+                .isReserved(false)
+                .hasSchedule(false)
+                .viewCount(0)
+                .build();
+
+        // when
+        Post savedPost = postRepository.save(post);
+        em.flush();
+        em.clear();
+
+        // then
+        Post foundPost = postRepository.findById(savedPost.getId()).orElseThrow();
+        assertThat(foundPost.getContent()).isEqualTo(hugeContent);
+        assertThat(foundPost.getContent().length()).isEqualTo(100_000);
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,34 @@
+spring:
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:testdb;MODE=MySQL;DB_CLOSE_DELAY=-1
+    username: sa
+    password:
+  jpa:
+    show-sql: true
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.H2Dialect
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
+jwt:
+  secret: testsecrettestsecrettestsecrettestsecrettestsecret
+  access-token-expiration: 3600000
+  refresh-token-expiration: 604800000
+
+cloud:
+  aws:
+    s3:
+      bucket: test-bucket
+    region:
+      static: ap-northeast-2
+    credentials:
+      access-key: test
+      secret-key: test
+    stack:
+      auto: false


### PR DESCRIPTION
## Summary
- Post.content 필드에 `@Column(columnDefinition = "LONGTEXT")` 적용
- 기존 VARCHAR(255) 제한으로 인한 긴 본문 저장 불가 문제 해결
- 100,000자 이상의 본문 저장 가능

## Changes
- `Post.java`: content 필드 LONGTEXT 컬럼 정의 추가
- `build.gradle.kts`: H2 테스트 DB 의존성 추가
- 테스트 코드 및 테스트 설정 추가

## Test
- 1,000자 / 10,000자 / 100,000자 본문 저장 테스트 통과

Closes #257

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 긴 텍스트 콘텐츠의 안정적인 저장 지원 개선

* **테스트**
  * 대용량 텍스트 콘텐츠(1,000~100,000자) 저장 및 검증 테스트 추가
  * 테스트 환경 구성 및 데이터베이스 설정 추가

* **리팩터**
  * 관리자 회원 승인/거부 및 가입 상태 처리 로직 간소화 (내부 처리 방식 변경)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->