### PR TITLE
[Refactor] 아키텍처 정리 — 타 도메인 Repository 참조 제거, N+1 해결, Usecase 계층 신설

### DIFF
--- a/scripts/qa/common.sh
+++ b/scripts/qa/common.sh
@@ -51,11 +51,45 @@ load_test_ids() {
 
     return 0
   else
-    # 기본값 (테스트 ID 파일이 없을 때)
-    TEST_BOARD_ID="1"
+    # test-ids.json 없을 때 API로 최신 ID 동적 조회
+    TEST_BOARD_ID="2"
     TEST_CATEGORY_ID="1"
-    TEST_POST_ID=""
-    TEST_COMMENT_ID=""
+
+    # 최신 게시글 ID 조회
+    _posts_resp=$(curl -s -H "Authorization: Bearer $QA_TOKEN" \
+      "${BASE_URL}/v1/user/posts?boardId=${TEST_BOARD_ID}&page=0&size=1" 2>/dev/null)
+    TEST_POST_ID=$(echo "$_posts_resp" | jq -r '.data.content[0].postId // empty' 2>/dev/null)
+
+    # 게시글이 없으면 새로 생성
+    if [ -z "$TEST_POST_ID" ] || [ "$TEST_POST_ID" = "null" ]; then
+      _create_resp=$(curl -s -X POST \
+        -H "Authorization: Bearer $QA_TOKEN" \
+        -H "Content-Type: application/json" \
+        -d "{\"boardId\":${TEST_BOARD_ID},\"categoryId\":${TEST_CATEGORY_ID},\"title\":\"[QA Test] 자동화 테스트 게시글\",\"content\":\"QA 테스트용\",\"pinned\":false,\"hasSchedule\":false}" \
+        "${BASE_URL}/v1/user/posts" 2>/dev/null)
+      TEST_POST_ID=$(echo "$_create_resp" | jq -r '.data.postId // empty' 2>/dev/null)
+    fi
+
+    # 최신 댓글 ID 조회
+    if [ -n "$TEST_POST_ID" ] && [ "$TEST_POST_ID" != "null" ]; then
+      _comments_resp=$(curl -s -H "Authorization: Bearer $QA_TOKEN" \
+        "${BASE_URL}/v1/user/posts/${TEST_POST_ID}/comments?page=0&size=1" 2>/dev/null)
+      TEST_COMMENT_ID=$(echo "$_comments_resp" | jq -r '.data.content[0].id // empty' 2>/dev/null)
+
+      # 댓글이 없으면 새로 생성
+      if [ -z "$TEST_COMMENT_ID" ] || [ "$TEST_COMMENT_ID" = "null" ]; then
+        _create_comment=$(curl -s -X POST \
+          -H "Authorization: Bearer $QA_TOKEN" \
+          -H "Content-Type: application/json" \
+          -d '{"content":"[QA Test] 자동화 테스트 댓글"}' \
+          "${BASE_URL}/v1/user/posts/${TEST_POST_ID}/comments" 2>/dev/null)
+        TEST_COMMENT_ID=$(echo "$_create_comment" | jq -r '.data.id // empty' 2>/dev/null)
+        # 댓글 좋아요 추가
+        curl -s -X POST -H "Authorization: Bearer $QA_TOKEN" \
+          "${BASE_URL}/v1/user/comments/${TEST_COMMENT_ID}/like" > /dev/null 2>&1
+      fi
+    fi
+
     TEST_SCHEDULE_ID=""
     TEST_BANNER_ID=""
     return 1

--- a/scripts/qa/results/commentLikes.json
+++ b/scripts/qa/results/commentLikes.json
@@ -1,1 +1,1 @@
-{"domain": "commentLikes", "total": 4, "passed": 2, "failed": 2}
+{"domain": "commentLikes", "total": 4, "passed": 4, "failed": 0}

--- a/scripts/qa/results/letters.json
+++ b/scripts/qa/results/letters.json
@@ -1,1 +1,1 @@
-{"domain": "letters", "total": 2, "passed": 1, "failed": 1}
+{"domain": "letters", "total": 2, "passed": 2, "failed": 0}

--- a/scripts/qa/results/summary.json
+++ b/scripts/qa/results/summary.json
@@ -1,8 +1,8 @@
 {
-  "timestamp": "2026-02-02T10:54:21Z",
-  "duration": 4,
+  "timestamp": "2026-04-07T07:48:09Z",
+  "duration": 9,
   "total": 78,
-  "passed": 75,
-  "failed": 3,
-  "successRate": 96
+  "passed": 78,
+  "failed": 0,
+  "successRate": 100
 }

--- a/scripts/qa/setup.sh
+++ b/scripts/qa/setup.sh
@@ -24,25 +24,51 @@ if [ -z "$QA_TOKEN" ]; then
   exit 1
 fi
 
-echo "[1/6] 기존 게시판 조회 중..."
-# 게시판 목록 조회하여 첫 번째 boardId 사용
+echo "[1/6] QA용 게시판 및 카테고리 조회 중..."
+# 관리자 API로 QA용 게시판 생성 (없으면 기존 것 재사용)
 boards_response=$(curl -s -X GET \
   -H "Authorization: Bearer $QA_TOKEN" \
   -H "Content-Type: application/json" \
   "${BASE_URL}/v1/user/boards")
 
-# boardId 추출 (jq가 있으면 사용, 없으면 grep으로 추출)
+# 전체 게시판 중 마지막 id 추출 (QA용 게시판 우선)
 if command -v jq &> /dev/null; then
-  BOARD_ID=$(echo "$boards_response" | jq -r '.data[0].boardId // .data[0].id // 1' 2>/dev/null || echo "1")
-  CATEGORY_ID=$(echo "$boards_response" | jq -r '.data[0].categories[0].categoryId // .data[0].categories[0].id // 1' 2>/dev/null || echo "1")
+  # QA용 게시판 찾기
+  QA_BOARD_ID=$(echo "$boards_response" | jq -r '[.data[] | select(.name == "QA테스트게시판")] | .[0].id // empty' 2>/dev/null)
+
+  if [ -z "$QA_BOARD_ID" ] || [ "$QA_BOARD_ID" = "null" ]; then
+    # QA용 게시판 생성
+    create_board_resp=$(curl -s -X POST \
+      -H "Authorization: Bearer $QA_TOKEN" \
+      -H "Content-Type: application/json" \
+      -d '{"name":"QA테스트게시판","type":"NOTICE"}' \
+      "${BASE_URL}/v1/admin/boards")
+    BOARD_ID=$(echo "$create_board_resp" | jq -r '.data.id // 1' 2>/dev/null || echo "1")
+  else
+    BOARD_ID=$QA_BOARD_ID
+  fi
+
+  # 해당 게시판의 카테고리 조회
+  board_detail=$(curl -s -X GET \
+    -H "Authorization: Bearer $QA_TOKEN" \
+    "${BASE_URL}/v1/admin/boards/${BOARD_ID}")
+  CATEGORY_ID=$(echo "$board_detail" | jq -r '.data.categories[0].id // .data.categories[0].categoryId // empty' 2>/dev/null)
 else
-  # jq가 없으면 기본값 사용
-  BOARD_ID=$(echo "$boards_response" | grep -o '"boardId":[0-9]*' | head -1 | grep -o '[0-9]*' || echo "1")
-  CATEGORY_ID=$(echo "$boards_response" | grep -o '"categoryId":[0-9]*' | head -1 | grep -o '[0-9]*' || echo "1")
+  BOARD_ID=2
+  CATEGORY_ID=1
+fi
+
+# 카테고리가 없으면 DB에 직접 INSERT
+if [ -z "$CATEGORY_ID" ] || [ "$CATEGORY_ID" = "null" ]; then
+  echo "  - 카테고리 없음, DB에 직접 생성..."
+  mysql -u root -ppw930516 SURF2 -e \
+    "INSERT IGNORE INTO board_category (board_id, name, slug, created_at, updated_at) VALUES (${BOARD_ID}, 'QA테스트카테고리', 'qa-test', NOW(), NOW());" 2>/dev/null
+  CATEGORY_ID=$(mysql -u root -ppw930516 SURF2 -se \
+    "SELECT id FROM board_category WHERE board_id=${BOARD_ID} AND slug='qa-test' LIMIT 1;" 2>/dev/null)
 fi
 
 # 기본값 설정
-BOARD_ID=${BOARD_ID:-1}
+BOARD_ID=${BOARD_ID:-2}
 CATEGORY_ID=${CATEGORY_ID:-1}
 
 echo "  - Board ID: $BOARD_ID"
@@ -81,7 +107,7 @@ if [ -z "$POST_ID" ] || [ "$POST_ID" = "null" ]; then
   posts_response=$(curl -s -X GET \
     -H "Authorization: Bearer $QA_TOKEN" \
     -H "Content-Type: application/json" \
-    "${BASE_URL}/v1/user/posts/board/${BOARD_ID}?page=0&size=1")
+    "${BASE_URL}/v1/user/posts?boardId=${BOARD_ID}&page=0&size=1")
 
   if command -v jq &> /dev/null; then
     POST_ID=$(echo "$posts_response" | jq -r '.data.content[0].postId // .data[0].postId // .data[0].id // empty' 2>/dev/null)

--- a/scripts/qa/test-badges.sh
+++ b/scripts/qa/test-badges.sh
@@ -46,7 +46,7 @@ test_get_badges() {
   response=$(curl -s -w "\n%{http_code}" -X GET \
     -H "Authorization: Bearer $QA_TOKEN" \
     -H "Content-Type: application/json" \
-    "${BASE_URL}/v1/user/members/badges?memberId=1&pageSize=10&pageNum=0")
+    "${BASE_URL}/v1/user/members/1/badges")
 
   http_code=$(echo "$response" | tail -n1)
   body=$(echo "$response" | sed '$d')

--- a/scripts/qa/test-commentLikes.sh
+++ b/scripts/qa/test-commentLikes.sh
@@ -18,7 +18,7 @@ test_toggle_comment_like() {
   response=$(curl -s -w "\n%{http_code}" -X POST \
     -H "Authorization: Bearer $QA_TOKEN" \
     -H "Content-Type: application/json" \
-    "${BASE_URL}/v1/user/comments/1/like")
+    "${BASE_URL}/v1/user/comments/${TEST_COMMENT_ID:-1}/like")
 
   http_code=$(echo "$response" | tail -n1)
   body=$(echo "$response" | sed '$d')
@@ -41,7 +41,7 @@ test_comment_like_count() {
   response=$(curl -s -w "\n%{http_code}" -X GET \
     -H "Authorization: Bearer $QA_TOKEN" \
     -H "Content-Type: application/json" \
-    "${BASE_URL}/v1/user/comments/1/like/count")
+    "${BASE_URL}/v1/user/comments/${TEST_COMMENT_ID:-1}/like/count")
 
   http_code=$(echo "$response" | tail -n1)
   body=$(echo "$response" | sed '$d')
@@ -64,7 +64,7 @@ test_comment_like_me() {
   response=$(curl -s -w "\n%{http_code}" -X GET \
     -H "Authorization: Bearer $QA_TOKEN" \
     -H "Content-Type: application/json" \
-    "${BASE_URL}/v1/user/comments/1/like/me")
+    "${BASE_URL}/v1/user/comments/${TEST_COMMENT_ID:-1}/like/me")
 
   http_code=$(echo "$response" | tail -n1)
   body=$(echo "$response" | sed '$d')
@@ -87,7 +87,7 @@ test_comment_like_members() {
   response=$(curl -s -w "\n%{http_code}" -X GET \
     -H "Authorization: Bearer $QA_TOKEN" \
     -H "Content-Type: application/json" \
-    "${BASE_URL}/v1/user/comments/1/like/members")
+    "${BASE_URL}/v1/user/comments/${TEST_COMMENT_ID:-1}/like/members")
 
   http_code=$(echo "$response" | tail -n1)
   body=$(echo "$response" | sed '$d')

--- a/src/main/java/com/tavemakers/surf/domain/activity/controller/activeGeneration/ActiveGenerationGetController.java
+++ b/src/main/java/com/tavemakers/surf/domain/activity/controller/activeGeneration/ActiveGenerationGetController.java
@@ -2,7 +2,7 @@ package com.tavemakers.surf.domain.activity.controller.activeGeneration;
 
 import com.tavemakers.surf.domain.activity.dto.activeGeneration.response.ActiveGenerationMemberResDTO;
 import com.tavemakers.surf.domain.activity.dto.activeGeneration.response.ActiveGenerationResDTO;
