### PR TITLE
[FEAT] 하위 게시판 카테고리 생성 API 구현

### DIFF
--- a/src/main/java/com/tavemakers/surf/domain/board/controller/BoardCategoryCreateController.java
+++ b/src/main/java/com/tavemakers/surf/domain/board/controller/BoardCategoryCreateController.java
@@ -11,7 +11,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
-import static com.tavemakers.surf.domain.board.controller.ResponseMessage.CATEGORY_CREATED;
+import static com.tavemakers.surf.domain.board.controller.ResponseMessage.BOARD_CATEGORY_CREATED;
 
 @RestController
 @RequiredArgsConstructor
@@ -22,13 +22,14 @@ public class BoardCategoryCreateController {
 
     private final BoardCategoryUsecase  boardCategoryUsecase;
 
+    /** 게시판 카테고리를 생성합니다. */
     @Operation(summary = "게시판 카테고리 생성", description = "특정 게시판에 하위 카테고리를 생성합니다.")
     @PostMapping("/v1/admin/boards/{boardId}/categories")
     public ApiResponse<BoardCategoryResDTO> createCategory(
             @PathVariable Long boardId,
             @Valid @RequestBody BoardCategoryCreateReqDTO req) {
         BoardCategoryResDTO response = boardCategoryUsecase.createCategory(boardId, req);
-        return ApiResponse.response(HttpStatus.CREATED, CATEGORY_CREATED.getMessage(), response);
+        return ApiResponse.response(HttpStatus.CREATED, BOARD_CATEGORY_CREATED.getMessage(), response);
     }
 
 }

--- a/src/main/java/com/tavemakers/surf/domain/board/controller/BoardCategoryCreateController.java
+++ b/src/main/java/com/tavemakers/surf/domain/board/controller/BoardCategoryCreateController.java
@@ -1,0 +1,34 @@
+package com.tavemakers.surf.domain.board.controller;
+
+import com.tavemakers.surf.domain.board.dto.request.BoardCategoryCreateReqDTO;
+import com.tavemakers.surf.domain.board.dto.response.BoardCategoryResDTO;
+import com.tavemakers.surf.domain.board.usecase.BoardCategoryUsecase;
+import com.tavemakers.surf.global.common.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import static com.tavemakers.surf.domain.board.controller.ResponseMessage.CATEGORY_CREATED;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping
+// 게시판 태그와 동일한 태그 사용
+@Tag(name = "게시판", description = "추후 MVP를 통해 디벨롭 될 예정")
+public class BoardCategoryCreateController {
+
+    private final BoardCategoryUsecase  boardCategoryUsecase;
+
+    @Operation(summary = "게시판 카테고리 생성", description = "특정 게시판에 하위 카테고리를 생성합니다.")
+    @PostMapping("/v1/admin/boards/{boardId}/categories")
+    public ApiResponse<BoardCategoryResDTO> createCategory(
+            @PathVariable Long boardId,
+            @Valid @RequestBody BoardCategoryCreateReqDTO req) {
+        BoardCategoryResDTO response = boardCategoryUsecase.createCategory(boardId, req);
+        return ApiResponse.response(HttpStatus.CREATED, CATEGORY_CREATED.getMessage(), response);
+    }
+
+}

