### PR TITLE
[Feat] 회원 권한 변경 API V2

### DIFF
--- a/src/main/java/com/tavemakers/surf/domain/member/controller/AdminMemberController.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/controller/AdminMemberController.java
@@ -1,6 +1,7 @@
 package com.tavemakers.surf.domain.member.controller;
 
 import com.tavemakers.surf.domain.member.dto.request.RoleChangeReqDTO;
+import com.tavemakers.surf.domain.member.dto.request.RoleChangeRequestDtoV2;
 import com.tavemakers.surf.domain.member.dto.response.AdminTotalMemberListResDTO;
 import com.tavemakers.surf.domain.member.dto.response.ApprovedMemberSliceResDTO;
 import com.tavemakers.surf.domain.member.dto.response.MemberInformationResDTO;
@@ -31,6 +32,14 @@ public class AdminMemberController {
             @RequestBody @Valid RoleChangeReqDTO request) {
 
         memberAdminUsecase.changeRole(memberId, request.role());
+        return ApiResponse.response(HttpStatus.OK, "회원 역할이 성공적으로 변경되었습니다.",null);
+    }
+
+    @PatchMapping
+    public ApiResponse<Void> changeMembersRole(
+            @RequestBody RoleChangeRequestDtoV2 dto
+    ) {
+        memberAdminUsecase.changeMembersRole(dto);
         return ApiResponse.response(HttpStatus.OK, "회원 역할이 성공적으로 변경되었습니다.",null);
     }
 

--- a/src/main/java/com/tavemakers/surf/domain/member/controller/AdminMemberController.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/controller/AdminMemberController.java
@@ -35,6 +35,7 @@ public class AdminMemberController {
         return ApiResponse.response(HttpStatus.OK, "회원 역할이 성공적으로 변경되었습니다.",null);
     }
 