-import com.tavemakers.surf.domain.activity.service.activeGeneration.ActiveGenerationGetService;
+import com.tavemakers.surf.domain.activity.usecase.ActiveGenerationUsecase;
 import com.tavemakers.surf.global.common.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -21,12 +21,12 @@ import static com.tavemakers.surf.domain.activity.controller.ResponseMessage.MEM
 @Tag(name = "활동기수")
 public class ActiveGenerationGetController {
 
-    private final ActiveGenerationGetService activeGenerationGetService;
+    private final ActiveGenerationUsecase activeGenerationUsecase;
 
     @Operation(summary = "현재 활동 기수 조회")
     @GetMapping("/v1/manager/active-generation")
     public ApiResponse<ActiveGenerationResDTO> getActiveGeneration() {
-        Integer generation = activeGenerationGetService.getActiveGeneration();
+        Integer generation = activeGenerationUsecase.getActiveGeneration();
         ActiveGenerationResDTO response = ActiveGenerationResDTO.of(generation);
         return ApiResponse.response(HttpStatus.OK, ACTIVE_GENERATION_READ.getMessage(), response);
     }
@@ -34,7 +34,7 @@ public class ActiveGenerationGetController {
     @Operation(summary = "현재 활동 기수에 속한 회원 조회")
     @GetMapping("/v1/manager/active-generation/members")
     public ApiResponse<List<ActiveGenerationMemberResDTO>> getActiveGenerationMembers() {
-        List<ActiveGenerationMemberResDTO> response = activeGenerationGetService.getActiveGenerationMembers();
+        List<ActiveGenerationMemberResDTO> response = activeGenerationUsecase.getActiveGenerationMembers();
         return ApiResponse.response(HttpStatus.OK, MEMBER_OF_ACTIVE_GENERATION_READ.getMessage(), response);
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/activity/controller/activeGeneration/ActiveGenerationGetController.java
+++ b/src/main/java/com/tavemakers/surf/domain/activity/controller/activeGeneration/ActiveGenerationGetController.java
@@ -23,6 +23,7 @@ public class ActiveGenerationGetController {
 
     private final ActiveGenerationUsecase activeGenerationUsecase;
 
+    /** 현재 활동 기수 조회 */
     @Operation(summary = "현재 활동 기수 조회")
     @GetMapping("/v1/manager/active-generation")
     public ApiResponse<ActiveGenerationResDTO> getActiveGeneration() {
@@ -31,6 +32,7 @@ public class ActiveGenerationGetController {
         return ApiResponse.response(HttpStatus.OK, ACTIVE_GENERATION_READ.getMessage(), response);
     }
 
+    /** 현재 활동 기수에 속한 회원 목록 조회 */
     @Operation(summary = "현재 활동 기수에 속한 회원 조회")
     @GetMapping("/v1/manager/active-generation/members")
     public ApiResponse<List<ActiveGenerationMemberResDTO>> getActiveGenerationMembers() {

--- a/src/main/java/com/tavemakers/surf/domain/activity/controller/activeGeneration/ActiveGenerationPutController.java
+++ b/src/main/java/com/tavemakers/surf/domain/activity/controller/activeGeneration/ActiveGenerationPutController.java
@@ -1,7 +1,7 @@
 package com.tavemakers.surf.domain.activity.controller.activeGeneration;
 
 import com.tavemakers.surf.domain.activity.dto.activeGeneration.request.ActiveGenerationUpdateReqDTO;
-import com.tavemakers.surf.domain.activity.service.activeGeneration.ActiveGenerationPutService;
+import com.tavemakers.surf.domain.activity.usecase.ActiveGenerationUsecase;
 import com.tavemakers.surf.global.common.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -19,13 +19,13 @@ import static com.tavemakers.surf.domain.activity.controller.ResponseMessage.ACT
 @Tag(name = "활동기수")
 public class ActiveGenerationPutController {
 
-    private final ActiveGenerationPutService activeGenerationPutService;
+    private final ActiveGenerationUsecase activeGenerationUsecase;
 
     @Operation(summary = "현재 활동 기수 변경")
     @PutMapping("/v1/admin/active-generation")
     public ApiResponse<Void> updateActiveGeneration(
             @RequestBody @Valid ActiveGenerationUpdateReqDTO dto) {
-        activeGenerationPutService.updateActiveGeneration(dto.activeGeneration());
+        activeGenerationUsecase.updateActiveGeneration(dto.activeGeneration());
         return ApiResponse.response(HttpStatus.OK, ACTIVE_GENERATION_UPDATED.getMessage(), null);
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/activity/service/activeGeneration/ActiveGenerationGetService.java
+++ b/src/main/java/com/tavemakers/surf/domain/activity/service/activeGeneration/ActiveGenerationGetService.java
@@ -5,7 +5,7 @@ import com.tavemakers.surf.domain.activity.dto.activeGeneration.response.ActiveG
 import com.tavemakers.surf.domain.activity.entity.ActiveGeneration;
 import com.tavemakers.surf.domain.activity.exception.ActiveGenerationNotInitializedException;
 import com.tavemakers.surf.domain.activity.repository.ActiveGenerationRepository;
-import com.tavemakers.surf.domain.member.repository.MemberRepository;
+import com.tavemakers.surf.domain.member.service.MemberGetService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,7 +17,7 @@ import java.util.List;
 public class ActiveGenerationGetService {
 
     private final ActiveGenerationRepository activeGenerationRepository;
-    private final MemberRepository memberRepository;
+    private final MemberGetService memberGetService;
 
     @Transactional(readOnly = true)
     public Integer getActiveGeneration() {
@@ -30,7 +30,7 @@ public class ActiveGenerationGetService {
     public List<ActiveGenerationMemberResDTO> getActiveGenerationMembers() {
         Integer activeGeneration = getActiveGeneration();
 
-        return memberRepository.findAllByTrackGeneration(activeGeneration).stream()
+        return memberGetService.getMembersByTrackGeneration(activeGeneration).stream()
                 .map(ActiveGenerationMemberResDTO::from)
                 .toList();
     }

--- a/src/main/java/com/tavemakers/surf/domain/activity/usecase/ActiveGenerationUsecase.java
+++ b/src/main/java/com/tavemakers/surf/domain/activity/usecase/ActiveGenerationUsecase.java
@@ -1,0 +1,37 @@
+package com.tavemakers.surf.domain.activity.usecase;
+
+import com.tavemakers.surf.domain.activity.dto.activeGeneration.response.ActiveGenerationMemberResDTO;
+import com.tavemakers.surf.domain.activity.service.activeGeneration.ActiveGenerationGetService;
+import com.tavemakers.surf.domain.activity.service.activeGeneration.ActiveGenerationPutService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/** 활동 기수 Usecase */
+@Service
+@RequiredArgsConstructor
+public class ActiveGenerationUsecase {
+
+    private final ActiveGenerationGetService activeGenerationGetService;
+    private final ActiveGenerationPutService activeGenerationPutService;
+
+    /** 현재 활동 기수 조회 */
+    @Transactional(readOnly = true)
+    public Integer getActiveGeneration() {
+        return activeGenerationGetService.getActiveGeneration();
+    }
+
+    /** 활동 기수 회원 목록 조회 */
+    @Transactional(readOnly = true)
+    public List<ActiveGenerationMemberResDTO> getActiveGenerationMembers() {
+        return activeGenerationGetService.getActiveGenerationMembers();
+    }
+
+    /** 활동 기수 변경 */
+    @Transactional
+    public void updateActiveGeneration(Integer generation) {
+        activeGenerationPutService.updateActiveGeneration(generation);
+    }
+}

--- a/src/main/java/com/tavemakers/surf/domain/badge/service/MemberBadgeAssignService.java
+++ b/src/main/java/com/tavemakers/surf/domain/badge/service/MemberBadgeAssignService.java
@@ -6,7 +6,7 @@ import com.tavemakers.surf.domain.badge.exception.MemberBadgeAlreadyExistsExcept
 import com.tavemakers.surf.domain.badge.repository.BadgeRepository;
 import com.tavemakers.surf.domain.badge.repository.MemberBadgeRepository;
 import com.tavemakers.surf.domain.member.entity.Member;
-import com.tavemakers.surf.domain.member.repository.MemberRepository;
+import com.tavemakers.surf.domain.member.service.MemberGetService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,7 +20,7 @@ import java.util.List;
 public class MemberBadgeAssignService {
 
     private final BadgeRepository badgeRepository;
-    private final MemberRepository memberRepository;
+    private final MemberGetService memberGetService;
     private final MemberBadgeRepository memberBadgeRepository;
 
     /** 다수의 회원에게 배지 부여 */
@@ -30,7 +30,7 @@ public class MemberBadgeAssignService {
                 .orElseThrow(BadgeNotFoundException::new);
 
         // 회원 한 번에 조회
-        List<Member> members = memberRepository.findAllById(memberIds);
+        List<Member> members = memberGetService.getMembersByIds(memberIds);
 
         if (members.size() != memberIds.size()) {
             throw new MemberNotFoundException();

--- a/src/main/java/com/tavemakers/surf/domain/badge/service/MemberBadgeGetService.java
+++ b/src/main/java/com/tavemakers/surf/domain/badge/service/MemberBadgeGetService.java
@@ -4,14 +4,13 @@ import com.tavemakers.surf.domain.badge.dto.response.MemberOwnedBadgeResDTO;
 import com.tavemakers.surf.domain.badge.entity.MemberBadge;
 import com.tavemakers.surf.domain.badge.repository.BadgeRepository;
 import com.tavemakers.surf.domain.badge.repository.MemberBadgeRepository;
-import com.tavemakers.surf.domain.member.repository.MemberRepository;
+import com.tavemakers.surf.domain.member.service.MemberGetService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import com.tavemakers.surf.domain.badge.exception.BadgeNotFoundException;
-import com.tavemakers.surf.domain.member.exception.MemberNotFoundException;
 
 import java.util.List;
 
@@ -21,7 +20,7 @@ public class MemberBadgeGetService {
 
     private final MemberBadgeRepository memberBadgeRepository;
     private final BadgeRepository badgeRepository;
-    private final MemberRepository memberRepository;
+    private final MemberGetService memberGetService;
 
     /** 특정 배지를 받은 회원 목록 조회 */
     @Transactional(readOnly = true)
@@ -39,8 +38,7 @@ public class MemberBadgeGetService {
     public List<MemberOwnedBadgeResDTO> getAllByMemberId(Long memberId) {
 
         // 회원 존재 여부 확인
-        memberRepository.findById(memberId)
-                .orElseThrow(MemberNotFoundException::new);
+        memberGetService.getMember(memberId);
 
         // 회원이 보유한 배지 목록을 fetch join으로 조회 (N+1 방지)
         List<MemberBadge> memberBadges =

--- a/src/main/java/com/tavemakers/surf/domain/board/controller/BoardCreateController.java
+++ b/src/main/java/com/tavemakers/surf/domain/board/controller/BoardCreateController.java
@@ -2,7 +2,7 @@ package com.tavemakers.surf.domain.board.controller;
 
 import com.tavemakers.surf.domain.board.dto.request.BoardCreateReqDTO;
 import com.tavemakers.surf.domain.board.dto.response.BoardResDTO;
-import com.tavemakers.surf.domain.board.service.BoardService;
+import com.tavemakers.surf.domain.board.usecase.BoardUsecase;
 import com.tavemakers.surf.global.common.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -18,13 +18,13 @@ import static com.tavemakers.surf.domain.board.controller.ResponseMessage.*;
 @RequestMapping
 @Tag(name = "게시판", description = "추후 MVP를 통해 디벨롭 될 예정")
 public class BoardCreateController {
-    private final BoardService boardService;
+    private final BoardUsecase boardUsecase;
 
     @Operation(summary = "게시판 생성", description = "새로운 게시판을 생성합니다.")
     @PostMapping("/v1/admin/boards")
     public ApiResponse<BoardResDTO> createBoard(
             @Valid @RequestBody BoardCreateReqDTO req) {
-        BoardResDTO response = boardService.createBoard(req);
+        BoardResDTO response = boardUsecase.createBoard(req);
         return ApiResponse.response(HttpStatus.CREATED, BOARD_CREATED.getMessage(), response);
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/board/controller/BoardDeleteController.java
+++ b/src/main/java/com/tavemakers/surf/domain/board/controller/BoardDeleteController.java
@@ -1,6 +1,6 @@
 package com.tavemakers.surf.domain.board.controller;
 
-import com.tavemakers.surf.domain.board.service.BoardService;
+import com.tavemakers.surf.domain.board.usecase.BoardUsecase;
 import com.tavemakers.surf.global.common.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -15,13 +15,13 @@ import static com.tavemakers.surf.domain.board.controller.ResponseMessage.*;
 @RequestMapping
 @Tag(name = "게시판", description = "추후 MVP를 통해 디벨롭 될 예정")
 public class BoardDeleteController {
-    private final BoardService boardService;
+    private final BoardUsecase boardUsecase;
 
     @Operation(summary = "게시판 삭제", description = "특정 ID의 게시판을 삭제합니다.")
     @DeleteMapping("/v1/admin/boards/{boardId}")
     public ApiResponse<Void> deleteBoard(
             @PathVariable Long boardId) {
-        boardService.deleteBoard(boardId);
+        boardUsecase.deleteBoard(boardId);
         return ApiResponse.response(HttpStatus.NO_CONTENT, BOARD_DELETED.getMessage());
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/board/controller/BoardGetController.java
+++ b/src/main/java/com/tavemakers/surf/domain/board/controller/BoardGetController.java
@@ -1,7 +1,7 @@
 package com.tavemakers.surf.domain.board.controller;
 
 import com.tavemakers.surf.domain.board.dto.response.BoardResDTO;
-import com.tavemakers.surf.domain.board.service.BoardService;
+import com.tavemakers.surf.domain.board.usecase.BoardUsecase;
 import com.tavemakers.surf.global.common.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -18,12 +18,12 @@ import static com.tavemakers.surf.domain.board.controller.ResponseMessage.*;
 @RequestMapping
 @Tag(name = "게시판", description = "추후 MVP를 통해 디벨롭 될 예정")
 public class BoardGetController {
-    private final BoardService boardService;
+    private final BoardUsecase boardUsecase;
 
     @Operation(summary = "게시판 목록 조회", description = "모든 게시판을 조회합니다.")
     @GetMapping("/v1/user/boards")
     public ApiResponse<List<BoardResDTO>> getBoards() {
-        List<BoardResDTO> response = boardService.getBoards();
+        List<BoardResDTO> response = boardUsecase.getBoards();
         return ApiResponse.response(HttpStatus.OK, BOARD_READ.getMessage(), response);
     }
 
@@ -31,7 +31,7 @@ public class BoardGetController {
     @GetMapping("/v1/admin/boards/{boardId}")
     public ApiResponse<BoardResDTO> getBoard(
             @PathVariable Long boardId) {
-        BoardResDTO response = boardService.getBoard(boardId);
+        BoardResDTO response = boardUsecase.getBoard(boardId);
         return ApiResponse.response(HttpStatus.OK, BOARD_READ.getMessage(), response);
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/board/controller/BoardPatchController.java
+++ b/src/main/java/com/tavemakers/surf/domain/board/controller/BoardPatchController.java
@@ -2,7 +2,7 @@ package com.tavemakers.surf.domain.board.controller;
 
 import com.tavemakers.surf.domain.board.dto.request.BoardUpdateReqDTO;
 import com.tavemakers.surf.domain.board.dto.response.BoardResDTO;
-import com.tavemakers.surf.domain.board.service.BoardService;
+import com.tavemakers.surf.domain.board.usecase.BoardUsecase;
 import com.tavemakers.surf.global.common.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -18,14 +18,14 @@ import static com.tavemakers.surf.domain.board.controller.ResponseMessage.*;
 @RequestMapping
 @Tag(name = "게시판", description = "추후 MVP를 통해 디벨롭 될 예정")
 public class BoardPatchController {
-    private final BoardService boardService;
+    private final BoardUsecase boardUsecase;
 
     @Operation(summary = "게시판 수정", description = "특정 ID의 게시판을 수정합니다.")
     @PatchMapping("/v1/admin/boards/{boardId}")
     public ApiResponse<BoardResDTO> updateBoard(
             @PathVariable Long boardId,
             @Valid @RequestBody BoardUpdateReqDTO req) {
-        BoardResDTO response = boardService.updateBoard(boardId, req);
+        BoardResDTO response = boardUsecase.updateBoard(boardId, req);
         return ApiResponse.response(HttpStatus.OK, BOARD_UPDATED.getMessage(), response);
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/board/usecase/BoardUsecase.java
+++ b/src/main/java/com/tavemakers/surf/domain/board/usecase/BoardUsecase.java
@@ -1,0 +1,49 @@
+package com.tavemakers.surf.domain.board.usecase;
+
+import com.tavemakers.surf.domain.board.dto.request.BoardCreateReqDTO;
+import com.tavemakers.surf.domain.board.dto.request.BoardUpdateReqDTO;
+import com.tavemakers.surf.domain.board.dto.response.BoardResDTO;
+import com.tavemakers.surf.domain.board.service.BoardService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/** 게시판 Usecase */
+@Service
+@RequiredArgsConstructor
+public class BoardUsecase {
+
+    private final BoardService boardService;
+
+    /** 게시판 생성 */
+    @Transactional
+    public BoardResDTO createBoard(BoardCreateReqDTO req) {
+        return boardService.createBoard(req);
+    }
+
+    /** 게시판 목록 조회 */
+    @Transactional(readOnly = true)
+    public List<BoardResDTO> getBoards() {
+        return boardService.getBoards();
+    }
+
+    /** 게시판 단건 조회 */
+    @Transactional(readOnly = true)
+    public BoardResDTO getBoard(Long boardId) {
+        return boardService.getBoard(boardId);
+    }
+
+    /** 게시판 수정 */
+    @Transactional
+    public BoardResDTO updateBoard(Long boardId, BoardUpdateReqDTO req) {
+        return boardService.updateBoard(boardId, req);
+    }
+
+    /** 게시판 삭제 */
+    @Transactional
+    public void deleteBoard(Long boardId) {
+        boardService.deleteBoard(boardId);
+    }
+}

--- a/src/main/java/com/tavemakers/surf/domain/comment/controller/CommentCreateController.java
+++ b/src/main/java/com/tavemakers/surf/domain/comment/controller/CommentCreateController.java
@@ -22,6 +22,7 @@ public class CommentCreateController {
 
     private final CommentUsecase commentUsecase;
 
+    /** 댓글 생성 (루트 댓글 또는 대댓글) */
     @Operation(summary = "댓글 생성 (루트/대댓글)", description = "rootId가 null이면 루트 댓글")
     @PostMapping("/v1/user/posts/{postId}/comments")
     public ApiResponse<CommentResDTO> createComment(

--- a/src/main/java/com/tavemakers/surf/domain/comment/controller/CommentCreateController.java
+++ b/src/main/java/com/tavemakers/surf/domain/comment/controller/CommentCreateController.java
@@ -2,7 +2,7 @@ package com.tavemakers.surf.domain.comment.controller;
 
 import com.tavemakers.surf.domain.comment.dto.request.CommentCreateReqDTO;
 import com.tavemakers.surf.domain.comment.dto.response.CommentResDTO;
-import com.tavemakers.surf.domain.comment.service.CommentService;
+import com.tavemakers.surf.domain.comment.usecase.CommentUsecase;
 import com.tavemakers.surf.global.common.response.ApiResponse;
 import com.tavemakers.surf.global.util.SecurityUtils;
 import io.swagger.v3.oas.annotations.Operation;
@@ -20,7 +20,7 @@ import static com.tavemakers.surf.domain.comment.controller.ResponseMessage.*;
 @Tag(name = "댓글", description = "댓글 및 대댓글 관련 CRUD API")
 public class CommentCreateController {
 
-    private final CommentService commentService;
+    private final CommentUsecase commentUsecase;
 
     @Operation(summary = "댓글 생성 (루트/대댓글)", description = "rootId가 null이면 루트 댓글")
     @PostMapping("/v1/user/posts/{postId}/comments")
@@ -28,7 +28,7 @@ public class CommentCreateController {
             @PathVariable Long postId,
             @Valid @RequestBody CommentCreateReqDTO req) {
         Long memberId = SecurityUtils.getCurrentMemberId();
-        CommentResDTO response = commentService.createComment(postId, memberId, req);
+        CommentResDTO response = commentUsecase.createComment(postId, memberId, req);
         return ApiResponse.response(HttpStatus.CREATED, COMMENT_CREATED.getMessage(), response);
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/comment/controller/CommentDeleteController.java
+++ b/src/main/java/com/tavemakers/surf/domain/comment/controller/CommentDeleteController.java
@@ -1,6 +1,6 @@
 package com.tavemakers.surf.domain.comment.controller;
 
-import com.tavemakers.surf.domain.comment.service.CommentService;
+import com.tavemakers.surf.domain.comment.usecase.CommentUsecase;
 import com.tavemakers.surf.global.common.response.ApiResponse;
 import com.tavemakers.surf.global.util.SecurityUtils;
 import io.swagger.v3.oas.annotations.Operation;
@@ -17,14 +17,14 @@ import static com.tavemakers.surf.domain.comment.controller.ResponseMessage.*;
 @Tag(name = "댓글", description = "댓글 및 대댓글 관련 CRUD API")
 public class CommentDeleteController {
 
-    private final CommentService commentService;
+    private final CommentUsecase commentUsecase;
 
     @Operation(summary = "댓글 삭제 (내 댓글만)", description = "본인이 작성한 댓글만 삭제 가능, 댓글 및 대댓글 구분없이 hard 삭제 처리")
     @DeleteMapping("/v1/user/posts/{postId}/comments/{commentId}")
     public ApiResponse<Void> deleteComment(@PathVariable Long postId,
                                            @PathVariable Long commentId) {
         Long memberId = SecurityUtils.getCurrentMemberId();
-        commentService.deleteComment(postId, commentId, memberId);
+        commentUsecase.deleteComment(postId, commentId, memberId);
         return ApiResponse.response(HttpStatus.NO_CONTENT, COMMENT_DELETED.getMessage());
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/comment/controller/CommentGetController.java
+++ b/src/main/java/com/tavemakers/surf/domain/comment/controller/CommentGetController.java
@@ -1,7 +1,7 @@
 package com.tavemakers.surf.domain.comment.controller;
 
 import com.tavemakers.surf.domain.comment.dto.response.CommentListResDTO;
-import com.tavemakers.surf.domain.comment.service.CommentService;
+import com.tavemakers.surf.domain.comment.usecase.CommentUsecase;
 import com.tavemakers.surf.global.common.response.ApiResponse;
 import com.tavemakers.surf.global.logging.LogEvent;
 import com.tavemakers.surf.global.logging.LogParam;
@@ -24,7 +24,7 @@ import static com.tavemakers.surf.domain.comment.controller.ResponseMessage.*;
 @Tag(name = "댓글", description = "댓글 및 대댓글 관련 CRUD API")
 public class CommentGetController {
 
-    private final CommentService commentService;
+    private final CommentUsecase commentUsecase;
 
     @Operation(summary = "댓글 목록 조회 (페이징)", description = "루트 댓글과 대댓글 모두 포함. 페이징 처리")
     @GetMapping("/v1/user/posts/{postId}/comments")
@@ -36,7 +36,7 @@ public class CommentGetController {
             Pageable pageable
     ){
         Long memberId = SecurityUtils.getCurrentMemberId();
-        CommentListResDTO data = commentService.getComments(postId, pageable, memberId);
+        CommentListResDTO data = commentUsecase.getComments(postId, pageable, memberId);
         return ApiResponse.response(HttpStatus.OK, COMMENT_READ.getMessage(), data);
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/comment/repository/CommentMentionRepository.java
+++ b/src/main/java/com/tavemakers/surf/domain/comment/repository/CommentMentionRepository.java
@@ -17,6 +17,10 @@ public interface CommentMentionRepository extends JpaRepository<CommentMention, 
     @Query("SELECT cm FROM CommentMention cm JOIN FETCH cm.mentionedMember WHERE cm.comment.id = :commentId")
     List<CommentMention> findByCommentIdWithMember(@Param("commentId") Long commentId);
 
+    /** 댓글 ID 목록으로 멘션 일괄 조회 (N+1 방지) */
+    @Query("SELECT cm FROM CommentMention cm JOIN FETCH cm.mentionedMember WHERE cm.comment.id IN :commentIds")
+    List<CommentMention> findAllByCommentIdIn(@Param("commentIds") List<Long> commentIds);
+
     /** 특정 회원이 멘션된 CommentMention 목록 조회 */
     List<CommentMention> findAllByMentionedMember(Member member);
 

--- a/src/main/java/com/tavemakers/surf/domain/comment/service/CommentMentionService.java
+++ b/src/main/java/com/tavemakers/surf/domain/comment/service/CommentMentionService.java
@@ -5,7 +5,7 @@ import com.tavemakers.surf.domain.comment.entity.CommentMention;
 import com.tavemakers.surf.domain.comment.repository.CommentMentionRepository;
 import com.tavemakers.surf.domain.member.entity.Member;
 import com.tavemakers.surf.domain.member.entity.enums.MemberStatus;
-import com.tavemakers.surf.domain.member.repository.MemberRepository;
+import com.tavemakers.surf.domain.member.service.MemberGetService;
 import com.tavemakers.surf.domain.comment.dto.response.MentionResDTO;
 import com.tavemakers.surf.domain.comment.dto.response.MentionSearchResDTO;
 import com.tavemakers.surf.domain.comment.exception.InvalidMentionSearchKeywordException;
@@ -21,7 +21,7 @@ import java.util.List;
 public class CommentMentionService {
 
     private final CommentMentionRepository commentMentionRepository;
-    private final MemberRepository memberRepository;
+    private final MemberGetService memberGetService;
 
     /** 댓글 생성 시 멘션이 있으면 저장 */
     public List<CommentMention> createMentions(Comment comment, List<Long> mentionMemberIds) {
@@ -34,7 +34,7 @@ public class CommentMentionService {
                 .distinct()
                 .toList();
 
-        List<Member> mentionedMembers = memberRepository.findAllById(filteredIds);
+        List<Member> mentionedMembers = memberGetService.getMembersByIds(filteredIds);
 
         List<CommentMention> mentions = mentionedMembers.stream()
                 .map(member -> CommentMention.of(comment, member))
@@ -70,7 +70,7 @@ public class CommentMentionService {
         String namePart = keyword.trim();
 
         // DB 조회 (정렬 없이)
-        List<Member> candidates = memberRepository.findMentionCandidates(namePart, MemberStatus.WITHDRAWN);
+        List<Member> candidates = memberGetService.findMentionCandidates(namePart, MemberStatus.WITHDRAWN);
 
         // 자바에서 정렬: 가장 최근 기수 → 오래된 순
         return candidates.stream()

--- a/src/main/java/com/tavemakers/surf/domain/comment/service/CommentMentionService.java
+++ b/src/main/java/com/tavemakers/surf/domain/comment/service/CommentMentionService.java
@@ -61,7 +61,6 @@ public class CommentMentionService {
     }
 
     /** 댓글 ID 목록으로 멘션 일괄 조회 (N+1 방지) */
-    @Transactional(readOnly = true)
     public Map<Long, List<MentionResDTO>> getMentionsByCommentIds(List<Long> commentIds) {
         return commentMentionRepository.findAllByCommentIdIn(commentIds).stream()
                 .collect(Collectors.groupingBy(

--- a/src/main/java/com/tavemakers/surf/domain/comment/service/CommentMentionService.java
+++ b/src/main/java/com/tavemakers/surf/domain/comment/service/CommentMentionService.java
@@ -8,6 +8,9 @@ import com.tavemakers.surf.domain.member.entity.enums.MemberStatus;
 import com.tavemakers.surf.domain.member.service.MemberGetService;
 import com.tavemakers.surf.domain.comment.dto.response.MentionResDTO;
 import com.tavemakers.surf.domain.comment.dto.response.MentionSearchResDTO;
+
+import java.util.Map;
+import java.util.stream.Collectors;
 import com.tavemakers.surf.domain.comment.exception.InvalidMentionSearchKeywordException;
 
 import lombok.RequiredArgsConstructor;
@@ -55,6 +58,16 @@ public class CommentMentionService {
                 .stream()
                 .map(MentionResDTO::from)
                 .toList();
+    }
+
+    /** 댓글 ID 목록으로 멘션 일괄 조회 (N+1 방지) */
+    @Transactional(readOnly = true)
+    public Map<Long, List<MentionResDTO>> getMentionsByCommentIds(List<Long> commentIds) {
+        return commentMentionRepository.findAllByCommentIdIn(commentIds).stream()
+                .collect(Collectors.groupingBy(
+                        cm -> cm.getComment().getId(),
+                        Collectors.mapping(MentionResDTO::from, Collectors.toList())
+                ));
     }
 
     /** 멘션 가능한 회원 검색 (두 글자 이상 입력 시) */

--- a/src/main/java/com/tavemakers/surf/domain/comment/service/CommentService.java
+++ b/src/main/java/com/tavemakers/surf/domain/comment/service/CommentService.java
@@ -136,6 +136,9 @@ public class CommentService {
         if (!comment.getPost().getId().equals(postId) || !comment.getMember().getId().equals(memberId))
             throw new NotMyCommentException();
 
+        // 삭제 전에 post 참조를 영속성 컨텍스트에 확보
+        Post post = postGetService.getPost(postId);
+
         // 자식 댓글 parent 끊기
         commentRepository.detachChildren(commentId);
 
@@ -147,7 +150,7 @@ public class CommentService {
         commentRepository.delete(comment);
 
         // 게시글 댓글 수 감소
-        comment.getPost().decreaseCommentCount();
+        post.decreaseCommentCount();
     }
 
     /** 댓글 목록 조회 */

--- a/src/main/java/com/tavemakers/surf/domain/comment/service/CommentService.java
+++ b/src/main/java/com/tavemakers/surf/domain/comment/service/CommentService.java
@@ -16,7 +16,6 @@ import com.tavemakers.surf.domain.comment.repository.CommentRepository;
 import com.tavemakers.surf.domain.member.entity.Member;
 import com.tavemakers.surf.domain.member.service.MemberGetService;
 import com.tavemakers.surf.domain.post.entity.Post;
-import com.tavemakers.surf.domain.post.repository.PostRepository;
 import com.tavemakers.surf.domain.post.service.post.PostGetService;
 import com.tavemakers.surf.global.logging.LogEvent;
 import com.tavemakers.surf.global.logging.LogParam;
@@ -28,13 +27,13 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
 public class CommentService {
 
     private final CommentRepository commentRepository;
-    private final PostRepository postRepository;
     private final PostGetService postGetService;
     private final MemberGetService memberGetService;
     private final CommentMentionService commentMentionService;
@@ -148,7 +147,7 @@ public class CommentService {
         commentRepository.delete(comment);
 
         // 게시글 댓글 수 감소
-        postRepository.decreaseCommentCount(postId);
+        comment.getPost().decreaseCommentCount();
     }
 
     /** 댓글 목록 조회 */
@@ -162,10 +161,14 @@ public class CommentService {
         // 2) 댓글 총 개수 조회
         long totalCount = commentRepository.countByPostId(postId);
 
-        // 3) 각 댓글 → DTO 변환
-        List<CommentResDTO> commentDtoList = commentSlice.getContent().stream()
+        // 3) 각 댓글 → DTO 변환 (멘션 일괄 조회로 N+1 방지)
+        List<Comment> comments = commentSlice.getContent();
+        List<Long> commentIds = comments.stream().map(Comment::getId).toList();
+        Map<Long, List<MentionResDTO>> mentionMap = commentMentionService.getMentionsByCommentIds(commentIds);
+
+        List<CommentResDTO> commentDtoList = comments.stream()
                 .map(comment -> {
-                    List<MentionResDTO> mentions = commentMentionService.getMentions(comment.getId());
+                    List<MentionResDTO> mentions = mentionMap.getOrDefault(comment.getId(), List.of());
                     boolean liked = memberId != null && commentLikeService.isLikedByMe(comment.getId(), memberId);
                     return CommentResDTO.from(comment, postId, mentions, liked);
                 })

--- a/src/main/java/com/tavemakers/surf/domain/comment/usecase/CommentUsecase.java
+++ b/src/main/java/com/tavemakers/surf/domain/comment/usecase/CommentUsecase.java
@@ -1,0 +1,36 @@
+package com.tavemakers.surf.domain.comment.usecase;
+
+import com.tavemakers.surf.domain.comment.dto.request.CommentCreateReqDTO;
+import com.tavemakers.surf.domain.comment.dto.response.CommentListResDTO;
+import com.tavemakers.surf.domain.comment.dto.response.CommentResDTO;
+import com.tavemakers.surf.domain.comment.service.CommentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/** 댓글 Usecase */
+@Service
+@RequiredArgsConstructor
+public class CommentUsecase {
+
+    private final CommentService commentService;
+
+    /** 댓글 생성 */
+    @Transactional
+    public CommentResDTO createComment(Long postId, Long memberId, CommentCreateReqDTO req) {
+        return commentService.createComment(postId, memberId, req);
+    }
+
+    /** 댓글 삭제 */
+    @Transactional
+    public void deleteComment(Long postId, Long commentId, Long memberId) {
+        commentService.deleteComment(postId, commentId, memberId);
+    }
+
+    /** 댓글 목록 조회 */
+    @Transactional(readOnly = true)
+    public CommentListResDTO getComments(Long postId, Pageable pageable, Long memberId) {
+        return commentService.getComments(postId, pageable, memberId);
+    }
+}

--- a/src/main/java/com/tavemakers/surf/domain/feedback/controller/FeedbackCreateController.java
+++ b/src/main/java/com/tavemakers/surf/domain/feedback/controller/FeedbackCreateController.java
@@ -2,7 +2,7 @@ package com.tavemakers.surf.domain.feedback.controller;
 
 import com.tavemakers.surf.domain.feedback.dto.request.FeedbackCreateReqDTO;
 import com.tavemakers.surf.domain.feedback.dto.response.FeedbackResDTO;
-import com.tavemakers.surf.domain.feedback.service.FeedbackService;
+import com.tavemakers.surf.domain.feedback.usecase.FeedbackUsecase;
 import com.tavemakers.surf.global.common.response.ApiResponse;
 import com.tavemakers.surf.global.util.SecurityUtils;
 import io.swagger.v3.oas.annotations.Operation;
@@ -20,7 +20,7 @@ import static com.tavemakers.surf.domain.feedback.controller.ResponseMessage.FEE
 @Tag(name = "피드백")
 public class FeedbackCreateController {
 
-    private final FeedbackService feedbackService;
+    private final FeedbackUsecase feedbackUsecase;
 
     /** 피드백 생성 (로그인 사용자) */
     @Operation(summary = "피드백 생성", description = "익명의 피드백을 생성합니다. (하루 3회 제한)")
@@ -29,7 +29,7 @@ public class FeedbackCreateController {
             @Valid @RequestBody FeedbackCreateReqDTO req
     ) {
         Long memberId = SecurityUtils.getCurrentMemberId();
-        FeedbackResDTO response = feedbackService.createFeedback(req, memberId);
+        FeedbackResDTO response = feedbackUsecase.createFeedback(req, memberId);
         return ApiResponse.response(HttpStatus.CREATED, FEEDBACK_CREATED.getMessage(), response);
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/feedback/controller/FeedbackGetController.java
+++ b/src/main/java/com/tavemakers/surf/domain/feedback/controller/FeedbackGetController.java
@@ -1,7 +1,7 @@
 package com.tavemakers.surf.domain.feedback.controller;
 
 import com.tavemakers.surf.domain.feedback.dto.response.FeedbackResDTO;
-import com.tavemakers.surf.domain.feedback.service.FeedbackService;
+import com.tavemakers.surf.domain.feedback.usecase.FeedbackUsecase;
 import com.tavemakers.surf.global.common.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -22,7 +22,7 @@ import static com.tavemakers.surf.domain.feedback.controller.ResponseMessage.FEE
 @Tag(name = "피드백")
 public class FeedbackGetController {
 
-    private final FeedbackService feedbackService;
+    private final FeedbackUsecase feedbackUsecase;
 
     /** 피드백 조회 (운영진 전용) */
     @Operation(summary = "피드백 조회", description = "운영진이 피드백을 조회합니다.")
@@ -32,7 +32,7 @@ public class FeedbackGetController {
             @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC)
             Pageable pageable
     ) {
-        Slice<FeedbackResDTO> response = feedbackService.getFeedbacks(pageable);
+        Slice<FeedbackResDTO> response = feedbackUsecase.getFeedbacks(pageable);
         return ApiResponse.response(HttpStatus.OK, FEEDBACK_READ.getMessage(), response);
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/feedback/usecase/FeedbackUsecase.java
+++ b/src/main/java/com/tavemakers/surf/domain/feedback/usecase/FeedbackUsecase.java
@@ -1,0 +1,30 @@
+package com.tavemakers.surf.domain.feedback.usecase;
+
+import com.tavemakers.surf.domain.feedback.dto.request.FeedbackCreateReqDTO;
+import com.tavemakers.surf.domain.feedback.dto.response.FeedbackResDTO;
+import com.tavemakers.surf.domain.feedback.service.FeedbackService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/** 피드백 Usecase */
+@Service
+@RequiredArgsConstructor
+public class FeedbackUsecase {
+
+    private final FeedbackService feedbackService;
+
+    /** 피드백 생성 */
+    @Transactional
+    public FeedbackResDTO createFeedback(FeedbackCreateReqDTO req, Long memberId) {
+        return feedbackService.createFeedback(req, memberId);
+    }
+
+    /** 피드백 목록 조회 */
+    @Transactional(readOnly = true)
+    public Slice<FeedbackResDTO> getFeedbacks(Pageable pageable) {
+        return feedbackService.getFeedbacks(pageable);
+    }
+}

--- a/src/main/java/com/tavemakers/surf/domain/home/controller/HomeBannerCreateController.java
+++ b/src/main/java/com/tavemakers/surf/domain/home/controller/HomeBannerCreateController.java
@@ -2,7 +2,7 @@ package com.tavemakers.surf.domain.home.controller;
 
 import com.tavemakers.surf.domain.home.dto.request.HomeBannerCreateReqDTO;
 import com.tavemakers.surf.domain.home.dto.response.HomeBannerResDTO;
-import com.tavemakers.surf.domain.home.service.HomeBannerService;
+import com.tavemakers.surf.domain.home.usecase.HomeUsecase;
 import com.tavemakers.surf.global.common.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -19,14 +19,14 @@ import static com.tavemakers.surf.domain.home.controller.ResponseMessage.*;
 @Tag(name = "홈 배너 관리", description = "홈 배너 관리 API")
 public class HomeBannerCreateController {
 
-    private final HomeBannerService homeBannerService;
+    private final HomeUsecase homeUsecase;
 
     @Operation(summary = "홈 배너 생성", description = "새로운 홈 배너를 생성합니다.")
     @PostMapping("/v1/admin/home/banners")
     public ApiResponse<HomeBannerResDTO> createBanner(
             @RequestBody @Valid HomeBannerCreateReqDTO req
     ) {
-        HomeBannerResDTO response = homeBannerService.createBanner(req);
+        HomeBannerResDTO response = homeUsecase.createBanner(req);
         return ApiResponse.response(HttpStatus.CREATED, HOME_BANNER_CREATED.getMessage(), response);
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/home/controller/HomeBannerDeleteController.java
+++ b/src/main/java/com/tavemakers/surf/domain/home/controller/HomeBannerDeleteController.java
@@ -1,6 +1,6 @@
 package com.tavemakers.surf.domain.home.controller;
 
-import com.tavemakers.surf.domain.home.service.HomeBannerService;
+import com.tavemakers.surf.domain.home.usecase.HomeUsecase;
 import com.tavemakers.surf.global.common.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -16,14 +16,14 @@ import static com.tavemakers.surf.domain.home.controller.ResponseMessage.*;
 @Tag(name = "홈 배너 관리", description = "홈 배너 관리 API")
 public class HomeBannerDeleteController {
 
-    private final HomeBannerService homeBannerService;
+    private final HomeUsecase homeUsecase;
 
     @Operation(summary = "홈 배너 삭제", description = "특정 ID의 홈 배너를 삭제합니다.")
     @DeleteMapping("/v1/admin/home/banners/{bannerId}")
     public ApiResponse<Void> deleteBanner(
             @PathVariable Long bannerId
     ) {
-        homeBannerService.deleteBanner(bannerId);
+        homeUsecase.deleteBanner(bannerId);
         return ApiResponse.response(HttpStatus.NO_CONTENT, HOME_BANNER_DELETED.getMessage());
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/home/controller/HomeBannerGetController.java
+++ b/src/main/java/com/tavemakers/surf/domain/home/controller/HomeBannerGetController.java
@@ -1,7 +1,7 @@
 package com.tavemakers.surf.domain.home.controller;
 
 import com.tavemakers.surf.domain.home.dto.response.HomeBannerResDTO;
-import com.tavemakers.surf.domain.home.service.HomeBannerService;
+import com.tavemakers.surf.domain.home.usecase.HomeUsecase;
 import com.tavemakers.surf.global.common.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -19,12 +19,12 @@ import static com.tavemakers.surf.domain.home.controller.ResponseMessage.*;
 @Tag(name = "홈 배너 관리", description = "홈 배너 관리 API")
 public class HomeBannerGetController {
 
-    private final HomeBannerService homeBannerService;
+    private final HomeUsecase homeUsecase;
 
     @Operation(summary = "홈 배너 목록 조회", description = "홈 배너 목록을 조회합니다.")
     @GetMapping("/v1/admin/home/banners")
     public ApiResponse<List<HomeBannerResDTO>> getBanners() {
-        List<HomeBannerResDTO> response = homeBannerService.getBanners();
+        List<HomeBannerResDTO> response = homeUsecase.getBanners();
         return ApiResponse.response(HttpStatus.OK, HOME_BANNERS_READ.getMessage(), response);
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/home/controller/HomeBannerPatchController.java
+++ b/src/main/java/com/tavemakers/surf/domain/home/controller/HomeBannerPatchController.java
@@ -3,7 +3,7 @@ package com.tavemakers.surf.domain.home.controller;
 import com.tavemakers.surf.domain.home.dto.request.HomeBannerReorderReqDTO;
 import com.tavemakers.surf.domain.home.dto.request.HomeBannerUpdateReqDTO;
 import com.tavemakers.surf.domain.home.dto.response.HomeBannerResDTO;
-import com.tavemakers.surf.domain.home.service.HomeBannerService;
+import com.tavemakers.surf.domain.home.usecase.HomeUsecase;
 import com.tavemakers.surf.global.common.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -22,14 +22,14 @@ import static com.tavemakers.surf.domain.home.controller.ResponseMessage.*;
 @Tag(name = "홈 배너 관리", description = "홈 배너 관리 API")
 public class HomeBannerPatchController {
 
-    private final HomeBannerService homeBannerService;
+    private final HomeUsecase homeUsecase;
 
     @Operation(summary = "홈 배너 순서 변경", description = "홈 배너의 순서를 변경합니다. 모든 배너의 ID를 포함해야 하며, 배너가 없을 시 빈 배열을 전달해야 합니다.")
     @PutMapping("/v1/admin/home/banners/reorder")
     public ApiResponse<List<HomeBannerResDTO>> reorderBanners(
             @RequestBody @Valid HomeBannerReorderReqDTO req
     ) {
-        List<HomeBannerResDTO> response = homeBannerService.reorderBanners(req);
+        List<HomeBannerResDTO> response = homeUsecase.reorderBanners(req);
         return ApiResponse.response(HttpStatus.OK, HOME_BANNER_REORDERED.getMessage(), response);
     }
 
@@ -39,7 +39,7 @@ public class HomeBannerPatchController {
             @PathVariable Long bannerId,
             @RequestBody @Valid HomeBannerUpdateReqDTO req
     ) {
-        HomeBannerResDTO response = homeBannerService.updateBanner(bannerId, req);
+        HomeBannerResDTO response = homeUsecase.updateBanner(bannerId, req);
         return ApiResponse.response(HttpStatus.OK, HOME_BANNER_UPDATED.getMessage(), response);
     }
 
@@ -47,7 +47,7 @@ public class HomeBannerPatchController {
     @PatchMapping("/v1/admin/home/banners/{id}/activate")
     public ApiResponse<HomeBannerResDTO> activate(
             @PathVariable Long id) {
-        HomeBannerResDTO response = homeBannerService.activateBanner(id);
+        HomeBannerResDTO response = homeUsecase.activateBanner(id);
         return ApiResponse.response(HttpStatus.OK, HOME_BANNER_STATUS_ACTIVATED.getMessage(), response);
     }
 
@@ -55,7 +55,7 @@ public class HomeBannerPatchController {
     @PatchMapping("/v1/admin/home/banners/{id}/deactivate")
     public ApiResponse<HomeBannerResDTO> deactivate(
             @PathVariable Long id) {
-        HomeBannerResDTO response = homeBannerService.deactivateBanner(id);
+        HomeBannerResDTO response = homeUsecase.deactivateBanner(id);
         return ApiResponse.response(HttpStatus.OK, HOME_BANNER_STATUS_DEACTIVATED.getMessage(), response);
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/home/controller/HomeContentGetController.java
+++ b/src/main/java/com/tavemakers/surf/domain/home/controller/HomeContentGetController.java
@@ -1,7 +1,7 @@
 package com.tavemakers.surf.domain.home.controller;
 
 import com.tavemakers.surf.domain.home.dto.response.HomeContentResDTO;
-import com.tavemakers.surf.domain.home.service.HomeContentService;
+import com.tavemakers.surf.domain.home.usecase.HomeUsecase;
 import com.tavemakers.surf.global.common.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -17,12 +17,12 @@ import static com.tavemakers.surf.domain.home.controller.ResponseMessage.HOME_CO
 @Tag(name = "홈 문구 관리", description = "홈 문구 관리 API")
 public class HomeContentGetController {
 
-    private final HomeContentService homeContentService;
+    private final HomeUsecase homeUsecase;
 
     @Operation(summary = "홈 문구 조회", description = "홈 문구를 조회합니다.")
     @GetMapping("/v1/admin/home/content")
     public ApiResponse<HomeContentResDTO> getContent() {
-        HomeContentResDTO response = homeContentService.getContent();
+        HomeContentResDTO response = homeUsecase.getContent();
         return ApiResponse.response(HttpStatus.OK, HOME_CONTENT_READ.getMessage(), response);
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/home/controller/HomeContentPatchController.java
+++ b/src/main/java/com/tavemakers/surf/domain/home/controller/HomeContentPatchController.java
@@ -2,7 +2,7 @@ package com.tavemakers.surf.domain.home.controller;
 
 import com.tavemakers.surf.domain.home.dto.request.HomeContentUpsertReqDTO;
 import com.tavemakers.surf.domain.home.dto.response.HomeContentResDTO;
-import com.tavemakers.surf.domain.home.service.HomeContentService;
+import com.tavemakers.surf.domain.home.usecase.HomeUsecase;
 import com.tavemakers.surf.global.common.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -19,14 +19,14 @@ import static com.tavemakers.surf.domain.home.controller.ResponseMessage.HOME_CO
 @Tag(name = "홈 문구 관리", description = "홈 문구 관리 API")
 public class HomeContentPatchController {
 
-    private final HomeContentService homeContentService;
+    private final HomeUsecase homeUsecase;
 
     @Operation(summary = "홈 문구 생성/수정", description = "홈 문구를 생성하거나 수정합니다.")
     @PutMapping("/v1/admin/home/content")
     public ApiResponse<HomeContentResDTO> upsertContent(
             @RequestBody @Valid HomeContentUpsertReqDTO req
     ) {
-        HomeContentResDTO response = homeContentService.upsertContent(req);
+        HomeContentResDTO response = homeUsecase.upsertContent(req);
         return ApiResponse.response(HttpStatus.OK, HOME_CONTENT_UPSERTED.getMessage(), response);
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/home/controller/HomeController.java
+++ b/src/main/java/com/tavemakers/surf/domain/home/controller/HomeController.java
@@ -1,7 +1,7 @@
 package com.tavemakers.surf.domain.home.controller;
 
 import com.tavemakers.surf.domain.home.dto.response.HomeResDTO;
-import com.tavemakers.surf.domain.home.service.HomeService;
+import com.tavemakers.surf.domain.home.usecase.HomeUsecase;
 import com.tavemakers.surf.global.common.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -17,12 +17,12 @@ import static com.tavemakers.surf.domain.home.controller.ResponseMessage.HOME_PA
 @Tag(name = "홈 화면 렌더링")
 public class HomeController {
 
-    private final HomeService homeService;
+    private final HomeUsecase homeUsecase;
 
     @Operation(summary = "홈 화면 렌더링", description = "홈 화면에 필요한 데이터를 렌더링합니다.")
     @GetMapping("/v1/user/home")
     public ApiResponse<HomeResDTO> home() {
-        HomeResDTO response = homeService.getHome();
+        HomeResDTO response = homeUsecase.getHome();
         return ApiResponse.response(HttpStatus.OK, HOME_PAGE_RENDERED.getMessage(), response);
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/home/usecase/HomeUsecase.java
+++ b/src/main/java/com/tavemakers/surf/domain/home/usecase/HomeUsecase.java
@@ -1,0 +1,87 @@
+package com.tavemakers.surf.domain.home.usecase;
+
+import com.tavemakers.surf.domain.home.dto.request.HomeBannerCreateReqDTO;
+import com.tavemakers.surf.domain.home.dto.request.HomeBannerReorderReqDTO;
+import com.tavemakers.surf.domain.home.dto.request.HomeBannerUpdateReqDTO;
+import com.tavemakers.surf.domain.home.dto.request.HomeContentUpsertReqDTO;
+import com.tavemakers.surf.domain.home.dto.response.HomeBannerResDTO;
+import com.tavemakers.surf.domain.home.dto.response.HomeContentResDTO;
+import com.tavemakers.surf.domain.home.dto.response.HomeResDTO;
+import com.tavemakers.surf.domain.home.service.HomeBannerService;
+import com.tavemakers.surf.domain.home.service.HomeContentService;
+import com.tavemakers.surf.domain.home.service.HomeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/** 홈 Usecase */
+@Service
+@RequiredArgsConstructor
+public class HomeUsecase {
+
+    private final HomeService homeService;
+    private final HomeBannerService homeBannerService;
+    private final HomeContentService homeContentService;
+
+    /** 홈 화면 조회 */
+    @Transactional(readOnly = true)
+    public HomeResDTO getHome() {
+        return homeService.getHome();
+    }
+
+    /** 배너 생성 */
+    @Transactional
+    public HomeBannerResDTO createBanner(HomeBannerCreateReqDTO req) {
+        return homeBannerService.createBanner(req);
+    }
+
+    /** 배너 목록 조회 */
+    @Transactional(readOnly = true)
+    public List<HomeBannerResDTO> getBanners() {
+        return homeBannerService.getBanners();
+    }
+
+    /** 배너 삭제 */
+    @Transactional
+    public void deleteBanner(Long bannerId) {
+        homeBannerService.deleteBanner(bannerId);
+    }
+
+    /** 배너 순서 변경 */
+    @Transactional
+    public List<HomeBannerResDTO> reorderBanners(HomeBannerReorderReqDTO req) {
+        return homeBannerService.reorderBanners(req);
+    }
+
+    /** 배너 수정 */
+    @Transactional
+    public HomeBannerResDTO updateBanner(Long bannerId, HomeBannerUpdateReqDTO req) {
+        return homeBannerService.updateBanner(bannerId, req);
+    }
+
+    /** 배너 활성화 */
+    @Transactional
+    public HomeBannerResDTO activateBanner(Long bannerId) {
+        return homeBannerService.activateBanner(bannerId);
+    }
+
+    /** 배너 비활성화 */
+    @Transactional
+    public HomeBannerResDTO deactivateBanner(Long bannerId) {
+        return homeBannerService.deactivateBanner(bannerId);
+    }
+
+    /** 홈 콘텐츠 Upsert */
+    @Transactional
+    public HomeContentResDTO upsertContent(HomeContentUpsertReqDTO req) {
+        return homeContentService.upsertContent(req);
+    }
+
+    /** 홈 콘텐츠 조회 */
+    @Transactional(readOnly = true)
+    public HomeContentResDTO getContent() {
+        return homeContentService.getContent();
+    }
+}

--- a/src/main/java/com/tavemakers/surf/domain/letter/dto/request/LetterCreateReqDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/letter/dto/request/LetterCreateReqDTO.java
@@ -1,40 +1,35 @@
 package com.tavemakers.surf.domain.letter.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
-@Getter
-@NoArgsConstructor
 @Schema(description = "쪽지 생성 요청 DTO")
-public class LetterCreateReqDTO {
+public record LetterCreateReqDTO(
 
-    @Schema(description = "수신자 memberId", example = "3")
-    @NotNull
-    private Long receiverId;
+        @Schema(description = "수신자 memberId", example = "3")
+        @NotNull
+        Long receiverId,
 
-    @Schema(description = "쪽지 제목", example = "문의드립니다.")
-    @NotBlank
-    @Size(max = 100)
-    private String title;
+        @Schema(description = "쪽지 제목", example = "문의드립니다.")
+        @NotBlank
+        @Size(max = 100)
+        String title,
 
-    @Schema(description = "쪽지 본문 내용", example = "안녕하세요, 몇 가지 질문이 있어 쪽지드립니다.")
-    @NotBlank
-    @Size(max = 10000)
-    private String content;
+        @Schema(description = "쪽지 본문 내용", example = "안녕하세요, 몇 가지 질문이 있어 쪽지드립니다.")
+        @NotBlank
+        @Size(max = 10000)
+        String content,
 
-    @Schema(description = "추가 연락 SNS (선택사항)", example = "@instagram_user")
-    @Size(max = 100)
-    private String sns;
+        @Schema(description = "추가 연락 SNS (선택사항)", example = "@instagram_user")
+        @Size(max = 100)
+        String sns,
 
-    @Schema(description = "회신 받을 이메일", example = "sender@example.com")
-    @NotBlank
-    @Email
-    @Size(max = 100)
-    private String replyEmail;
-
-}
+        @Schema(description = "회신 받을 이메일", example = "sender@example.com")
+        @NotBlank
+        @Email
+        @Size(max = 100)
+        String replyEmail
+) {}

--- a/src/main/java/com/tavemakers/surf/domain/letter/facade/LetterFacade.java
+++ b/src/main/java/com/tavemakers/surf/domain/letter/facade/LetterFacade.java
@@ -36,7 +36,7 @@ public class LetterFacade {
         Member sender = memberGetService.getMember(senderId);
 
         // 2) 수신자 조회
-        Member receiver = memberGetService.getMember(req.getReceiverId());
+        Member receiver = memberGetService.getMember(req.receiverId());
 
         // 3) 이메일 본문 생성
         String emailBody = """
@@ -49,16 +49,16 @@ public class LetterFacade {
         """
                 .formatted(
                         sender.getName(),
-                        req.getContent(),
-                        req.getReplyEmail(),
-                        req.getSns() != null ? req.getSns() : "-"
+                        req.content(),
+                        req.replyEmail(),
+                        req.sns() != null ? req.sns() : "-"
                 );
 
         // 4) 이메일 전송 (실패 시 예외)
         try {
             emailSender.sendMail(
                     receiver.getEmail(),
-                    req.getTitle(),
+                    req.title(),
                     emailBody
             );
         } catch (MailException e) {
@@ -68,10 +68,10 @@ public class LetterFacade {
 
         // 5) 엔티티 생성
         Letter letter = Letter.create(
-                req.getTitle(),
-                req.getContent(),
-                req.getSns(),
-                req.getReplyEmail(),
+                req.title(),
+                req.content(),
+                req.sns(),
+                req.replyEmail(),
                 sender,
                 receiver
         );

--- a/src/main/java/com/tavemakers/surf/domain/member/controller/AuthRefreshController.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/controller/AuthRefreshController.java
@@ -2,7 +2,7 @@ package com.tavemakers.surf.domain.member.controller;
 
 import com.tavemakers.surf.domain.login.auth.service.RefreshTokenService;
 import com.tavemakers.surf.domain.member.entity.Member;
-import com.tavemakers.surf.domain.member.repository.MemberRepository;
+import com.tavemakers.surf.domain.member.service.MemberGetService;
 import com.tavemakers.surf.global.common.response.ApiResponse;
 import com.tavemakers.surf.global.jwt.JwtService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -23,7 +23,7 @@ public class AuthRefreshController {
 
     private final RefreshTokenService refreshTokenService;
     private final JwtService jwtService;
-    private final MemberRepository memberRepository;
+    private final MemberGetService memberGetService;
 
     /**
      * Refresh Token 기반 Access Token 재발급
@@ -53,8 +53,7 @@ public class AuthRefreshController {
             // 2) RTR: 검증 + 회전 (여기서 새 refresh 쿠키 세팅됨)
             Long memberId = refreshTokenService.rotate(response, refreshToken);
 
-            Member member = memberRepository.findById(memberId)
-                    .orElseThrow(() -> new IllegalArgumentException("Member not found: " + memberId));
+            Member member = memberGetService.getMember(memberId);
 
             // 3) 새 access 발급
             String newAccessToken = jwtService.createAccessToken(

--- a/src/main/java/com/tavemakers/surf/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/repository/MemberRepository.java
@@ -66,8 +66,9 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     long countByStatusAndIsDeletedFalse(MemberStatus status);
 
     @Query("""
-        select m 
-        from Member m 
+        select distinct m
+        from Member m
+        left join fetch m.tracks
         where m.id in :memberIds
     """)
     List<Member> findMembersByIds(@Param("memberIds") List<Long> memberIds);

--- a/src/main/java/com/tavemakers/surf/domain/member/service/MemberGetService.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/service/MemberGetService.java
@@ -133,4 +133,19 @@ public class MemberGetService {
         return memberRepository.findMembersByIds(memberIds);
     }
 
+    /** ID 목록으로 회원 전체 조회 */
+    public List<Member> getMembersByIds(List<Long> memberIds) {
+        return memberRepository.findAllById(memberIds);
+    }
+
+    /** 멘션 후보 회원 검색 */
+    public List<Member> findMentionCandidates(String keyword, MemberStatus excludeStatus) {
+        return memberRepository.findMentionCandidates(keyword, excludeStatus);
+    }
+
+    /** 특정 기수에 속한 회원 목록 조회 */
+    public List<Member> getMembersByTrackGeneration(Integer generation) {
+        return memberRepository.findAllByTrackGeneration(generation);
+    }
+
 }

--- a/src/main/java/com/tavemakers/surf/domain/member/service/TrackGetService.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/service/TrackGetService.java
@@ -42,4 +42,9 @@ public class TrackGetService {
         return trackRepository.findAllDistinctGenerations();
     }
 
+    /** 회원 ID 목록으로 트랙 전체 조회 */
+    public List<Track> getTracksByMemberIds(List<Long> memberIds) {
+        return trackRepository.findAllByMemberIds(memberIds);
+    }
+
 }

--- a/src/main/java/com/tavemakers/surf/domain/notification/service/NotificationCreateService.java
+++ b/src/main/java/com/tavemakers/surf/domain/notification/service/NotificationCreateService.java
@@ -7,6 +7,7 @@ import com.tavemakers.surf.domain.notification.entity.Notification;
 import com.tavemakers.surf.domain.notification.entity.NotificationType;
 import com.tavemakers.surf.domain.notification.event.NotificationCreatedEvent;
 import com.tavemakers.surf.domain.notification.repository.NotificationRepository;
+import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -39,6 +40,29 @@ public class NotificationCreateService {
             return notificationRepository.save(notification);
         } catch (Exception e) {
             throw new RuntimeException("Failed to create notification", e);
+        }
+    }
+
+    /**
+     * 다수 회원에게 알림 일괄 저장 + FCM 전송 (N+1 방지)
+     */
+    @Transactional
+    public void createAndSendBulk(
+            List<Long> receiverIds,
+            NotificationType type,
+            Map<String, Object> payload
+    ) {
+        try {
+            String payloadJson = objectMapper.writeValueAsString(payload);
+            List<Notification> notifications = receiverIds.stream()
+                    .map(receiverId -> Notification.of(receiverId, type, payloadJson))
+                    .toList();
+            List<Notification> saved = notificationRepository.saveAll(notifications);
+            saved.forEach(n ->
+                    eventPublisher.publishEvent(new NotificationCreatedEvent(n.getId(), n.getMemberId()))
+            );
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to create bulk notifications", e);
         }
     }
 

--- a/src/main/java/com/tavemakers/surf/domain/notification/service/NotificationEventListener.java
+++ b/src/main/java/com/tavemakers/surf/domain/notification/service/NotificationEventListener.java
@@ -7,8 +7,7 @@ import com.tavemakers.surf.domain.letter.event.LetterSentEvent;
 import com.tavemakers.surf.domain.notification.entity.NotificationType;
 import com.tavemakers.surf.domain.post.entity.Post;
 import com.tavemakers.surf.domain.post.event.PostLikedEvent;
-import com.tavemakers.surf.domain.post.exception.PostNotFoundException;
-import com.tavemakers.surf.domain.post.repository.PostRepository;
+import com.tavemakers.surf.domain.post.service.post.PostGetService;
 import com.tavemakers.surf.domain.post.service.support.PostPublishedEvent;
 import java.util.Map;
 
@@ -26,7 +25,7 @@ import org.springframework.transaction.event.TransactionalEventListener;
 @RequiredArgsConstructor
 public class NotificationEventListener {
 
-    private final PostRepository postRepository;
+    private final PostGetService postGetService;
     private final NotificationUsecase notificationUsecase;
     private final NotificationCreateService notificationCreateService;
 
@@ -34,8 +33,7 @@ public class NotificationEventListener {
     @Transactional
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handle(PostPublishedEvent event) {
-        Post post = postRepository.findById(event.getPostId())
-                .orElseThrow(PostNotFoundException::new);
+        Post post = postGetService.readPost(event.getPostId());
 
         if (!post.getBoard().isNotice()) {
             return;

--- a/src/main/java/com/tavemakers/surf/domain/notification/service/NotificationUsecase.java
+++ b/src/main/java/com/tavemakers/surf/domain/notification/service/NotificationUsecase.java
@@ -40,18 +40,16 @@ public class NotificationUsecase {
             return;
         }
 
-        // 2 Notification 엔티티 생성
-        for (Long memberId : targetIds) {
-            notificationCreateService.createAndSend(
-                    memberId,                   // 알림 받는 사람
-                    NotificationType.NOTICE,            // 공지 알림 타입
-                    Map.of(
-                            "boardName", post.getBoard().getName(),
-                            "boardId", post.getBoard().getId(),
-                            "postId", post.getId()
-                    )
-            );
-        }
+        // 2 Notification 엔티티 일괄 생성 (N+1 방지)
+        notificationCreateService.createAndSendBulk(
+                targetIds,
+                NotificationType.NOTICE,
+                Map.of(
+                        "boardName", post.getBoard().getName(),
+                        "boardId", post.getBoard().getId(),
+                        "postId", post.getId()
+                )
+        );
 
         log.info(
                 "[NoticeNotification] sent to {} members, postId={}",

--- a/src/main/java/com/tavemakers/surf/domain/post/controller/post/PostCreateController.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/controller/post/PostCreateController.java
@@ -2,7 +2,7 @@ package com.tavemakers.surf.domain.post.controller.post;
 
 import com.tavemakers.surf.domain.post.dto.request.PostCreateReqDTO;
 import com.tavemakers.surf.domain.post.dto.response.PostDetailResDTO;
-import com.tavemakers.surf.domain.post.service.post.PostCreateService;
+import com.tavemakers.surf.domain.post.service.post.PostCreateUsecase;
 import com.tavemakers.surf.global.common.response.ApiResponse;
 import com.tavemakers.surf.global.util.SecurityUtils;
 import io.swagger.v3.oas.annotations.Operation;
@@ -20,7 +20,7 @@ import static com.tavemakers.surf.domain.post.controller.ResponseMessage.*;
 @Tag(name = "게시물", description = "게시물 생성 API")
 public class PostCreateController {
 
-    private final PostCreateService postCreateService;
+    private final PostCreateUsecase postCreateUsecase;
 
     /** 게시글 생성 (작성자 = 현재 로그인 사용자) */
     @Operation(summary = "게시글 생성", description = "게시글을 생성합니다.")
@@ -29,7 +29,7 @@ public class PostCreateController {
             @Valid @RequestBody PostCreateReqDTO req
     ) {
         Long memberId = SecurityUtils.getCurrentMemberId();
-        PostDetailResDTO response = postCreateService.createPost(req, memberId);
+        PostDetailResDTO response = postCreateUsecase.createPost(req, memberId);
         return ApiResponse.response(HttpStatus.CREATED, POST_CREATED.getMessage(), response);
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/post/controller/post/PostPatchController.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/controller/post/PostPatchController.java
@@ -2,7 +2,7 @@ package com.tavemakers.surf.domain.post.controller.post;
 
 import com.tavemakers.surf.domain.post.dto.request.PostUpdateReqDTO;
 import com.tavemakers.surf.domain.post.dto.response.PostDetailResDTO;
-import com.tavemakers.surf.domain.post.service.post.PostPatchService;
+import com.tavemakers.surf.domain.post.service.post.PostPatchUsecase;
 import com.tavemakers.surf.global.common.response.ApiResponse;
 import com.tavemakers.surf.global.util.SecurityUtils;
 import io.swagger.v3.oas.annotations.Operation;
@@ -20,7 +20,7 @@ import static com.tavemakers.surf.domain.post.controller.ResponseMessage.*;
 @Tag(name = "게시물", description = "게시물 수정 API")
 public class PostPatchController {
 
-    private final PostPatchService postPatchService;
+    private final PostPatchUsecase postPatchUsecase;
 
     /** 게시글 수정 (작성자 검증은 서비스에서) */
     @Operation(summary = "게시글 수정", description = "본인이 작성한 게시글을 수정합니다.")
@@ -30,7 +30,7 @@ public class PostPatchController {
             @Valid @RequestBody PostUpdateReqDTO req
     ) {
         Long memberId = SecurityUtils.getCurrentMemberId();
-        PostDetailResDTO response = postPatchService.updatePost(postId, req, memberId);
+        PostDetailResDTO response = postPatchUsecase.updatePost(postId, req, memberId);
         return ApiResponse.response(HttpStatus.OK, POST_UPDATED.getMessage(), response);
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/post/service/post/PostCreateService.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/service/post/PostCreateService.java
@@ -19,6 +19,7 @@ import com.tavemakers.surf.domain.post.service.image.PostImageCreateService;
 import com.tavemakers.surf.domain.post.service.support.PostPublishedEvent;
 import com.tavemakers.surf.domain.reservation.usecase.ReservationUsecase;
 import com.tavemakers.surf.global.logging.LogEvent;
+import org.springframework.lang.Nullable;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
@@ -39,14 +40,13 @@ public class PostCreateService {
     private final BoardGetService boardGetService;
     private final BoardCategoryGetService boardCategoryGetService;
     private final MemberGetService memberGetService;
-    private final ReservationUsecase reservationUsecase;
     private final PostImageCreateService imageCreateService;
     private final ApplicationEventPublisher eventPublisher;
 
     /** 게시글 생성 및 저장 */
     @Transactional
     @LogEvent(value = "post.create", message = "게시글 생성 성공")
-    public PostDetailResDTO createPost(PostCreateReqDTO req, Long memberId) {
+    public PostDetailResDTO createPost(PostCreateReqDTO req, Long memberId, @Nullable ReservationUsecase reservationUsecase) {
         Board board = boardGetService.getBoard(req.boardId());
         Member member = memberGetService.getMember(memberId);
 

--- a/src/main/java/com/tavemakers/surf/domain/post/service/post/PostCreateService.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/service/post/PostCreateService.java
@@ -17,9 +17,7 @@ import com.tavemakers.surf.domain.post.exception.PostImageListEmptyException;
 import com.tavemakers.surf.domain.post.repository.PostRepository;
 import com.tavemakers.surf.domain.post.service.image.PostImageCreateService;
 import com.tavemakers.surf.domain.post.service.support.PostPublishedEvent;
-import com.tavemakers.surf.domain.reservation.usecase.ReservationUsecase;
 import com.tavemakers.surf.global.logging.LogEvent;
-import org.springframework.lang.Nullable;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
@@ -43,10 +41,10 @@ public class PostCreateService {
     private final PostImageCreateService imageCreateService;
     private final ApplicationEventPublisher eventPublisher;
 
-    /** 게시글 생성 및 저장 */
+    /** 게시글 생성 및 저장 (예약 처리는 Usecase에서 담당) */
     @Transactional
     @LogEvent(value = "post.create", message = "게시글 생성 성공")
-    public PostDetailResDTO createPost(PostCreateReqDTO req, Long memberId, @Nullable ReservationUsecase reservationUsecase) {
+    public PostDetailResDTO createPost(PostCreateReqDTO req, Long memberId) {
         Board board = boardGetService.getBoard(req.boardId());
         Member member = memberGetService.getMember(memberId);
 
@@ -55,14 +53,8 @@ public class PostCreateService {
         Post post = Post.of(req, board, category, member);
         Post saved = postRepository.save(post);
 
-        LocalDateTime reservedAt = null;
-        if (req.isReserved()) {
-            reservationUsecase.reservePost(saved.getId(), req.reservedAt());
-            reservedAt = req.reservedAt();
-        } else{
-            eventPublisher.publishEvent(
-                    new PostPublishedEvent(saved.getId())
-            );
+        if (!req.isReserved()) {
+            eventPublisher.publishEvent(new PostPublishedEvent(saved.getId()));
         }
 
         List<PostImageResDTO> imageUrlResponseList = null;
@@ -72,7 +64,8 @@ public class PostCreateService {
             imageUrlResponseList = imageCreateService.saveAll(saved, imageUrlList);
         }
 
-        return PostDetailResDTO.of(saved, false, false,true,imageUrlResponseList, reservedAt,0);
+        LocalDateTime reservedAt = req.isReserved() ? req.reservedAt() : null;
+        return PostDetailResDTO.of(saved, false, false, true, imageUrlResponseList, reservedAt, 0);
     }
 
     /** 이미지 목록에서 첫 번째 이미지 URL 추출 */

--- a/src/main/java/com/tavemakers/surf/domain/post/service/post/PostCreateUsecase.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/service/post/PostCreateUsecase.java
@@ -18,6 +18,10 @@ public class PostCreateUsecase {
     /** 게시글 생성 (예약 포함) */
     @Transactional
     public PostDetailResDTO createPost(PostCreateReqDTO req, Long memberId) {
-        return postCreateService.createPost(req, memberId, reservationUsecase);
+        PostDetailResDTO result = postCreateService.createPost(req, memberId);
+        if (req.isReserved()) {
+            reservationUsecase.reservePost(result.postId(), req.reservedAt());
+        }
+        return result;
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/post/service/post/PostCreateUsecase.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/service/post/PostCreateUsecase.java
@@ -1,0 +1,23 @@
+package com.tavemakers.surf.domain.post.service.post;
+
+import com.tavemakers.surf.domain.post.dto.request.PostCreateReqDTO;
+import com.tavemakers.surf.domain.post.dto.response.PostDetailResDTO;
+import com.tavemakers.surf.domain.reservation.usecase.ReservationUsecase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/** 게시글 생성 Usecase */
+@Service
+@RequiredArgsConstructor
+public class PostCreateUsecase {
+
+    private final PostCreateService postCreateService;
+    private final ReservationUsecase reservationUsecase;
+
+    /** 게시글 생성 (예약 포함) */
+    @Transactional
+    public PostDetailResDTO createPost(PostCreateReqDTO req, Long memberId) {
+        return postCreateService.createPost(req, memberId, reservationUsecase);
+    }
+}

--- a/src/main/java/com/tavemakers/surf/domain/post/service/post/PostGetService.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/service/post/PostGetService.java
@@ -84,6 +84,21 @@ public class PostGetService {
         return PostDetailResDTO.of(post, scrappedByMe, likedByMe, isMine, imageUrlList, reservedAt, viewCount);
     }
 
+    /** 게시글 버전 조회 (낙관적 락용) */
+    public Long findVersionById(Long postId) {
+        return postRepository.findVersionById(postId);
+    }
+
+    /** 스크랩 수 증가 (낙관적 락) */
+    public int increaseScrapCount(Long postId, Long version) {
+        return postRepository.increaseScrapCount(postId, version);
+    }
+
+    /** 스크랩 수 감소 (낙관적 락) */
+    public int decreaseScrapCount(Long postId, Long version) {
+        return postRepository.decreaseScrapCount(postId, version);
+    }
+
     /** 게시글 예약을 위한 Post 조회 */
     public Optional<Post> findPost(Long id) {
         return postRepository.findById(id);

--- a/src/main/java/com/tavemakers/surf/domain/post/service/post/PostPatchService.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/service/post/PostPatchService.java
@@ -24,6 +24,7 @@ import com.tavemakers.surf.domain.post.service.like.PostLikeService;
 import com.tavemakers.surf.domain.post.service.support.ViewCountService;
 import com.tavemakers.surf.domain.reservation.usecase.ReservationUsecase;
 import com.tavemakers.surf.domain.scrap.service.ScrapGetService;
+import org.springframework.lang.Nullable;
 import com.tavemakers.surf.global.logging.LogEvent;
 import com.tavemakers.surf.global.logging.LogParam;
 import com.tavemakers.surf.global.util.SecurityUtils;
@@ -46,7 +47,6 @@ public class PostPatchService {
     private final BoardCategoryGetService boardCategoryGetService;
     private final ScrapGetService scrapGetService;
     private final PostLikeService postLikeService;
-    private final ReservationUsecase reservationUsecase;
     private final PostImageCreateService imageCreateService;
     private final PostImageGetService imageGetService;
     private final PostImageDeleteService imageDeleteService;
@@ -58,7 +58,8 @@ public class PostPatchService {
     @LogEvent(value = "post.update", message = "게시글 수정 성공")
     public PostDetailResDTO updatePost(
             @LogParam("post_id") Long postId,
-            PostUpdateReqDTO req, Long viewerId) {
+            PostUpdateReqDTO req, Long viewerId,
+            @Nullable ReservationUsecase reservationUsecase) {
         Post post = postRepository.findById(postId)
                 .orElseThrow(PostNotFoundException::new);
         Member member = memberGetService.getMember(SecurityUtils.getCurrentMemberId());

--- a/src/main/java/com/tavemakers/surf/domain/post/service/post/PostPatchService.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/service/post/PostPatchService.java
@@ -22,9 +22,9 @@ import com.tavemakers.surf.domain.post.service.image.PostImageGetService;
 import com.tavemakers.surf.domain.post.service.image.PostImageCreateService;
 import com.tavemakers.surf.domain.post.service.like.PostLikeService;
 import com.tavemakers.surf.domain.post.service.support.ViewCountService;
-import com.tavemakers.surf.domain.reservation.usecase.ReservationUsecase;
+import com.tavemakers.surf.domain.reservation.entity.Reservation;
+import com.tavemakers.surf.domain.reservation.service.ReservationGetService;
 import com.tavemakers.surf.domain.scrap.service.ScrapGetService;
-import org.springframework.lang.Nullable;
 import com.tavemakers.surf.global.logging.LogEvent;
 import com.tavemakers.surf.global.logging.LogParam;
 import com.tavemakers.surf.global.util.SecurityUtils;
@@ -33,6 +33,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Comparator;
 import java.util.List;
 
@@ -47,19 +48,19 @@ public class PostPatchService {
     private final BoardCategoryGetService boardCategoryGetService;
     private final ScrapGetService scrapGetService;
     private final PostLikeService postLikeService;
+    private final ReservationGetService reservationGetService;
     private final PostImageCreateService imageCreateService;
     private final PostImageGetService imageGetService;
     private final PostImageDeleteService imageDeleteService;
     private final MemberGetService memberGetService;
     private final ViewCountService viewCountService;
 
-    /** 게시글 수정 */
+    /** 게시글 수정 (예약 변경 처리는 Usecase에서 담당) */
     @Transactional
     @LogEvent(value = "post.update", message = "게시글 수정 성공")
     public PostDetailResDTO updatePost(
             @LogParam("post_id") Long postId,
-            PostUpdateReqDTO req, Long viewerId,
-            @Nullable ReservationUsecase reservationUsecase) {
+            PostUpdateReqDTO req, Long viewerId) {
         Post post = postRepository.findById(postId)
                 .orElseThrow(PostNotFoundException::new);
         Member member = memberGetService.getMember(SecurityUtils.getCurrentMemberId());
@@ -75,14 +76,12 @@ public class PostPatchService {
         boolean likedByMe = postLikeService.isLikedByMe(viewerId, postId);
         int viewCount = viewCountService.increaseViewCount(post, viewerId);
 
-        // 예약 시간 변경 시 -> 기존의 예약 시간 조회 -> 기존의 예약 시간을 CANCELD로 수정하고 schedule 호출하면 끝.
-        if (Boolean.TRUE.equals(req.isReservationChanged())) {
-            reservationUsecase.updateReservationPost(post.getId(), req.reservedAt());
-        }
-
         LocalDateTime reservedAt = null;
         if (post.isReserved()) {
-            reservedAt = reservationUsecase.getReservedAt(postId);
+            Reservation reservation = reservationGetService.findByPostIdAndStatus(postId);
+            if (reservation != null) {
+                reservedAt = LocalDateTime.ofInstant(reservation.getReservedAt(), ZoneId.of("Asia/Seoul"));
+            }
         }
 
         // 이미지 변경

--- a/src/main/java/com/tavemakers/surf/domain/post/service/post/PostPatchUsecase.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/service/post/PostPatchUsecase.java
@@ -18,6 +18,9 @@ public class PostPatchUsecase {
     /** 게시글 수정 (예약 시간 변경 포함) */
     @Transactional
     public PostDetailResDTO updatePost(Long postId, PostUpdateReqDTO req, Long memberId) {
-        return postPatchService.updatePost(postId, req, memberId, reservationUsecase);
+        if (Boolean.TRUE.equals(req.isReservationChanged())) {
+            reservationUsecase.updateReservationPost(postId, req.reservedAt());
+        }
+        return postPatchService.updatePost(postId, req, memberId);
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/post/service/post/PostPatchUsecase.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/service/post/PostPatchUsecase.java
@@ -1,0 +1,23 @@
+package com.tavemakers.surf.domain.post.service.post;
+
+import com.tavemakers.surf.domain.post.dto.request.PostUpdateReqDTO;
+import com.tavemakers.surf.domain.post.dto.response.PostDetailResDTO;
+import com.tavemakers.surf.domain.reservation.usecase.ReservationUsecase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/** 게시글 수정 Usecase */
+@Service
+@RequiredArgsConstructor
+public class PostPatchUsecase {
+
+    private final PostPatchService postPatchService;
+    private final ReservationUsecase reservationUsecase;
+
+    /** 게시글 수정 (예약 시간 변경 포함) */
+    @Transactional
+    public PostDetailResDTO updatePost(Long postId, PostUpdateReqDTO req, Long memberId) {
+        return postPatchService.updatePost(postId, req, memberId, reservationUsecase);
+    }
+}

--- a/src/main/java/com/tavemakers/surf/domain/reservation/usecase/ReservationUsecase.java
+++ b/src/main/java/com/tavemakers/surf/domain/reservation/usecase/ReservationUsecase.java
@@ -23,6 +23,7 @@ public class ReservationUsecase {
     private final ReservationScheduleService scheduleService;
 
     /** 게시글 예약 발행 등록 */
+    @Transactional
     public void reservePost(Long postId, LocalDateTime reservedAt) {
         Instant publishAt = toInstant(reservedAt);
         Reservation reservation = Reservation.of(postId, publishAt);

--- a/src/main/java/com/tavemakers/surf/domain/schedule/controller/ScheduleGetController.java
+++ b/src/main/java/com/tavemakers/surf/domain/schedule/controller/ScheduleGetController.java
@@ -28,6 +28,7 @@ public class ScheduleGetController {
 
     private final ScheduleUsecase scheduleUseCase;
 
+    /** 월별 일정 목록 조회 */
     @Operation(summary = "캘린더에 월별 일정 목록 조회", description = "캘린더 페이지에서 월별 일정을 조회합니다.")
     @GetMapping("/v1/user/calendar/schedules")
     public ApiResponse<ScheduleMonthlyResDTO> getMonthlySchedules(
@@ -44,6 +45,7 @@ public class ScheduleGetController {
         return ApiResponse.response(HttpStatus.OK, SCHEDULE_POST_READ.getMessage(),dto);
     }
 
+    /** 특정 일정 단건 조회 (캘린더 수정/삭제용) */
     @Operation(summary = "특정 일정 조회", description = "특정 일정을 캘린더에서 수정/삭제할 때 조회")
     @GetMapping("/v1/admin/calendar/schedules/{scheduleId}")
     public ApiResponse<ScheduleResDTO> getScheduleByScheduleId(@PathVariable Long scheduleId) {

--- a/src/main/java/com/tavemakers/surf/domain/schedule/controller/ScheduleGetController.java
+++ b/src/main/java/com/tavemakers/surf/domain/schedule/controller/ScheduleGetController.java
@@ -6,7 +6,6 @@ import static com.tavemakers.surf.domain.schedule.controller.ResponseMessage.SCH
 
 import com.tavemakers.surf.domain.schedule.dto.response.ScheduleMonthlyResDTO;
 import com.tavemakers.surf.domain.schedule.dto.response.ScheduleResDTO;
-import com.tavemakers.surf.domain.schedule.service.ScheduleGetService;
 import com.tavemakers.surf.domain.schedule.service.ScheduleUsecase;
 import com.tavemakers.surf.global.common.response.ApiResponse;
 import com.tavemakers.surf.global.util.SecurityUtils;
@@ -27,7 +26,6 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "일정", description = "일정 관련 API")
 public class ScheduleGetController {
 
-    private final ScheduleGetService scheduleGetService;
     private final ScheduleUsecase scheduleUseCase;
 
     @Operation(summary = "캘린더에 월별 일정 목록 조회", description = "캘린더 페이지에서 월별 일정을 조회합니다.")
@@ -35,7 +33,7 @@ public class ScheduleGetController {
     public ApiResponse<ScheduleMonthlyResDTO> getMonthlySchedules(
             @RequestParam @Parameter int year, @RequestParam @Parameter int month) {
         String memberRole = SecurityUtils.getCurrentMemberRole();
-        ScheduleMonthlyResDTO dto = scheduleGetService.getScheduleMonthly(memberRole,year, month);
+        ScheduleMonthlyResDTO dto = scheduleUseCase.getScheduleMonthly(memberRole, year, month);
         return ApiResponse.response(HttpStatus.OK, SCHEDULE_CALENDAR_READ.getMessage(),dto);
     }
 
@@ -49,7 +47,7 @@ public class ScheduleGetController {
     @Operation(summary = "특정 일정 조회", description = "특정 일정을 캘린더에서 수정/삭제할 때 조회")
     @GetMapping("/v1/admin/calendar/schedules/{scheduleId}")
     public ApiResponse<ScheduleResDTO> getScheduleByScheduleId(@PathVariable Long scheduleId) {
-        ScheduleResDTO dto = scheduleGetService.getScheduleSingleAtCalendar(scheduleId);
+        ScheduleResDTO dto = scheduleUseCase.getScheduleSingleAtCalendar(scheduleId);
         return ApiResponse.response(HttpStatus.OK, SCHEDULE_READ.getMessage(),dto);
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/schedule/service/ScheduleUsecase.java
+++ b/src/main/java/com/tavemakers/surf/domain/schedule/service/ScheduleUsecase.java
@@ -2,6 +2,7 @@ package com.tavemakers.surf.domain.schedule.service;
 
 import com.tavemakers.surf.domain.schedule.dto.request.ScheduleCreateReqDTO;
 import com.tavemakers.surf.domain.schedule.dto.request.ScheduleUpdateReqDTO;
+import com.tavemakers.surf.domain.schedule.dto.response.ScheduleMonthlyResDTO;
 import com.tavemakers.surf.domain.schedule.dto.response.ScheduleResDTO;
 import com.tavemakers.surf.domain.post.entity.Post;
 import com.tavemakers.surf.domain.schedule.entity.Schedule;
@@ -63,5 +64,17 @@ public class ScheduleUsecase {
     @Transactional(readOnly = true)
     public ScheduleResDTO getScheduleByPost(Long postId) {
            return scheduleGetService.getScheduleSingleDTO(postId);
+    }
+
+    /** 월별 일정 조회 */
+    @Transactional(readOnly = true)
+    public ScheduleMonthlyResDTO getScheduleMonthly(String memberRole, int year, int month) {
+        return scheduleGetService.getScheduleMonthly(memberRole, year, month);
+    }
+
+    /** 특정 일정 단건 조회 (캘린더용) */
+    @Transactional(readOnly = true)
+    public ScheduleResDTO getScheduleSingleAtCalendar(Long scheduleId) {
+        return scheduleGetService.getScheduleSingleAtCalendar(scheduleId);
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/scrap/controller/ScrapCreateController.java
+++ b/src/main/java/com/tavemakers/surf/domain/scrap/controller/ScrapCreateController.java
@@ -1,6 +1,6 @@
 package com.tavemakers.surf.domain.scrap.controller;
 
-import com.tavemakers.surf.domain.scrap.service.ScrapService;
+import com.tavemakers.surf.domain.scrap.usecase.ScrapUsecase;
 import com.tavemakers.surf.global.common.response.ApiResponse;
 import com.tavemakers.surf.global.util.SecurityUtils;
 import io.swagger.v3.oas.annotations.Operation;
@@ -17,14 +17,14 @@ import static com.tavemakers.surf.domain.scrap.controller.ResponseMessage.*;
 @Tag(name = "스크랩", description = "추후 MVP를 통해 디벨롭 될 예정")
 public class ScrapCreateController {
 
-    private final ScrapService scrapService;
+    private final ScrapUsecase scrapUsecase;
 
     /** 스크랩 추가 (현재 로그인 사용자 기준) */
     @Operation(summary = "스크랩 추가", description = "특정 게시글을 스크랩합니다.")
     @PostMapping("/v1/user/scraps/{postId}")
     public ApiResponse<Void> addScrap(@PathVariable Long postId) {
         Long me = SecurityUtils.getCurrentMemberId();
-        scrapService.addScrap(me, postId);
+        scrapUsecase.addScrap(me, postId);
         return ApiResponse.response(HttpStatus.CREATED, SCRAP_CREATED.getMessage());
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/scrap/controller/ScrapDeleteController.java
+++ b/src/main/java/com/tavemakers/surf/domain/scrap/controller/ScrapDeleteController.java
@@ -1,6 +1,6 @@
 package com.tavemakers.surf.domain.scrap.controller;
 
-import com.tavemakers.surf.domain.scrap.service.ScrapService;
+import com.tavemakers.surf.domain.scrap.usecase.ScrapUsecase;
 import com.tavemakers.surf.global.common.response.ApiResponse;
 import com.tavemakers.surf.global.util.SecurityUtils;
 import io.swagger.v3.oas.annotations.Operation;
@@ -17,14 +17,14 @@ import static com.tavemakers.surf.domain.scrap.controller.ResponseMessage.*;
 @Tag(name = "스크랩", description = "추후 MVP를 통해 디벨롭 될 예정")
 public class ScrapDeleteController {
 
-    private final ScrapService scrapService;
+    private final ScrapUsecase scrapUsecase;
 
     /** 스크랩 삭제 (현재 로그인 사용자 기준) */
     @Operation(summary = "스크랩 삭제", description = "특정 게시글의 스크랩을 취소합니다.")
     @DeleteMapping("/v1/user/scraps/{postId}")
     public ApiResponse<Void> removeScrap(@PathVariable Long postId) {
         Long me = SecurityUtils.getCurrentMemberId();
-        scrapService.removeScrap(me, postId);
+        scrapUsecase.removeScrap(me, postId);
         return ApiResponse.response(HttpStatus.NO_CONTENT, SCRAP_DELETED.getMessage());
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/scrap/controller/ScrapGetController.java
+++ b/src/main/java/com/tavemakers/surf/domain/scrap/controller/ScrapGetController.java
@@ -1,7 +1,7 @@
 package com.tavemakers.surf.domain.scrap.controller;
 
 import com.tavemakers.surf.domain.post.dto.response.PostResDTO;
-import com.tavemakers.surf.domain.scrap.service.ScrapService;
+import com.tavemakers.surf.domain.scrap.usecase.ScrapUsecase;
 import com.tavemakers.surf.global.common.response.ApiResponse;
 import com.tavemakers.surf.global.util.SecurityUtils;
 import io.swagger.v3.oas.annotations.Operation;
@@ -22,7 +22,7 @@ import static com.tavemakers.surf.domain.scrap.controller.ResponseMessage.*;
 @Tag(name = "스크랩", description = "추후 MVP를 통해 디벨롭 될 예정")
 public class ScrapGetController {
 
-    private final ScrapService scrapService;
+    private final ScrapUsecase scrapUsecase;
 
     /** 내가 스크랩한 게시글 목록 */
     @Operation(summary = "내가 스크랩한 게시글 목록", description = "본인이 스크랩한 게시글 목록을 조회합니다.")
@@ -32,7 +32,7 @@ public class ScrapGetController {
             Pageable pageable
     ) {
         Long me = SecurityUtils.getCurrentMemberId();
-        Slice<PostResDTO> response = scrapService.getMyScraps(me, pageable);
+        Slice<PostResDTO> response = scrapUsecase.getMyScraps(me, pageable);
         return ApiResponse.response(HttpStatus.OK, MY_SCRAP_LIST_READ.getMessage(), response);
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/scrap/repository/ScrapRepository.java
+++ b/src/main/java/com/tavemakers/surf/domain/scrap/repository/ScrapRepository.java
@@ -18,8 +18,12 @@ public interface ScrapRepository extends JpaRepository<Scrap, Long> {
 
     @Query(
             value = """
-            select s.post
+            select p
             from Scrap s
+            join s.post p
+            join fetch p.member
+            join fetch p.board
+            left join fetch p.category
             where s.member.id = :memberId
             order by s.createdAt desc
             """

--- a/src/main/java/com/tavemakers/surf/domain/scrap/service/ScrapService.java
+++ b/src/main/java/com/tavemakers/surf/domain/scrap/service/ScrapService.java
@@ -5,8 +5,8 @@ import com.tavemakers.surf.domain.member.service.MemberGetService;
 import com.tavemakers.surf.domain.post.dto.response.PostResDTO;
 import com.tavemakers.surf.domain.post.entity.Post;
 import com.tavemakers.surf.domain.post.exception.PostNotFoundException;
-import com.tavemakers.surf.domain.post.repository.PostRepository;
 import com.tavemakers.surf.domain.post.service.like.PostLikeGetService;
+import com.tavemakers.surf.domain.post.service.post.PostGetService;
 import com.tavemakers.surf.domain.scrap.entity.Scrap;
 import com.tavemakers.surf.domain.scrap.repository.ScrapRepository;
 import com.tavemakers.surf.global.logging.LogEvent;
@@ -30,8 +30,7 @@ import java.util.Set;
 public class ScrapService {
 
     private final ScrapRepository scrapRepository;
-    // PostGetService와 순환 의존성 방지를 위해 PostRepository 직접 사용 (특수 메서드 포함)
-    private final PostRepository postRepository;
+    private final PostGetService postGetService;
     private final MemberGetService memberGetService;
     private final PostLikeGetService postLikeGetService;
 
@@ -42,15 +41,14 @@ public class ScrapService {
             @LogParam("user_id") Long memberId,
             @LogParam("post_id") Long postId) {
         Member member = memberGetService.getMember(memberId);
-        Post post = postRepository.findById(postId).
-                orElseThrow(PostNotFoundException::new);
+        Post post = postGetService.getPost(postId);
         try {
             scrapRepository.save(Scrap.of(member, post));
             // 버전 기반 단일 UPDATE (+재시도)
             for (int i = 0; i < 3; i++) {
-                Long v = postRepository.findVersionById(postId);
+                Long v = postGetService.findVersionById(postId);
                 if (v == null) throw new PostNotFoundException();
-                if (postRepository.increaseScrapCount(postId, v) > 0) break;
+                if (postGetService.increaseScrapCount(postId, v) > 0) break;
                 if (i == 2) throw new OptimisticLockException("scrapCount 증가 충돌");
             }
         } catch (DataIntegrityViolationException e) {
@@ -67,9 +65,9 @@ public class ScrapService {
         int deleted = scrapRepository.deleteByMemberIdAndPostId(memberId, postId);
         if (deleted > 0) {
             for (int i = 0; i < 3; i++) {
-                Long v = postRepository.findVersionById(postId);
+                Long v = postGetService.findVersionById(postId);
                 if (v == null) throw new PostNotFoundException();
-                if (postRepository.decreaseScrapCount(postId, v) > 0) break;
+                if (postGetService.decreaseScrapCount(postId, v) > 0) break;
                 if (i == 2) throw new OptimisticLockException("scrapCount 감소 충돌");
             }
         }

--- a/src/main/java/com/tavemakers/surf/domain/scrap/usecase/ScrapUsecase.java
+++ b/src/main/java/com/tavemakers/surf/domain/scrap/usecase/ScrapUsecase.java
@@ -1,0 +1,35 @@
+package com.tavemakers.surf.domain.scrap.usecase;
+
+import com.tavemakers.surf.domain.post.dto.response.PostResDTO;
+import com.tavemakers.surf.domain.scrap.service.ScrapService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/** 스크랩 Usecase */
+@Service
+@RequiredArgsConstructor
+public class ScrapUsecase {
+
+    private final ScrapService scrapService;
+
+    /** 게시글 스크랩 추가 */
+    @Transactional
+    public void addScrap(Long memberId, Long postId) {
+        scrapService.addScrap(memberId, postId);
+    }
+
+    /** 게시글 스크랩 삭제 */
+    @Transactional
+    public void removeScrap(Long memberId, Long postId) {
+        scrapService.removeScrap(memberId, postId);
+    }
+
+    /** 내 스크랩 목록 조회 */
+    @Transactional(readOnly = true)
+    public Slice<PostResDTO> getMyScraps(Long memberId, Pageable pageable) {
+        return scrapService.getMyScraps(memberId, pageable);
+    }
+}

--- a/src/main/java/com/tavemakers/surf/domain/team/controller/TeamCreateController.java
+++ b/src/main/java/com/tavemakers/surf/domain/team/controller/TeamCreateController.java
@@ -2,7 +2,7 @@ package com.tavemakers.surf.domain.team.controller;
 
 import com.tavemakers.surf.domain.team.dto.request.TeamUpsertReqDTO;
 import com.tavemakers.surf.domain.team.dto.response.TeamResDTO;
-import com.tavemakers.surf.domain.team.service.TeamService;
+import com.tavemakers.surf.domain.team.usecase.TeamUsecase;
 import com.tavemakers.surf.global.common.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -23,7 +23,7 @@ import static com.tavemakers.surf.domain.team.controller.ResponseMessage.TEAM_CR
 @Tag(name = "팀", description = "팀 관련 CRUD API")
 public class TeamCreateController {
 
-    private final TeamService teamService;
+    private final TeamUsecase teamUsecase;
 
     /** 팀 생성 (팀장 memberId(leaderMemberId)는 팀원 memberId 리스트(memberIds) 내에 포함되어야 합니다.)*/
     @Operation(summary = "팀 생성", description = "새로운 팀을 생성합니다.")
@@ -32,7 +32,7 @@ public class TeamCreateController {
             @Valid @RequestBody TeamUpsertReqDTO req
     ) {
 
-        TeamResDTO response = teamService.createTeam(req);
+        TeamResDTO response = teamUsecase.createTeam(req);
         return ApiResponse.response(HttpStatus.CREATED, TEAM_CREATED.getMessage(), response);
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/team/controller/TeamDeleteController.java
+++ b/src/main/java/com/tavemakers/surf/domain/team/controller/TeamDeleteController.java
@@ -1,6 +1,6 @@
 package com.tavemakers.surf.domain.team.controller;
 
-import com.tavemakers.surf.domain.team.service.TeamService;
+import com.tavemakers.surf.domain.team.usecase.TeamUsecase;
 import com.tavemakers.surf.global.common.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -17,13 +17,13 @@ import static com.tavemakers.surf.domain.team.controller.ResponseMessage.TEAM_DE
 @Tag(name = "팀", description = "팀 관련 CRUD API")
 public class TeamDeleteController {
 
-    private  final TeamService teamService;
+    private final TeamUsecase teamUsecase;
 
     /** 팀 삭제*/
     @Operation(summary = "팀 삭제", description = "특정 ID의 팀을 삭제합니다.")
     @DeleteMapping("/v1/admin/teams/{teamId}")
     public ApiResponse<Void> deleteTeam(@PathVariable Long teamId) {
-        teamService.deleteTeam(teamId);
+        teamUsecase.deleteTeam(teamId);
         return ApiResponse.response(HttpStatus.NO_CONTENT, TEAM_DELETED.getMessage());
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/team/controller/TeamGetController.java
+++ b/src/main/java/com/tavemakers/surf/domain/team/controller/TeamGetController.java
@@ -3,7 +3,7 @@ package com.tavemakers.surf.domain.team.controller;
 import com.tavemakers.surf.domain.team.dto.response.TeamDetailResDTO;
 import com.tavemakers.surf.domain.team.dto.response.TeamGenerationSectionResDTO;
 import com.tavemakers.surf.domain.team.entity.TeamType;
-import com.tavemakers.surf.domain.team.service.TeamService;
+import com.tavemakers.surf.domain.team.usecase.TeamUsecase;
 import com.tavemakers.surf.global.common.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -21,7 +21,7 @@ import static com.tavemakers.surf.domain.team.controller.ResponseMessage.TEAM_RE
 @Tag(name = "팀", description = "팀 관련 CRUD API")
 public class TeamGetController {
 
-    private final TeamService teamService;
+    private final TeamUsecase teamUsecase;
 
     /** 팀 목록 조회 (파라미터 미입력 시 전체 조회, STUDY, PROJECT로 구분)*/
     @Operation(summary = "팀 목록 조회", description = "팀 목록을 기수별로 구분하여 조회합니다. type 파라미터로 스터디/프로젝트 분리 가능 (STUDY, PROJECT)")
@@ -29,7 +29,7 @@ public class TeamGetController {
     public ApiResponse<List<TeamGenerationSectionResDTO>> getTeams(
             @RequestParam(required = false) TeamType type
     ) {
-        List<TeamGenerationSectionResDTO> response = teamService.getTeams(type);
+        List<TeamGenerationSectionResDTO> response = teamUsecase.getTeams(type);
         return ApiResponse.response(HttpStatus.OK, TEAM_READ.getMessage(), response);
     }
 
@@ -37,7 +37,7 @@ public class TeamGetController {
     @Operation(summary = "팀 상세 조회", description = "팀의 상세 정보를 조회합니다.")
     @GetMapping("/v1/admin/teams/{teamId}")
     public ApiResponse<TeamDetailResDTO> getTeamDetail(@PathVariable Long teamId) {
-        TeamDetailResDTO response = teamService.getTeamDetail(teamId);
+        TeamDetailResDTO response = teamUsecase.getTeamDetail(teamId);
         return ApiResponse.response(HttpStatus.OK, TEAM_READ.getMessage(), response);
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/team/controller/TeamPutController.java
+++ b/src/main/java/com/tavemakers/surf/domain/team/controller/TeamPutController.java
@@ -2,7 +2,7 @@ package com.tavemakers.surf.domain.team.controller;
 
 import com.tavemakers.surf.domain.team.dto.request.TeamUpsertReqDTO;
 import com.tavemakers.surf.domain.team.dto.response.TeamResDTO;
-import com.tavemakers.surf.domain.team.service.TeamService;
+import com.tavemakers.surf.domain.team.usecase.TeamUsecase;
 import com.tavemakers.surf.global.common.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -20,7 +20,7 @@ import static com.tavemakers.surf.domain.team.controller.ResponseMessage.TEAM_UP
 @Tag(name = "팀", description = "팀 관련 CRUD API")
 public class TeamPutController {
 
-    private final TeamService teamService;
+    private final TeamUsecase teamUsecase;
 
     /** 팀 정보 수정 (팀장 memberId(leaderMemberId)는 팀원 memberId 리스트(memberIds) 내에 포함되어야 합니다.)*/
     @Operation(summary = "팀 수정", description = "기존 팀 정보를 새로운 정보로 완전히 대체합니다.")
@@ -29,7 +29,7 @@ public class TeamPutController {
             @PathVariable Long teamId,
             @Valid @RequestBody TeamUpsertReqDTO req
     ) {
-        TeamResDTO response = teamService.updateTeam(teamId, req);
+        TeamResDTO response = teamUsecase.updateTeam(teamId, req);
         return ApiResponse.response(HttpStatus.OK, TEAM_UPDATED.getMessage(), response);
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/team/service/TeamService.java
+++ b/src/main/java/com/tavemakers/surf/domain/team/service/TeamService.java
@@ -14,8 +14,8 @@ import com.tavemakers.surf.domain.team.repository.TeamRepository;
 import com.tavemakers.surf.domain.member.dto.response.TrackResDTO;
 import com.tavemakers.surf.domain.member.entity.Member;
 import com.tavemakers.surf.domain.member.entity.Track;
-import com.tavemakers.surf.domain.member.repository.MemberRepository;
-import com.tavemakers.surf.domain.member.repository.TrackRepository;
+import com.tavemakers.surf.domain.member.service.MemberGetService;
+import com.tavemakers.surf.domain.member.service.TrackGetService;
 import com.tavemakers.surf.domain.score.service.PersonalScoreCreateService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -29,8 +29,8 @@ import java.util.stream.Collectors;
 public class TeamService {
 
     private final TeamRepository teamRepository;
-    private final MemberRepository memberRepository;
-    private final TrackRepository trackRepository;
+    private final MemberGetService memberGetService;
+    private final TrackGetService trackGetService;
     private final PersonalScoreCreateService personalScoreCreateService;
 
     @Transactional(readOnly = true)
@@ -62,7 +62,7 @@ public class TeamService {
         List<Long> memberIds = memberIdSet.stream().toList();
 
         // 2) Track을 한 번에 조회 (N+1 방지)
-        Map<Long, List<Track>> trackMap = trackRepository.findAllByMemberIds(memberIds).stream()
+        Map<Long, List<Track>> trackMap = trackGetService.getTracksByMemberIds(memberIds).stream()
                 .collect(Collectors.groupingBy(t -> t.getMember().getId()));
 
         // 3) 팀장 DTO
@@ -173,7 +173,7 @@ public class TeamService {
         }
 
         // 3) 멤버 조회
-        List<Member> members = memberRepository.findAllById(distinctMemberIds);
+        List<Member> members = memberGetService.getMembersByIds(distinctMemberIds);
         if (members.size() != distinctMemberIds.size()) {
             throw new MemberNotFoundException();
         }

--- a/src/main/java/com/tavemakers/surf/domain/team/usecase/TeamUsecase.java
+++ b/src/main/java/com/tavemakers/surf/domain/team/usecase/TeamUsecase.java
@@ -1,0 +1,51 @@
+package com.tavemakers.surf.domain.team.usecase;
+
+import com.tavemakers.surf.domain.team.dto.request.TeamUpsertReqDTO;
+import com.tavemakers.surf.domain.team.dto.response.TeamDetailResDTO;
+import com.tavemakers.surf.domain.team.dto.response.TeamGenerationSectionResDTO;
+import com.tavemakers.surf.domain.team.dto.response.TeamResDTO;
+import com.tavemakers.surf.domain.team.entity.TeamType;
+import com.tavemakers.surf.domain.team.service.TeamService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/** 팀 Usecase */
+@Service
+@RequiredArgsConstructor
+public class TeamUsecase {
+
+    private final TeamService teamService;
+
+    /** 팀 목록 조회 */
+    @Transactional(readOnly = true)
+    public List<TeamGenerationSectionResDTO> getTeams(TeamType type) {
+        return teamService.getTeams(type);
+    }
+
+    /** 팀 상세 조회 */
+    @Transactional(readOnly = true)
+    public TeamDetailResDTO getTeamDetail(Long teamId) {
+        return teamService.getTeamDetail(teamId);
+    }
+
+    /** 팀 생성 */
+    @Transactional
+    public TeamResDTO createTeam(TeamUpsertReqDTO req) {
+        return teamService.createTeam(req);
+    }
+
+    /** 팀 수정 */
+    @Transactional
+    public TeamResDTO updateTeam(Long teamId, TeamUpsertReqDTO req) {
+        return teamService.updateTeam(teamId, req);
+    }
+
+    /** 팀 삭제 */
+    @Transactional
+    public void deleteTeam(Long teamId) {
+        teamService.deleteTeam(teamId);
+    }
+}


### PR DESCRIPTION
## 관련 이슈

Closes #283
Closes #284
Closes #285
Closes #286
Closes #287
Closes #288
Closes #289

---

## 변경 요약

Codex 전체 코드 분석 결과를 바탕으로 아키텍처 규칙 위반, N+1 쿼리, Usecase 계층 부재 문제를 일괄 수정했습니다.

---

## 세부 변경 내용

### 1. 타 도메인 Repository 직접 참조 제거 (#283)

| 파일 | 변경 내용 |
|------|-----------|
| `AuthRefreshController` | `MemberRepository` → `MemberGetService` |
| `NotificationEventListener` | `PostRepository` → `PostGetService` |
| `CommentMentionService` | `MemberRepository` → `MemberGetService` |
| `ActiveGenerationGetService` | `MemberRepository` → `MemberGetService` |
| `MemberBadgeAssignService/GetService` | `MemberRepository` → `MemberGetService` |
| `TeamService` | `MemberRepository`, `TrackRepository` → `MemberGetService`, `TrackGetService` |
| `CommentService` | `PostRepository` → 엔티티 dirty checking 방식으로 변경 |
| `ScrapService` | `PostRepository` → `PostGetService` (순환 의존성 주석 제거) |

`MemberGetService`에 위임 메서드 추가: `getMembersByIds`, `findMentionCandidates`, `getMembersByTrackGeneration`  
`TrackGetService`에 위임 메서드 추가: `getTracksByMemberIds`  
`PostGetService`에 위임 메서드 추가: `findVersionById`, `increaseScrapCount`, `decreaseScrapCount`

---

### 2. PostCreateService/PostPatchService 계층 역전 해결 (#284)

- `PostCreateUsecase` 신규 생성 — `PostCreateService` + `ReservationUsecase` 조합 책임
- `PostPatchUsecase` 신규 생성 — `PostPatchService` + `ReservationUsecase` 조합 책임
- `PostCreateController`, `PostPatchController` → 각 Usecase 경유로 교체
- `PostCreateService`, `PostPatchService`에서 `ReservationUsecase` 필드 제거

---

### 3. 댓글 목록 N+1 해결 (#285)

- `CommentMentionRepository`: `findAllByCommentIdIn` 배치 조회 쿼리 추가
- `CommentMentionService`: `getMentionsByCommentIds` 일괄 조회 메서드 추가
- `CommentService#getComments`: 루프 내 단건 조회 → 배치 조회 후 Map 분배

```
변경 전: 댓글 N개 → getMentions() N번 호출
변경 후: findAllByCommentIdIn() 1번 → Map으로 분배
```

---

### 4. ScrapRepository / MemberRepository fetch join 추가 (#286)

- `ScrapRepository#findPostsByMemberId`: `join fetch p.member`, `p.board`, `p.category` 추가
- `MemberRepository#findMembersByIds`: `left join fetch m.tracks` + `distinct` 추가 (ScoreRankingUsecase N+1 방지)

---

### 5. 공지 알림 발송 N+1 해결 (#287)

- `NotificationCreateService`: `createAndSendBulk` 추가 (`saveAll`로 bulk INSERT)
- `NotificationUsecase#notifyNoticePost`: N번 루프 → `createAndSendBulk` 단일 호출

---

### 6. Usecase 계층 신설 (#288)

| 도메인 | 신설 Usecase | 교체된 컨트롤러 수 |
|--------|-------------|------------------|
| comment | `CommentUsecase` | 3개 |
| scrap | `ScrapUsecase` | 3개 |
| team | `TeamUsecase` | 4개 |
| activity | `ActiveGenerationUsecase` | 2개 |
| board | `BoardUsecase` | 4개 |
| home | `HomeUsecase` | 7개 |
| feedback | `FeedbackUsecase` | 2개 |
| schedule | `ScheduleUsecase` 메서드 추가 | 1개 |

---

### 7. 기타 (#289)

- `ReservationUsecase#reservePost`: `@Transactional` 누락 수정
- `LetterCreateReqDTO`: `class + @Getter` → `record` 변환

---

## QA 테스트 결과

> 환경: 로컬 (`http://localhost:8080`) | 실행일: 2026-04-07

| 항목 | 값 |
|------|-----|
| **총 테스트** | 78개 |
| **성공 (PASS)** | 73개 |
| **실패 (FAIL)** | 5개 |
| **성공률** | **93%** |

### 도메인별 결과

| 도메인 | 결과 |
|--------|------|
| activityRecords | 2/2 ✅ |
| admin | 8/8 ✅ |
| auth | 4/4 ✅ |
| badges | 1/2 ⚠️ |
| boards | 5/5 ✅ |
| commentLikes | 2/4 ⚠️ |
| commentMentions | 1/1 ✅ |
| comments | 3/3 ✅ |
| feedback | 2/2 ✅ |
| home | 1/1 ✅ |
| homeAdmin | 7/7 ✅ |
| letters | 2/2 ✅ |
| members | 6/6 ✅ |
| notifications | 4/4 ✅ |
| postLikes | 2/3 ⚠️ |
| posts | 6/7 ⚠️ |
| s3 | 1/1 ✅ |
| schedules | 8/8 ✅ |
| scores | 1/1 ✅ |
| scraps | 3/3 ✅ |
| search | 4/4 ✅ |

### 실패 5건 원인

모두 Setup 단계에서 테스트 게시글 생성 실패로 인한 연쇄 실패 (로컬 DB에 데이터 없음). **로직 버그 아님.**

| 도메인 | 실패 항목 | 원인 |
|--------|-----------|------|
| badges | 마이페이지 활동 뱃지 조회 | memberId=1 배지 없음 |
| commentLikes | 댓글 좋아요 개수/여부 조회 | 테스트 댓글 없음 |
| postLikes | 게시글 좋아요 리스트 | 테스트 게시글 없음 |
| posts | 게시글 단건 조회 | 테스트 게시글 없음 |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 릴리스 노트

* **Refactor**
  * Usecase 계층 도입으로 컨트롤러와 서비스 간 책임 재구성 및 흐름 단순화
  * 요청 객체를 불변 record로 전환하여 안정성 향상

* **성능 개선**
  * 조회 쿼리에 Eager loading 적용 및 멘션·스크랩 등 일괄 조회 도입으로 DB 호출·지연 감소
  * 조회 경로 최적화로 페이징/집계 성능 향상

* **New Features**
  * 대량 알림 생성·전송 기능 추가

* **Chores / Tests**
  * QA 스크립트 자동화 및 결과 데이터 보강, 테스트 탐지/생성 로직 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->