### PR TITLE
[Refactor] 게시글 예약 기능 개선

### DIFF
--- a/src/main/java/com/tavemakers/surf/domain/notification/service/NotificationEventListener.java
+++ b/src/main/java/com/tavemakers/surf/domain/notification/service/NotificationEventListener.java
@@ -11,11 +11,15 @@ import com.tavemakers.surf.domain.post.exception.PostNotFoundException;
 import com.tavemakers.surf.domain.post.repository.PostRepository;
 import com.tavemakers.surf.domain.post.service.support.PostPublishedEvent;
 import java.util.Map;
+
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
 
 @Slf4j
 @Component
@@ -27,7 +31,8 @@ public class NotificationEventListener {
     private final NotificationCreateService notificationCreateService;
 
     @Async
-    @EventListener
+    @Transactional
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handle(PostPublishedEvent event) {
         Post post = postRepository.findById(event.getPostId())
                 .orElseThrow(PostNotFoundException::new);

--- a/src/main/java/com/tavemakers/surf/domain/post/service/post/PostGetService.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/service/post/PostGetService.java
@@ -17,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -73,6 +74,11 @@ public class PostGetService {
         }
 
         return PostDetailResDTO.of(post, scrappedByMe, likedByMe, isMine, imageUrlList, reservedAt, viewCount);
+    }
+
+    /** 게시글 예약을 위한 Post 조회 */
+    public Optional<Post> findPost(Long id) {
+        return postRepository.findById(id);
     }
 
     /** 게시글 ID로 엔티티 조회 */

--- a/src/main/java/com/tavemakers/surf/domain/reservation/entity/Reservation.java
+++ b/src/main/java/com/tavemakers/surf/domain/reservation/entity/Reservation.java
@@ -44,8 +44,4 @@ public class Reservation extends BaseEntity {
         status = ReservationStatus.CANCELLED;
     }
 
-    public boolean isCanceled() {
-        return status == ReservationStatus.CANCELLED;
-    }
-
 }

--- a/src/main/java/com/tavemakers/surf/domain/reservation/entity/Reservation.java
+++ b/src/main/java/com/tavemakers/surf/domain/reservation/entity/Reservation.java
@@ -44,4 +44,8 @@ public class Reservation extends BaseEntity {
         status = ReservationStatus.CANCELLED;
     }
 
+    public boolean isCanceled() {
+        return status == ReservationStatus.CANCELLED;
+    }
+
 }

--- a/src/main/java/com/tavemakers/surf/domain/reservation/task/PostPublishRunner.java
+++ b/src/main/java/com/tavemakers/surf/domain/reservation/task/PostPublishRunner.java
@@ -1,17 +1,19 @@
 package com.tavemakers.surf.domain.reservation.task;
 
 import com.tavemakers.surf.domain.post.entity.Post;
-import com.tavemakers.surf.domain.post.exception.PostAlreadyDeletedException;
 import com.tavemakers.surf.domain.post.repository.PostRepository;
+import com.tavemakers.surf.domain.post.service.post.PostGetService;
 import com.tavemakers.surf.domain.post.service.support.PostPublishedEvent;
 import com.tavemakers.surf.domain.reservation.entity.Reservation;
-import com.tavemakers.surf.domain.reservation.exception.ReservationCanceledException;
 import com.tavemakers.surf.domain.reservation.service.ReservationGetService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
 
 @Slf4j
 @Service
@@ -19,19 +21,21 @@ import org.springframework.transaction.annotation.Transactional;
 public class PostPublishRunner {
 
     private final ReservationGetService reservationGetService;
+    private final PostGetService postGetService;
     private final PostRepository postRepository;
     private final ApplicationEventPublisher eventPublisher;
 
 
-    @Transactional(noRollbackFor = PostAlreadyDeletedException.class)
+    @Transactional
     public void publishPost(Long reservationId) {
         Reservation reservation = reservationGetService.getReservationById(reservationId);
-        validateReservation(reservation);
+        Post post = getPost(reservation);
+        if (post == null) {
+            reservation.cancel();
+            log.info("게시글이 삭제되어 예약을 취소합니다. reservationId={}", reservationId);
+            return;
+        }
 
-        Post post = postRepository.findById(reservation.getPostId()).orElse(null);
-        cancelReservationIfPostDeleted(post, reservation);
-
-        log.info("예약 번호 {}번 예약 작업 수행", reservationId);
         post.publish();
         reservation.publish();
 
@@ -39,19 +43,12 @@ public class PostPublishRunner {
                 new PostPublishedEvent(post.getId())
         );
 
+        log.info("예약 번호 {}번 예약 작업 수행", reservationId);
     }
 
-    private void cancelReservationIfPostDeleted(Post post, Reservation reservation) {
-        if(post == null) {
-            reservation.cancel();
-            throw new PostAlreadyDeletedException();
-        }
-    }
-
-    private void validateReservation(Reservation reservation) {
-        if(reservation == null) {
-            throw new ReservationCanceledException();
-        }
+    private @Nullable Post getPost(Reservation reservation) {
+        return postGetService.findPost(reservation.getPostId())
+                .orElse(null);
     }
 
 }


### PR DESCRIPTION
## 📄 작업 내용 요약

### 1. 필요 없는 Reservation cancel 체크 삭제

getReservationById에서 이미 `ReservationStatus.RESERVED`로 조회함.
기존의 isCanceled 체크는 삭제

https://github.com/Tave-Makers/SURF-BE/blob/61b1b701cf9efbc498274ab8998fcc7c6b416f51/src/main/java/com/tavemakers/surf/domain/reservation/service/ReservationGetService.java#L18-L22

### 2. Post Optional 조회

PostGetService에서 조회 시, orElseThrow로 가져오게되면,
바로 예외 처리가 되어, reservation의 상태를 cancel로 변경하지 못함.
따라서 Optional<Post>로 가져온 뒤, PostPublishRunner 내부에서 null 확인 후, `reservation.cancel()` + `early return`

### 3. @TransactionalEventListener

기존에 사용되었던 EventListener를 사용하면, 이벤트 발행 시점에 바로 알림이 전송됨.
따라서 게시글 게시 전에 알림이 갈 수 있음.

https://github.com/Tave-Makers/SURF-BE/blob/61b1b701cf9efbc498274ab8998fcc7c6b416f51/src/main/java/com/tavemakers/surf/domain/notification/service/NotificationEventListener.java#L29-L31

게시글이 `RESERVED` 상태 적용 이후 알림이 갈 수 있도록 `@TransactionalEventListener`과 AFTER_COMMIT 적용.


## 📎 Issue #281
<!-- closed #281 -->