+    @Operation(summary = "회원 역할 변경", description = "여러 회원들의 역할을 변경합니다.")
     @PatchMapping("/v1/admin/members/role")
     public ApiResponse<Void> changeMembersRole(
             @RequestBody RoleChangeReqDTOV2 dto

--- a/src/main/java/com/tavemakers/surf/domain/member/controller/AdminMemberController.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/controller/AdminMemberController.java
@@ -1,7 +1,7 @@
 package com.tavemakers.surf.domain.member.controller;
 
 import com.tavemakers.surf.domain.member.dto.request.RoleChangeReqDTO;
-import com.tavemakers.surf.domain.member.dto.request.RoleChangeRequestDtoV2;
+import com.tavemakers.surf.domain.member.dto.request.RoleChangeReqDTOV2;
 import com.tavemakers.surf.domain.member.dto.response.AdminTotalMemberListResDTO;
 import com.tavemakers.surf.domain.member.dto.response.ApprovedMemberSliceResDTO;
 import com.tavemakers.surf.domain.member.dto.response.MemberInformationResDTO;
@@ -35,9 +35,9 @@ public class AdminMemberController {
         return ApiResponse.response(HttpStatus.OK, "회원 역할이 성공적으로 변경되었습니다.",null);
     }
 
-    @PatchMapping
+    @PatchMapping("/v1/admin/members/role")
     public ApiResponse<Void> changeMembersRole(
-            @RequestBody RoleChangeRequestDtoV2 dto
+            @RequestBody RoleChangeReqDTOV2 dto
     ) {
         memberAdminUsecase.changeMembersRole(dto);
         return ApiResponse.response(HttpStatus.OK, "회원 역할이 성공적으로 변경되었습니다.",null);

--- a/src/main/java/com/tavemakers/surf/domain/member/dto/request/RoleChangeReqDTOV2.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/dto/request/RoleChangeReqDTOV2.java
@@ -6,7 +6,7 @@ import jakarta.validation.constraints.NotNull;
 
 import java.util.List;
 
-public record RoleChangeRequestDtoV2(
+public record RoleChangeReqDTOV2(
 
         @Schema(description = "Role 변경 대상의 ID 목록")
         List<Long> memberIdList,

--- a/src/main/java/com/tavemakers/surf/domain/member/dto/request/RoleChangeRequestDtoV2.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/dto/request/RoleChangeRequestDtoV2.java
@@ -1,0 +1,17 @@
+package com.tavemakers.surf.domain.member.dto.request;
+
+import com.tavemakers.surf.domain.member.entity.enums.MemberRole;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
+
+public record RoleChangeRequestDtoV2(
+
+        @Schema(description = "Role 변경 대상의 ID 목록")
+        List<Long> memberIdList,
+
+        @Schema(description = "변경할 역할", example = "MANAGER")
+        @NotNull(message = "역할은 필수입니다.")
+        MemberRole role
+) {}

--- a/src/main/java/com/tavemakers/surf/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/repository/MemberRepository.java
@@ -65,4 +65,11 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     long countByStatusAndIsDeletedFalse(MemberStatus status);
 
+    @Query("""
+        select m 
+        from Member m 
+        where m.id in :memberIds
+    """)
+    List<Member> findMembersByIds(@Param("memberIds") List<Long> memberIds);
+
 }

--- a/src/main/java/com/tavemakers/surf/domain/member/service/MemberGetService.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/service/MemberGetService.java
@@ -129,4 +129,8 @@ public class MemberGetService {
         return memberSearchRepository.searchMemberInAdminPage(generation, keyword, pageable);
     }
 
+    public List<Member> findMembersByIds(List<Long> memberIds) {
+        return memberRepository.findMembersByIds(memberIds);
+    }
+
 }

--- a/src/main/java/com/tavemakers/surf/domain/member/service/MemberPatchService.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/service/MemberPatchService.java
@@ -25,6 +25,7 @@ public class MemberPatchService {
         member.exchangeRole(role);
     }
 
+    /** 여러 회원의 권한을 일괄 변경 version 2*/
     @Transactional
     public void grantRoleV2(List<Member> members, MemberRole role) {
         members.forEach(member -> member.exchangeRole(role));

--- a/src/main/java/com/tavemakers/surf/domain/member/service/MemberPatchService.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/service/MemberPatchService.java
@@ -7,6 +7,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class MemberPatchService {
@@ -21,5 +23,11 @@ public class MemberPatchService {
     public void grantRole(Member member, MemberRole role) {
         //유저 권한 부여
         member.exchangeRole(role);
+    }
+
+    @Transactional
+    public void grantRoleV2(List<Member> members, MemberRole role) {
+        members.forEach(member -> member.exchangeRole(role));
+
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/member/usecase/MemberAdminUsecase.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/usecase/MemberAdminUsecase.java
@@ -3,6 +3,7 @@ package com.tavemakers.surf.domain.member.usecase;
 import com.tavemakers.surf.domain.login.auth.service.RefreshTokenService;
 import com.tavemakers.surf.domain.member.dto.request.AdminPageLoginReqDto;
 import com.tavemakers.surf.domain.member.dto.request.PasswordReqDto;
+import com.tavemakers.surf.domain.member.dto.request.RoleChangeRequestDtoV2;
 import com.tavemakers.surf.domain.member.dto.response.*;
 import com.tavemakers.surf.domain.member.entity.Member;
 import com.tavemakers.surf.domain.member.entity.enums.MemberRole;
@@ -49,6 +50,13 @@ public class MemberAdminUsecase {
     public void changeRole (Long memberId, MemberRole role) {
         Member member = memberGetService.getMember(memberId);
         memberPatchService.grantRole(member, role);
+    }
+
+    /** 회원 권한 변경 Version 2 */
+    @Transactional
+    public void changeMembersRole(RoleChangeRequestDtoV2 dto) {
+        List<Member> members = memberGetService.findMembersByIds(dto.memberIdList());
+        memberPatchService.grantRoleV2(members, dto.role());
     }
 
     /** 회원가입 승인 처리 */

--- a/src/main/java/com/tavemakers/surf/domain/member/usecase/MemberAdminUsecase.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/usecase/MemberAdminUsecase.java
@@ -3,7 +3,7 @@ package com.tavemakers.surf.domain.member.usecase;
 import com.tavemakers.surf.domain.login.auth.service.RefreshTokenService;
 import com.tavemakers.surf.domain.member.dto.request.AdminPageLoginReqDto;
 import com.tavemakers.surf.domain.member.dto.request.PasswordReqDto;
-import com.tavemakers.surf.domain.member.dto.request.RoleChangeRequestDtoV2;
+import com.tavemakers.surf.domain.member.dto.request.RoleChangeReqDTOV2;
 import com.tavemakers.surf.domain.member.dto.response.*;
 import com.tavemakers.surf.domain.member.entity.Member;
 import com.tavemakers.surf.domain.member.entity.enums.MemberRole;
@@ -53,7 +53,7 @@ public class MemberAdminUsecase {
 
     /** 회원 권한 변경 Version 2 */
     @Transactional
-    public void changeMembersRole(RoleChangeRequestDtoV2 dto) {
+    public void changeMembersRole(RoleChangeReqDTOV2 dto) {
         List<Member> members = memberGetService.findMembersByIds(dto.memberIdList());
         memberPatchService.grantRoleV2(members, dto.role());
     }


### PR DESCRIPTION
## 📄 작업 내용 요약

### 회원 권한 변경 API V2
기존에 존재하는 회원 권한 변경 API는 단일 회원에게만 적용할 수 있었습니다.
여러명의 회원 권한을 변경할 수 있는  API를 추가로 제작했습니다.

## 📎 Issue #241
<!-- closed #241 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 여러 멤버의 역할을 한 번에 변경할 수 있는 대량 역할 변경 기능 추가
  * 기존 개별 멤버 역할 변경 기능은 유지됨
<!-- end of auto-generated comment: release notes by coderabbit.ai -->