### PR TITLE
[FEAT] 게시판 타입별 게시글 작성 권한 분리

### DIFF
--- a/src/main/java/com/tavemakers/surf/domain/board/entity/Board.java
+++ b/src/main/java/com/tavemakers/surf/domain/board/entity/Board.java
@@ -47,4 +47,8 @@ public class Board extends BaseEntity {
     public boolean isNotice() {
         return type == BoardType.NOTICE;
     }
+
+    public boolean isGeneral() {
+        return type == BoardType.GENERAL;
+    }
 }

--- a/src/main/java/com/tavemakers/surf/domain/board/entity/BoardType.java
+++ b/src/main/java/com/tavemakers/surf/domain/board/entity/BoardType.java
@@ -1,5 +1,6 @@
 package com.tavemakers.surf.domain.board.entity;
 
 public enum BoardType {
-    NOTICE,   // 공지사항
+    NOTICE,   // 공지사항 - 관리자만 게시글 작성 가능
+    GENERAL,  // 일반 게시판 - 일반 회원도 게시글 작성 가능
 }

--- a/src/main/java/com/tavemakers/surf/domain/post/exception/BoardWriteNotAllowedException.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/exception/BoardWriteNotAllowedException.java
@@ -5,6 +5,7 @@ import com.tavemakers.surf.global.common.exception.BaseException;
 import static com.tavemakers.surf.domain.post.exception.ErrorMessage.BOARD_WRITE_NOT_ALLOWED;
 
 public class BoardWriteNotAllowedException extends BaseException {
+    /** 공지사항 게시글 작성 권한이 없을 때 발생하는 예외 */
     public BoardWriteNotAllowedException() {
         super(BOARD_WRITE_NOT_ALLOWED.getStatus(), BOARD_WRITE_NOT_ALLOWED.getMessage());
     }

--- a/src/main/java/com/tavemakers/surf/domain/post/exception/BoardWriteNotAllowedException.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/exception/BoardWriteNotAllowedException.java
@@ -1,0 +1,11 @@
+package com.tavemakers.surf.domain.post.exception;
+
+import com.tavemakers.surf.global.common.exception.BaseException;
+
+import static com.tavemakers.surf.domain.post.exception.ErrorMessage.BOARD_WRITE_NOT_ALLOWED;
+
+public class BoardWriteNotAllowedException extends BaseException {
+    public BoardWriteNotAllowedException() {
+        super(BOARD_WRITE_NOT_ALLOWED.getStatus(), BOARD_WRITE_NOT_ALLOWED.getMessage());
+    }
+}

--- a/src/main/java/com/tavemakers/surf/domain/post/exception/ErrorMessage.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/exception/ErrorMessage.java
@@ -11,8 +11,9 @@ public enum ErrorMessage {
     POST_ALREADY_DELETED(HttpStatus.NOT_FOUND, "이미 삭제된 [게시글]입니다."),
 
     POST_IMAGE_EMPTY(HttpStatus.NOT_FOUND, "[이미지 목록]이 비어있습니다."),
-    POST_DELETED_DENIED(HttpStatus.UNAUTHORIZED, "[게시글]을 삭제할 권한이 없습니다.")
-    ;
+    POST_DELETED_DENIED(HttpStatus.UNAUTHORIZED, "[게시글]을 삭제할 권한이 없습니다."),
+
+    BOARD_WRITE_NOT_ALLOWED(HttpStatus.FORBIDDEN, "[공지사항] 게시판은 관리자만 게시글을 작성할 수 있습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/tavemakers/surf/domain/post/service/post/PostCreateService.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/service/post/PostCreateService.java
@@ -13,6 +13,7 @@ import com.tavemakers.surf.domain.post.dto.request.PostImageCreateReqDTO;
 import com.tavemakers.surf.domain.post.dto.response.PostDetailResDTO;
 import com.tavemakers.surf.domain.post.dto.response.PostImageResDTO;
 import com.tavemakers.surf.domain.post.entity.Post;
+import com.tavemakers.surf.domain.post.exception.BoardWriteNotAllowedException;
 import com.tavemakers.surf.domain.post.exception.PostImageListEmptyException;
 import com.tavemakers.surf.domain.post.repository.PostRepository;
 import com.tavemakers.surf.domain.post.service.image.PostImageCreateService;
@@ -47,6 +48,13 @@ public class PostCreateService {
     public PostDetailResDTO createPost(PostCreateReqDTO req, Long memberId) {
         Board board = boardGetService.getBoard(req.boardId());
         Member member = memberGetService.getMember(memberId);
+
+        // BoardType.NOTICE인 경우 관리자인지 검증
+        if(board.isNotice()){
+            if(!member.hasDeleteRole()){
+                throw new BoardWriteNotAllowedException();
+            }
+        }
 
         BoardCategory category = resolveCategory(board, req.categoryId());
 

--- a/src/main/java/com/tavemakers/surf/domain/post/service/post/PostCreateService.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/service/post/PostCreateService.java
@@ -28,7 +28,9 @@ import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.List;
 
-/** 게시글 생성 관련 서비스 */
+/**
+ * 게시글 생성 관련 서비스
+ */
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -42,23 +44,21 @@ public class PostCreateService {
     private final PostImageCreateService imageCreateService;
     private final ApplicationEventPublisher eventPublisher;
 
-    /** 게시글 생성 및 저장 (예약 처리는 Usecase에서 담당) */
+    /**
+     * 게시글 생성 및 저장 (예약 처리는 Usecase에서 담당)
+     */
     @Transactional
     @LogEvent(value = "post.create", message = "게시글 생성 성공")
     public PostDetailResDTO createPost(PostCreateReqDTO req, Long memberId) {
         Board board = boardGetService.getBoard(req.boardId());
-        Member member = memberGetService.getMember(memberId);
+        Member writer = memberGetService.getMember(memberId);
 
         // BoardType.NOTICE인 경우 관리자인지 검증
-        if(board.isNotice()){
-            if(!member.hasDeleteRole()){
-                throw new BoardWriteNotAllowedException();
-            }
-        }
+        validateWritePermission(board, writer);
 
         BoardCategory category = resolveCategory(board, req.categoryId());
 
-        Post post = Post.of(req, board, category, member);
+        Post post = Post.of(req, board, category, writer);
         Post saved = postRepository.save(post);
 
         if (!req.isReserved()) {
@@ -76,7 +76,9 @@ public class PostCreateService {
         return PostDetailResDTO.of(saved, false, false, true, imageUrlResponseList, reservedAt, 0);
     }
 
-    /** 이미지 목록에서 첫 번째 이미지 URL 추출 */
+    /**
+     * 이미지 목록에서 첫 번째 이미지 URL 추출
+     */
     private String findFirstImage(List<PostImageCreateReqDTO> dto) {
         if (dto == null || dto.isEmpty()) {
             throw new PostImageListEmptyException();
@@ -88,7 +90,9 @@ public class PostCreateService {
         return postImageCreateReqDTO.originalUrl();
     }
 
-    /** 카테고리 유효성 검증 및 조회 */
+    /**
+     * 카테고리 유효성 검증 및 조회
+     */
     private BoardCategory resolveCategory(Board board, Long categoryId) {
         if (categoryId == null) {
             throw new CategoryRequiredException();
@@ -98,5 +102,11 @@ public class PostCreateService {
             throw new InvalidCategoryMappingException();
         }
         return category;
+    }
+
+    private void validateWritePermission(Board board, Member writer) {
+        if (board.isNotice() && !writer.hasDeleteRole()) {
+            throw new BoardWriteNotAllowedException();
+        }
     }
 }


### PR DESCRIPTION
## 📄 작업 내용 요약
기존: 게시판 타입이 NOTICE만 존재하며 해당 게시판의 게시글 작성은 관리자만 가능합니다.
추가: 게시판 타입 GENERAL을 추가하고 /v1/user/posts에서는 NOTICE작성을 방지합니다.


## 📎 Issue 번호
<!-- closed #번호 -->
closed #294 

## DB Schema 수동 업데이트 주의사항
이번 PR에서 `BoardType`에 `GENERAL` 상수가 추가됨에 따라, 배포 후 DB 컬럼 수정이 반드시 필요합니다.

1. 배경 및 원인
- 현재 개발/운영 서버의 `board.type` 컬럼은 `enum('NOTICE')`로 정의되어 있습니다.
- 현재 설정된 ddl-auto: update 전략은 새로운 컬럼 추가는 지원하지만, 기존 ENUM 타입의 정의 수정은 지원하지 않습니다.
- 수정 없이 배포 시 `GENERAL` 타입 저장 시 `GenericJDBCException`이 발생합니다.

2. 조치사항 (SQL)
배포 직후, 아래 쿼리를 실행하여 ENUM 정의를 업데이트해야 합니다.
```SQL
-- 기존 NOTICE 데이터를 유지하면서 GENERAL 타입을 추가합니다.
ALTER TABLE board 
MODIFY COLUMN type ENUM('NOTICE', 'GENERAL') NOT NULL;

 # 수정 후 확인
 DESC board;
```

### 실행 화면
`POST /v1/admin/boards` 관리자 GENERAL타입 게시판 추가
<img width="1465" height="734" alt="GENERAL타입 게시판 추가" src="https://github.com/user-attachments/assets/29740254-f04c-4c1b-b9bf-3476f7216be4" />

`POST /v1/user/posts` 일반 사용자 일반적인 게시글 작성
<img width="1475" height="747" alt="일반 유저 일반 게시글 시도" src="https://github.com/user-attachments/assets/a1b381bd-4a3b-4a70-9509-97c5f18cea8b" />

`POST /v1/user/posts` 일반 사용자 공지사항 게시글 작성
<img width="1567" height="738" alt="일반 유저 공지사항 게시글 시도" src="https://github.com/user-attachments/assets/f05cc32b-5f1a-465d-9f4a-50ec1a827303" />

`POST /v1/user/posts` 관리자 공지사항 게시글 작성
<img width="1484" height="711" alt="관리자 공지글 시도" src="https://github.com/user-attachments/assets/f4ab4173-aefe-49ed-b301-6084a630b130" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * 일반 게시판 타입이 추가되었습니다.

* **개선 사항**
  * 공지사항 게시글 작성에 권한 검증이 도입되어, 이제 관리자만 공지사항을 작성할 수 있습니다.
  * 권한 거부 시의 오류 응답이 명확한 메시지/상태로 표준화되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->