--- a/src/main/java/com/tavemakers/surf/domain/board/controller/ResponseMessage.java
+++ b/src/main/java/com/tavemakers/surf/domain/board/controller/ResponseMessage.java
@@ -10,7 +10,9 @@ public enum ResponseMessage {
     BOARD_CREATED("[게시판]이 성공적으로 생성되었습니다."),
     BOARD_UPDATED("[게시판]이 성공적으로 수정되었습니다."),
     BOARD_DELETED("[게시판]이 성공적으로 삭제되었습니다."),
-    BOARD_READ("[게시판]이 성공적으로 조회되었습니다.");
+    BOARD_READ("[게시판]이 성공적으로 조회되었습니다."),
+
+    CATEGORY_CREATED("[카테고리]가 성공적으로 생성되었습니다.");
 
     private final String message;
 

--- a/src/main/java/com/tavemakers/surf/domain/board/controller/ResponseMessage.java
+++ b/src/main/java/com/tavemakers/surf/domain/board/controller/ResponseMessage.java
@@ -12,7 +12,7 @@ public enum ResponseMessage {
     BOARD_DELETED("[게시판]이 성공적으로 삭제되었습니다."),
     BOARD_READ("[게시판]이 성공적으로 조회되었습니다."),
 
-    CATEGORY_CREATED("[카테고리]가 성공적으로 생성되었습니다.");
+    BOARD_CATEGORY_CREATED("[게시판-카테고리]가 성공적으로 생성되었습니다.");
 
     private final String message;
 

--- a/src/main/java/com/tavemakers/surf/domain/board/dto/request/BoardCategoryCreateReqDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/board/dto/request/BoardCategoryCreateReqDTO.java
@@ -1,0 +1,15 @@
+package com.tavemakers.surf.domain.board.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(description = "게시판 카테고리 생성 요청 DTO")
+public record BoardCategoryCreateReqDTO(
+
+        @Schema(description = "카테고리 이름", example = "제휴")
+        @NotBlank String name,
+
+        @Schema(description = "URL용 식별 슬러그 (게시판 내 unique)", example = "partnership")
+        @NotBlank String slug
+) {
+}

--- a/src/main/java/com/tavemakers/surf/domain/board/dto/response/BoardCategoryResDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/board/dto/response/BoardCategoryResDTO.java
@@ -1,0 +1,25 @@
+package com.tavemakers.surf.domain.board.dto.response;
+
+import com.tavemakers.surf.domain.board.entity.BoardCategory;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "게시판 카테고리 응답 DTO")
+public record BoardCategoryResDTO(
+
+        @Schema(description = "카테고리 ID", example = "1")
+        Long id,
+
+        @Schema(description = "카테고리 이름", example = "제휴")
+        String name,
+
+        @Schema(description = "슬러그", example = "partnership")
+        String slug
+) {
+    public static BoardCategoryResDTO from(BoardCategory category) {
+        return new BoardCategoryResDTO(
+                category.getId(),
+                category.getName(),
+                category.getSlug()
+        );
+    }
+}

--- a/src/main/java/com/tavemakers/surf/domain/board/entity/BoardCategory.java
+++ b/src/main/java/com/tavemakers/surf/domain/board/entity/BoardCategory.java
@@ -1,5 +1,6 @@
 package com.tavemakers.surf.domain.board.entity;
 
+import com.tavemakers.surf.domain.board.dto.request.BoardCategoryCreateReqDTO;
 import com.tavemakers.surf.global.common.entity.BaseEntity;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
@@ -37,5 +38,13 @@ public class BoardCategory extends BaseEntity {
     public void update(String name, String slug) {
         if (name != null) this.name = name;
         if (slug != null) this.slug = slug;
+    }
+
+    public static BoardCategory of(Board board, BoardCategoryCreateReqDTO req) {
+        return BoardCategory.builder()
+                .board(board)
+                .name(req.name())
+                .slug(req.slug())
+                .build();
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/board/exception/BoardCategoryAlreadyExistsException.java
+++ b/src/main/java/com/tavemakers/surf/domain/board/exception/BoardCategoryAlreadyExistsException.java
@@ -1,0 +1,11 @@
+package com.tavemakers.surf.domain.board.exception;
+
+import com.tavemakers.surf.global.common.exception.BaseException;
+
+import static com.tavemakers.surf.domain.board.exception.ErrorMessage.BOARD_CATEGORY_ALREADY_EXISTS;
+
+public class BoardCategoryAlreadyExistsException extends BaseException {
+    public BoardCategoryAlreadyExistsException() {
+        super(BOARD_CATEGORY_ALREADY_EXISTS.getStatus(), BOARD_CATEGORY_ALREADY_EXISTS.getMessage());
+    }
+}

--- a/src/main/java/com/tavemakers/surf/domain/board/exception/ErrorMessage.java
+++ b/src/main/java/com/tavemakers/surf/domain/board/exception/ErrorMessage.java
@@ -13,6 +13,8 @@ public enum ErrorMessage {
 
     CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 [카테고리]입니다."),
 
+    BOARD_CATEGORY_ALREADY_EXISTS(HttpStatus.CONFLICT, "해당 [게시판]에 이미 존재하는 [슬러그]입니다."),
+
     INVALID_CATEGORY_MAPPING(HttpStatus.BAD_REQUEST, "유효하지 않은 [게시판]과 [카테고리] 조합입니다.");
 
     private final HttpStatus status;

--- a/src/main/java/com/tavemakers/surf/domain/board/repository/BoardCategoryRepository.java
+++ b/src/main/java/com/tavemakers/surf/domain/board/repository/BoardCategoryRepository.java
@@ -1,5 +1,6 @@
 package com.tavemakers.surf.domain.board.repository;
 
+import com.tavemakers.surf.domain.board.entity.Board;
 import com.tavemakers.surf.domain.board.entity.BoardCategory;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -13,4 +14,6 @@ public interface BoardCategoryRepository extends JpaRepository<BoardCategory, Lo
 
     // 보드 내 슬러그로 조회 (URL 접근용)
     Optional<BoardCategory> findByBoardIdAndSlug(Long boardId, String slug);
+
+    boolean existsByBoardAndSlug(Board board, String slug);
 }

--- a/src/main/java/com/tavemakers/surf/domain/board/service/BoardCategoryService.java
+++ b/src/main/java/com/tavemakers/surf/domain/board/service/BoardCategoryService.java
@@ -4,9 +4,11 @@ import com.tavemakers.surf.domain.board.dto.request.BoardCategoryCreateReqDTO;
 import com.tavemakers.surf.domain.board.dto.response.BoardCategoryResDTO;
 import com.tavemakers.surf.domain.board.entity.Board;
 import com.tavemakers.surf.domain.board.entity.BoardCategory;
+import com.tavemakers.surf.domain.board.exception.BoardCategoryAlreadyExistsException;
 import com.tavemakers.surf.domain.board.repository.BoardCategoryRepository;
 import com.tavemakers.surf.global.logging.LogEvent;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,8 +22,17 @@ public class BoardCategoryService {
     @Transactional
     @LogEvent(value = "board.category.create", message = "게시판 카테고리 생성 성공")
     public BoardCategoryResDTO createBoardCategory(Board board, BoardCategoryCreateReqDTO req) {
+        if (boardCategoryRepository.existsByBoardAndSlug(board, req.slug())) {
+            throw new BoardCategoryAlreadyExistsException();
+        }
+
         BoardCategory boardCategory = BoardCategory.of(board, req);
-        BoardCategory saved = boardCategoryRepository.save(boardCategory);
-        return BoardCategoryResDTO.from(saved);
+
+        try {
+            BoardCategory saved = boardCategoryRepository.saveAndFlush(boardCategory);
+            return BoardCategoryResDTO.from(saved);
+        } catch (DataIntegrityViolationException e) {
+            throw new BoardCategoryAlreadyExistsException();
+        }
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/board/service/BoardCategoryService.java
+++ b/src/main/java/com/tavemakers/surf/domain/board/service/BoardCategoryService.java
@@ -1,0 +1,27 @@
+package com.tavemakers.surf.domain.board.service;
+
+import com.tavemakers.surf.domain.board.dto.request.BoardCategoryCreateReqDTO;
+import com.tavemakers.surf.domain.board.dto.response.BoardCategoryResDTO;
+import com.tavemakers.surf.domain.board.entity.Board;
+import com.tavemakers.surf.domain.board.entity.BoardCategory;
+import com.tavemakers.surf.domain.board.repository.BoardCategoryRepository;
+import com.tavemakers.surf.global.logging.LogEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class BoardCategoryService {
+    private final BoardCategoryRepository boardCategoryRepository;
+
+    /** 새 게시판 카테고리 생성 */
+    @Transactional
+    @LogEvent(value = "board.category.create", message = "게시판 카테고리 생성 성공")
+    public BoardCategoryResDTO createBoardCategory(Board board, BoardCategoryCreateReqDTO req) {
+        BoardCategory boardCategory = BoardCategory.of(board, req);
+        BoardCategory saved = boardCategoryRepository.save(boardCategory);
+        return BoardCategoryResDTO.from(saved);
+    }
+}

--- a/src/main/java/com/tavemakers/surf/domain/board/usecase/BoardCategoryUsecase.java
+++ b/src/main/java/com/tavemakers/surf/domain/board/usecase/BoardCategoryUsecase.java
@@ -15,6 +15,7 @@ public class BoardCategoryUsecase {
     private final BoardGetService boardGetService;
     private final BoardCategoryService boardCategoryService;
 
+    /** 게시판 카테고리를 생성합니다. */
     @Transactional
     public BoardCategoryResDTO createCategory(Long boardId, BoardCategoryCreateReqDTO req) {
         Board board = boardGetService.getBoard(boardId);

--- a/src/main/java/com/tavemakers/surf/domain/board/usecase/BoardCategoryUsecase.java
+++ b/src/main/java/com/tavemakers/surf/domain/board/usecase/BoardCategoryUsecase.java
@@ -1,0 +1,23 @@
+package com.tavemakers.surf.domain.board.usecase;
+
+import com.tavemakers.surf.domain.board.dto.request.BoardCategoryCreateReqDTO;
+import com.tavemakers.surf.domain.board.dto.response.BoardCategoryResDTO;
+import com.tavemakers.surf.domain.board.entity.Board;
+import com.tavemakers.surf.domain.board.service.BoardGetService;
+import com.tavemakers.surf.domain.board.service.BoardCategoryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class BoardCategoryUsecase {
+    private final BoardGetService boardGetService;
+    private final BoardCategoryService boardCategoryService;
+
+    @Transactional
+    public BoardCategoryResDTO createCategory(Long boardId, BoardCategoryCreateReqDTO req) {
+        Board board = boardGetService.getBoard(boardId);
+        return boardCategoryService.createBoardCategory(board, req);
+    }
+}


### PR DESCRIPTION
## 📄 작업 내용 요약
기존에 SQL 마이그레이션으로 직접 DB에 삽입하던 게시판 카테고리(BoardCategory)를 관리자가 API를 통해 동적으로 생성할 수 있도록 기능을 추가합니다.
관리자가 특정 게시판(Board) 하위에 새로운 카테고리를 생성합니다.

> [노션] 게시판, 게시글 관련 2 기준: `Task2`입니다. 1은 admin권한 체크가 포함 되어있어 해당 PR 다음으로 분리 했어요
이후 Task 1, Task 3 순으로 진행 하겠습니다.

## 📎 Issue 번호
<!-- closed #번호 -->
closed #292 

## 실행 화면
`POST /v1/admin/boards/{boardId}/categories` 실행 화면
<img width="1916" height="1029" alt="POST /v1/admin/boards/{boardId}/categories 실행 화면" src="https://github.com/user-attachments/assets/d3d8c99d-ca3b-4109-af00-72a4ea5314e2" />

---

### 참고 사항

변경점 커밋: 4834032

기존  BoardUsecase 수정 > BoardCategoryUsecase 추가
사유: BoardUsecase가 충분히 Board 도메인의 종속되어 있다고 판단되어 분리하는 것이 유지 비용이 적을 것이라 판단했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 보드 카테고리 생성 기능이 추가되었습니다. 관리자는 보드에 이름과 슬러그를 지정하여 새 카테고리를 생성할 수 있으며, 생성 시 생성된 카테고리의 ID·이름·슬러그 정보가 응답으로 반환됩니다. 요청 유효성 검사가 적용됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### 추가 변경점

변경점 커밋: cd42652
카테고리 중복 409로 전달

<img width="695" height="442" alt="image" src="https://github.com/user-attachments/assets/32a4c46d-0208-485a-b9c2-c5c8de7d1adf" />
