### PR TITLE
[FEAT] 게시판 일반 문서 첨부 기능 추가

### DIFF
--- a/src/main/java/com/tavemakers/surf/domain/post/dto/request/PostCreateReqDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/dto/request/PostCreateReqDTO.java
@@ -35,6 +35,9 @@ public record PostCreateReqDTO(
         @Schema(description = "게시글 이미지 목록")
         List<PostImageCreateReqDTO> imageUrlList,
 
+        @Schema(description = "게시글 첨부파일 목록")
+        List<PostFileCreateReqDTO> fileList,
+
         @Schema(description = "일정 매핑 유무", example = "true")
         Boolean hasSchedule
 
@@ -54,6 +57,10 @@ public record PostCreateReqDTO(
 
         public boolean hasImage() {
                 return imageUrlList != null && !imageUrlList.isEmpty();
+        }
+
+        public boolean hasFile() {
+                return fileList != null && !fileList.isEmpty();
         }
 
 }

--- a/src/main/java/com/tavemakers/surf/domain/post/dto/request/PostFileCreateReqDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/dto/request/PostFileCreateReqDTO.java
@@ -1,0 +1,21 @@
+package com.tavemakers.surf.domain.post.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record PostFileCreateReqDTO(
+
+        @Schema(description = "파일 S3 URL", example = "https://bucket.s3.ap-northeast-2.amazonaws.com/files/doc.pdf")
+        @NotBlank
+        String fileUrl,
+
+        @Schema(description = "원본 파일명", example = "2025_발표자료.pdf")
+        @NotBlank
+        String originalFileName,
+
+        @Schema(description = "파일 게시 순서", example = "1")
+        @NotNull
+        Integer sequence
+) {
+}

--- a/src/main/java/com/tavemakers/surf/domain/post/dto/request/PostUpdateReqDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/dto/request/PostUpdateReqDTO.java
@@ -39,6 +39,12 @@ public record PostUpdateReqDTO(
         @Schema(description = "게시글 이미지")
         List<PostImageCreateReqDTO> imageUrlList,
 
+        @Schema(description = "파일 변경 여부", example = "true")
+        Boolean isFileChanged,
+
+        @Schema(description = "게시글 첨부파일")
+        List<PostFileCreateReqDTO> fileList,
+
         @Schema(description = "일정 매핑 유무", example = "true")
         Boolean hasSchedule
 
@@ -60,6 +66,10 @@ public record PostUpdateReqDTO(
 
         public Boolean isImageChanged() {
                 return isImageChanged;
+        }
+
+        public Boolean isFileChanged() {
+                return isFileChanged;
         }
 
         public Boolean isReservationChanged() {

--- a/src/main/java/com/tavemakers/surf/domain/post/dto/request/PostUpdateReqDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/dto/request/PostUpdateReqDTO.java
@@ -64,16 +64,4 @@ public record PostUpdateReqDTO(
                 );
         }
 
-        public Boolean isImageChanged() {
-                return isImageChanged;
-        }
-
-        public Boolean isFileChanged() {
-                return isFileChanged;
-        }
-
-        public Boolean isReservationChanged() {
-                return isReservationChanged;
-        }
-
 }

--- a/src/main/java/com/tavemakers/surf/domain/post/dto/response/PostDetailResDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/dto/response/PostDetailResDTO.java
@@ -62,6 +62,9 @@ public record PostDetailResDTO(
         @Schema(description = "게시글 이미지 링크")
         List<PostImageResDTO> imageUrlList,
 
+        @Schema(description = "게시글 첨부파일 목록")
+        List<PostFileResDTO> fileList,
+
         @Schema(description = "예약된 게시글 여부", example = "true")
         boolean isReserved,
 
@@ -83,6 +86,7 @@ public record PostDetailResDTO(
             boolean likedByMe,
             boolean isMine,
             List<PostImageResDTO> imageUrlList,
+            List<PostFileResDTO> fileList,
             LocalDateTime reservedAt,
             int viewCount
     ){
@@ -106,6 +110,7 @@ public record PostDetailResDTO(
                     .profileImageUrl(writer.getProfileImageUrl())
                     .isMine(isMine)
                     .imageUrlList(imageUrlList)
+                    .fileList(fileList)
                     .isReserved(post.isReserved())
                     .reservedAt(reservedAt)
                     .viewCount(viewCount)

--- a/src/main/java/com/tavemakers/surf/domain/post/dto/response/PostFileResDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/dto/response/PostFileResDTO.java
@@ -16,9 +16,6 @@ public record PostFileResDTO(
         @Schema(description = "원본 파일명")
         String originalFileName,
 
-        @Schema(description = "게시물 ID")
-        Long postId,
-
         @Schema(description = "파일 순서")
         Integer sequence
 ) {
@@ -27,7 +24,6 @@ public record PostFileResDTO(
                 .fileId(fileURL.getId())
                 .fileUrl(fileURL.getFileUrl())
                 .originalFileName(fileURL.getOriginalFileName())
-                .postId(fileURL.getPost().getId())
                 .sequence(fileURL.getSequence())
                 .build();
     }

--- a/src/main/java/com/tavemakers/surf/domain/post/dto/response/PostFileResDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/dto/response/PostFileResDTO.java
@@ -1,0 +1,34 @@
+package com.tavemakers.surf.domain.post.dto.response;
+
+import com.tavemakers.surf.domain.post.entity.PostFileUrl;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+public record PostFileResDTO(
+
+        @Schema(description = "파일 ID")
+        Long fileId,
+
+        @Schema(description = "파일 S3 URL")
+        String fileUrl,
+
+        @Schema(description = "원본 파일명")
+        String originalFileName,
+
+        @Schema(description = "게시물 ID")
+        Long postId,
+
+        @Schema(description = "파일 순서")
+        Integer sequence
+) {
+    public static PostFileResDTO from(PostFileUrl fileURL){
+        return PostFileResDTO.builder()
+                .fileId(fileURL.getId())
+                .fileUrl(fileURL.getFileUrl())
+                .originalFileName(fileURL.getOriginalFileName())
+                .postId(fileURL.getPost().getId())
+                .sequence(fileURL.getSequence())
+                .build();
+    }
+}

--- a/src/main/java/com/tavemakers/surf/domain/post/dto/response/PostImageResDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/dto/response/PostImageResDTO.java
@@ -7,14 +7,12 @@ import lombok.Builder;
 public record PostImageResDTO(
         Long imageId,
         String originalUrl,
-        Long postId,
         Integer sequence
 ) {
     public static PostImageResDTO from(PostImageUrl postImageUrl) {
         return PostImageResDTO.builder()
                 .imageId(postImageUrl.getId())
                 .originalUrl(postImageUrl.getOriginalUrl())
-                .postId(postImageUrl.getPost().getId())
                 .sequence(postImageUrl.getSequence())
                 .build();
     }

--- a/src/main/java/com/tavemakers/surf/domain/post/entity/PostFileUrl.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/entity/PostFileUrl.java
@@ -1,0 +1,42 @@
+package com.tavemakers.surf.domain.post.entity;
+
+import com.tavemakers.surf.domain.post.dto.request.PostFileCreateReqDTO;
+import com.tavemakers.surf.global.common.entity.BaseEntity;
+import io.hypersistence.utils.hibernate.id.Tsid;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Entity
+@Getter
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PostFileUrl extends BaseEntity {
+
+    @Id @Tsid
+    @Column(name = "post_file_url_id")
+    private Long id;
+
+    @Column(nullable = false, length = 500)
+    private String fileUrl;
+
+    @Column(nullable = false, length = 255)
+    private String originalFileName;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", nullable = false)
+    private Post post;
+
+    private Integer sequence;
+
+    public static PostFileUrl of(Post post, PostFileCreateReqDTO dto) {
+        return PostFileUrl.builder()
+                .post(post)
+                .fileUrl(dto.fileUrl())
+                .originalFileName(dto.originalFileName())
+                .sequence(dto.sequence())
+                .build();
+    }
+}

--- a/src/main/java/com/tavemakers/surf/domain/post/entity/PostFileUrl.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/entity/PostFileUrl.java
@@ -29,6 +29,7 @@ public class PostFileUrl extends BaseEntity {
     @JoinColumn(name = "post_id", nullable = false)
     private Post post;
 
+    @Column(nullable = false)
     private Integer sequence;
 
     public static PostFileUrl of(Post post, PostFileCreateReqDTO dto) {

--- a/src/main/java/com/tavemakers/surf/domain/post/entity/PostImageUrl.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/entity/PostImageUrl.java
@@ -31,6 +31,7 @@ public class PostImageUrl extends BaseEntity {
     @JoinColumn(name = "post_id", nullable = false)
     private Post post;
 
+    @Column(nullable = false)
     private Integer sequence;
 
     public static PostImageUrl of(Post post, PostImageCreateReqDTO dto) {

--- a/src/main/java/com/tavemakers/surf/domain/post/repository/PostFileUrlRepository.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/repository/PostFileUrlRepository.java
@@ -1,0 +1,10 @@
+package com.tavemakers.surf.domain.post.repository;
+
+import com.tavemakers.surf.domain.post.entity.PostFileUrl;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface PostFileUrlRepository extends JpaRepository<PostFileUrl, Long> {
+    List<PostFileUrl> findByPostId(Long postId);
+}

--- a/src/main/java/com/tavemakers/surf/domain/post/service/file/PostFileCreateService.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/service/file/PostFileCreateService.java
@@ -15,7 +15,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class PostFileCreateService {
 
-    private final PostFileUrlRepository repository;
+    private final PostFileUrlRepository postFileUrlRepository;
 
     /** 게시글 첨부파일 일괄 저장 */
     @Transactional
@@ -27,7 +27,7 @@ public class PostFileCreateService {
         List<PostFileUrl> filesUrlList = dto.stream()
                 .map(f -> PostFileUrl.of(post, f))
                 .toList();
-        return repository.saveAll(filesUrlList).stream()
+        return postFileUrlRepository.saveAll(filesUrlList).stream()
                 .map(PostFileResDTO::from)
                 .toList();
     }

--- a/src/main/java/com/tavemakers/surf/domain/post/service/file/PostFileCreateService.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/service/file/PostFileCreateService.java
@@ -1,0 +1,34 @@
+package com.tavemakers.surf.domain.post.service.file;
+
+import com.tavemakers.surf.domain.post.dto.request.PostFileCreateReqDTO;
+import com.tavemakers.surf.domain.post.dto.response.PostFileResDTO;
+import com.tavemakers.surf.domain.post.entity.Post;
+import com.tavemakers.surf.domain.post.entity.PostFileUrl;
+import com.tavemakers.surf.domain.post.repository.PostFileUrlRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class PostFileCreateService {
+
+    private final PostFileUrlRepository repository;
+
+    /** 게시글 첨부파일 일괄 저장 */
+    @Transactional
+    public List<PostFileResDTO> saveAll(Post post, List<PostFileCreateReqDTO> dto) {
+        if (dto == null || dto.isEmpty()) {
+            return List.of();
+        }
+
+        List<PostFileUrl> filesUrlList = dto.stream()
+                .map(f -> PostFileUrl.of(post, f))
+                .toList();
+        return repository.saveAll(filesUrlList).stream()
+                .map(PostFileResDTO::from)
+                .toList();
+    }
+}

--- a/src/main/java/com/tavemakers/surf/domain/post/service/file/PostFileDeleteService.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/service/file/PostFileDeleteService.java
@@ -1,0 +1,25 @@
+package com.tavemakers.surf.domain.post.service.file;
+
+import com.tavemakers.surf.domain.post.entity.PostFileUrl;
+import com.tavemakers.surf.domain.post.repository.PostFileUrlRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class PostFileDeleteService {
+
+    private final PostFileUrlRepository repository;
+
+    /** 게시글 첨부파일 일괄 삭제 */
+    @Transactional
+    public void deleteAll(List<PostFileUrl> beforeFiles) {
+        if (beforeFiles == null || beforeFiles.isEmpty()) {
+            return;
+        }
+        repository.deleteAllInBatch(beforeFiles);
+    }
+}

--- a/src/main/java/com/tavemakers/surf/domain/post/service/file/PostFileGetService.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/service/file/PostFileGetService.java
@@ -1,0 +1,20 @@
+package com.tavemakers.surf.domain.post.service.file;
+
+import com.tavemakers.surf.domain.post.entity.PostFileUrl;
+import com.tavemakers.surf.domain.post.repository.PostFileUrlRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class PostFileGetService {
+
+    private final PostFileUrlRepository repository;
+
+    /** 게시글 파일 URL 목록 조회 */
+    public List<PostFileUrl> getPostFileUrls(Long postId) {
+        return repository.findByPostId(postId);
+    }
+}

--- a/src/main/java/com/tavemakers/surf/domain/post/service/file/PostFileGetService.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/service/file/PostFileGetService.java
@@ -6,15 +6,17 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class PostFileGetService {
 
-    private final PostFileUrlRepository repository;
+    private final PostFileUrlRepository postFileUrlRepository;
 
     /** 게시글 파일 URL 목록 조회 */
+    @Transactional(readOnly = true)
     public List<PostFileUrl> getPostFileUrls(Long postId) {
-        return repository.findByPostId(postId);
+        return postFileUrlRepository.findByPostId(postId);
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/post/service/image/PostImageCreateService.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/service/image/PostImageCreateService.java
@@ -16,7 +16,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class PostImageCreateService {
 
-    private final PostImageUrlRepository repository;
+    private final PostImageUrlRepository postImageUrlRepository;
 
     /** 게시글 이미지 일괄 저장 */
     @Transactional
@@ -28,7 +28,7 @@ public class PostImageCreateService {
         List<PostImageUrl> imageUrlList = dto.stream()
                 .map(url -> PostImageUrl.of(post, url))
                 .toList();
-        return repository.saveAll(imageUrlList)
+        return postImageUrlRepository.saveAll(imageUrlList)
                 .stream()
                 .map(PostImageResDTO::from)
                 .sorted(Comparator.comparing(PostImageResDTO::sequence))

--- a/src/main/java/com/tavemakers/surf/domain/post/service/image/PostImageGetService.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/service/image/PostImageGetService.java
@@ -6,16 +6,18 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class PostImageGetService {
 
-    private final PostImageUrlRepository repository;
+    private final PostImageUrlRepository postImageUrlRepository;
 
     /** 게시글 이미지 URL 목록 조회 */
+    @Transactional(readOnly = true)
     public List<PostImageUrl> getPostImageUrls(Long postId) {
-        return repository.findByPostId(postId);
+        return postImageUrlRepository.findByPostId(postId);
     }
 
 }

--- a/src/main/java/com/tavemakers/surf/domain/post/service/post/PostCreateService.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/service/post/PostCreateService.java
@@ -11,10 +11,12 @@ import com.tavemakers.surf.domain.member.service.MemberGetService;
 import com.tavemakers.surf.domain.post.dto.request.PostCreateReqDTO;
 import com.tavemakers.surf.domain.post.dto.request.PostImageCreateReqDTO;
 import com.tavemakers.surf.domain.post.dto.response.PostDetailResDTO;
+import com.tavemakers.surf.domain.post.dto.response.PostFileResDTO;
 import com.tavemakers.surf.domain.post.dto.response.PostImageResDTO;
 import com.tavemakers.surf.domain.post.entity.Post;
 import com.tavemakers.surf.domain.post.exception.PostImageListEmptyException;
 import com.tavemakers.surf.domain.post.repository.PostRepository;
+import com.tavemakers.surf.domain.post.service.file.PostFileCreateService;
 import com.tavemakers.surf.domain.post.service.image.PostImageCreateService;
 import com.tavemakers.surf.domain.post.service.support.PostPublishedEvent;
 import com.tavemakers.surf.global.logging.LogEvent;
@@ -39,6 +41,7 @@ public class PostCreateService {
     private final BoardCategoryGetService boardCategoryGetService;
     private final MemberGetService memberGetService;
     private final PostImageCreateService imageCreateService;
+    private final PostFileCreateService fileCreateService;
     private final ApplicationEventPublisher eventPublisher;
 
     /** 게시글 생성 및 저장 (예약 처리는 Usecase에서 담당) */
@@ -64,8 +67,13 @@ public class PostCreateService {
             imageUrlResponseList = imageCreateService.saveAll(saved, imageUrlList);
         }
 
+        List<PostFileResDTO> fileResponseList = null;
+        if (req.hasFile()) {
+            fileResponseList = fileCreateService.saveAll(saved, req.fileList());
+        }
+
         LocalDateTime reservedAt = req.isReserved() ? req.reservedAt() : null;
-        return PostDetailResDTO.of(saved, false, false, true, imageUrlResponseList, reservedAt, 0);
+        return PostDetailResDTO.of(saved, false, false, true, imageUrlResponseList, fileResponseList, reservedAt, 0);
     }
 
     /** 이미지 목록에서 첫 번째 이미지 URL 추출 */

--- a/src/main/java/com/tavemakers/surf/domain/post/service/post/PostGetService.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/service/post/PostGetService.java
@@ -115,7 +115,7 @@ public class PostGetService {
                 .orElseThrow(PostNotFoundException::new);
     }
 
-    private List<PostImageResDTO> getImageUrlList(Post post) {
+    public List<PostImageResDTO> getImageUrlList(Post post) {
         return imageGetService.getPostImageUrls(post.getId()).stream()
                 .map(PostImageResDTO::from)
                 .sorted(Comparator.comparing(PostImageResDTO::sequence))

--- a/src/main/java/com/tavemakers/surf/domain/post/service/post/PostGetService.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/service/post/PostGetService.java
@@ -1,10 +1,12 @@
 package com.tavemakers.surf.domain.post.service.post;
 
 import com.tavemakers.surf.domain.post.dto.response.PostDetailResDTO;
+import com.tavemakers.surf.domain.post.dto.response.PostFileResDTO;
 import com.tavemakers.surf.domain.post.dto.response.PostImageResDTO;
 import com.tavemakers.surf.domain.post.entity.Post;
 import com.tavemakers.surf.domain.post.exception.PostNotFoundException;
 import com.tavemakers.surf.domain.post.repository.PostRepository;
+import com.tavemakers.surf.domain.post.service.file.PostFileGetService;
 import com.tavemakers.surf.domain.post.service.image.PostImageGetService;
 import com.tavemakers.surf.domain.post.service.like.PostLikeService;
 import com.tavemakers.surf.domain.post.service.support.ViewCountService;
@@ -30,6 +32,7 @@ public class PostGetService {
     private final ScrapGetService scrapGetService;
     private final PostLikeService postLikeService;
     private final PostImageGetService imageGetService;
+    private final PostFileGetService fileGetService;
     private final ViewCountService viewCountService;
     private final ReservationGetService reservationGetService;
 
@@ -69,6 +72,7 @@ public class PostGetService {
         boolean likedByMe = postLikeService.isLikedByMe(memberId, postId);
         boolean isMine = post.isOwner(memberId);
         List<PostImageResDTO> imageUrlList = getImageUrlList(post);
+        List<PostFileResDTO> fileUrlList = getPostFileList(post);
         int viewCount = viewCountService.increaseViewCount(post, memberId);
         LocalDateTime reservedAt = null;
         if (post.isReserved()) {
@@ -81,7 +85,7 @@ public class PostGetService {
             }
         }
 
-        return PostDetailResDTO.of(post, scrappedByMe, likedByMe, isMine, imageUrlList, reservedAt, viewCount);
+        return PostDetailResDTO.of(post, scrappedByMe, likedByMe, isMine, imageUrlList, fileUrlList, reservedAt, viewCount);
     }
 
     /** 게시글 버전 조회 (낙관적 락용) */
@@ -115,6 +119,13 @@ public class PostGetService {
         return imageGetService.getPostImageUrls(post.getId()).stream()
                 .map(PostImageResDTO::from)
                 .sorted(Comparator.comparing(PostImageResDTO::sequence))
+                .toList();
+    }
+
+    public List<PostFileResDTO> getPostFileList(Post post) {
+        return fileGetService.getPostFileUrls(post.getId()).stream()
+                .map(PostFileResDTO::from)
+                .sorted(Comparator.comparing(PostFileResDTO::sequence))
                 .toList();
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/post/service/post/PostPatchService.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/service/post/PostPatchService.java
@@ -53,6 +53,7 @@ public class PostPatchService {
 
     private final BoardCategoryGetService boardCategoryGetService;
     private final ScrapGetService scrapGetService;
+    private final PostGetService postGetService;
     private final PostLikeService postLikeService;
     private final ReservationGetService reservationGetService;
     private final PostImageCreateService imageCreateService;
@@ -107,7 +108,7 @@ public class PostPatchService {
                 imageDtoList = imageCreateService.saveAll(post, changeImages);
             }
         } else {
-            imageDtoList = getImageUrlList(post);
+            imageDtoList = postGetService.getImageUrlList(post);
         }
 
         // 파일 변경
@@ -121,7 +122,7 @@ public class PostPatchService {
                 fileDtoList = fileCreateService.saveAll(post, changeFiles);
             }
         } else {
-            fileDtoList = getPostFileList(post);
+            fileDtoList = postGetService.getPostFileList(post);
         }
 
         return PostDetailResDTO.of(post, scrappedByMe, likedByMe, true, imageDtoList, fileDtoList, reservedAt, viewCount);
@@ -149,22 +150,6 @@ public class PostPatchService {
             throw new InvalidCategoryMappingException();
         }
         return category;
-    }
-
-    /** 이미지 URL 목록 조회 */
-    private List<PostImageResDTO> getImageUrlList(Post post) {
-        return imageGetService.getPostImageUrls(post.getId()).stream()
-                .map(PostImageResDTO::from)
-                .sorted(Comparator.comparing(PostImageResDTO::sequence))
-                .toList();
-    }
-
-    /** 첨부파일 목록 조회 */
-    private List<PostFileResDTO> getPostFileList(Post post) {
-        return fileGetService.getPostFileUrls(post.getId()).stream()
-                .map(PostFileResDTO::from)
-                .sorted(Comparator.comparing(PostFileResDTO::sequence))
-                .toList();
     }
 
     /** 이미지 목록에서 첫 번째 이미지 URL 추출 */

--- a/src/main/java/com/tavemakers/surf/domain/post/service/post/PostPatchService.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/service/post/PostPatchService.java
@@ -7,16 +7,22 @@ import com.tavemakers.surf.domain.board.exception.InvalidCategoryMappingExceptio
 import com.tavemakers.surf.domain.board.service.BoardCategoryGetService;
 import com.tavemakers.surf.domain.member.entity.Member;
 import com.tavemakers.surf.domain.member.service.MemberGetService;
+import com.tavemakers.surf.domain.post.dto.request.PostFileCreateReqDTO;
 import com.tavemakers.surf.domain.post.dto.request.PostImageCreateReqDTO;
 import com.tavemakers.surf.domain.post.dto.request.PostUpdateReqDTO;
 import com.tavemakers.surf.domain.post.dto.response.PostDetailResDTO;
+import com.tavemakers.surf.domain.post.dto.response.PostFileResDTO;
 import com.tavemakers.surf.domain.post.dto.response.PostImageResDTO;
 import com.tavemakers.surf.domain.post.entity.Post;
+import com.tavemakers.surf.domain.post.entity.PostFileUrl;
 import com.tavemakers.surf.domain.post.entity.PostImageUrl;
 import com.tavemakers.surf.domain.post.exception.PostDeleteAccessDeniedException;
 import com.tavemakers.surf.domain.post.exception.PostImageListEmptyException;
 import com.tavemakers.surf.domain.post.exception.PostNotFoundException;
 import com.tavemakers.surf.domain.post.repository.PostRepository;
+import com.tavemakers.surf.domain.post.service.file.PostFileCreateService;
+import com.tavemakers.surf.domain.post.service.file.PostFileDeleteService;
+import com.tavemakers.surf.domain.post.service.file.PostFileGetService;
 import com.tavemakers.surf.domain.post.service.image.PostImageDeleteService;
 import com.tavemakers.surf.domain.post.service.image.PostImageGetService;
 import com.tavemakers.surf.domain.post.service.image.PostImageCreateService;
@@ -52,6 +58,9 @@ public class PostPatchService {
     private final PostImageCreateService imageCreateService;
     private final PostImageGetService imageGetService;
     private final PostImageDeleteService imageDeleteService;
+    private final PostFileCreateService fileCreateService;
+    private final PostFileGetService fileGetService;
+    private final PostFileDeleteService fileDeleteService;
     private final MemberGetService memberGetService;
     private final ViewCountService viewCountService;
 
@@ -85,28 +94,49 @@ public class PostPatchService {
         }
 
         // 이미지 변경
+        // TODO Spring Event로 PostImageUrl 삭제 로직 분리.
+        List<PostImageResDTO> imageDtoList;
         if (Boolean.TRUE.equals(req.isImageChanged())) {
-            deleteExistingImage(post);
-            List<PostImageCreateReqDTO> changeImage = req.imageUrlList();
-            if(changeImage.isEmpty()){
+            deleteExistingImages(post);
+            List<PostImageCreateReqDTO> changeImages = req.imageUrlList();
+            if (changeImages == null || changeImages.isEmpty()) {
                 post.addThumbnailUrl(null);
-                // TODO Spring Event로 PostImageUrl 삭제 로직 분리.
-                return PostDetailResDTO.of(post, scrappedByMe, likedByMe, true, null, reservedAt, viewCount);
+                imageDtoList = null;
+            } else {
+                post.addThumbnailUrl(findFirstImage(changeImages));
+                imageDtoList = imageCreateService.saveAll(post, changeImages);
             }
-
-            post.addThumbnailUrl(findFirstImage(changeImage));
-            List<PostImageResDTO> savedChangedImage = imageCreateService.saveAll(post, changeImage);
-            return PostDetailResDTO.of(post, scrappedByMe, likedByMe, true, savedChangedImage, reservedAt, viewCount);
+        } else {
+            imageDtoList = getImageUrlList(post);
         }
 
-        List<PostImageResDTO> imageDtoList = getImageUrlList(post);
-        return PostDetailResDTO.of(post, scrappedByMe, likedByMe, true, imageDtoList, reservedAt, viewCount);
+        // 파일 변경
+        List<PostFileResDTO> fileDtoList;
+        if (Boolean.TRUE.equals(req.isFileChanged())) {
+            deleteExistingFiles(post);
+            List<PostFileCreateReqDTO> changeFiles = req.fileList();
+            if (changeFiles == null || changeFiles.isEmpty()) {
+                fileDtoList = null;
+            } else {
+                fileDtoList = fileCreateService.saveAll(post, changeFiles);
+            }
+        } else {
+            fileDtoList = getPostFileList(post);
+        }
+
+        return PostDetailResDTO.of(post, scrappedByMe, likedByMe, true, imageDtoList, fileDtoList, reservedAt, viewCount);
     }
 
     /** 기존 이미지 삭제 */
-    private void deleteExistingImage(Post post) {
-        List<PostImageUrl> beforeImage = imageGetService.getPostImageUrls(post.getId());
-        imageDeleteService.deleteAll(beforeImage);
+    private void deleteExistingImages(Post post) {
+        List<PostImageUrl> beforeImages = imageGetService.getPostImageUrls(post.getId());
+        imageDeleteService.deleteAll(beforeImages);
+    }
+
+    /** 기존 첨부파일 삭제 */
+    private void deleteExistingFiles(Post post) {
+        List<PostFileUrl> beforeFiles = fileGetService.getPostFileUrls(post.getId());
+        fileDeleteService.deleteAll(beforeFiles);
     }
 
     /** 카테고리 유효성 검증 및 조회 */
@@ -126,6 +156,14 @@ public class PostPatchService {
         return imageGetService.getPostImageUrls(post.getId()).stream()
                 .map(PostImageResDTO::from)
                 .sorted(Comparator.comparing(PostImageResDTO::sequence))
+                .toList();
+    }
+
+    /** 첨부파일 목록 조회 */
+    private List<PostFileResDTO> getPostFileList(Post post) {
+        return fileGetService.getPostFileUrls(post.getId()).stream()
+                .map(PostFileResDTO::from)
+                .sorted(Comparator.comparing(PostFileResDTO::sequence))
                 .toList();
     }
 


### PR DESCRIPTION
## 📄 작업 내용 요약

  - 게시글에 이미지 외 일반 파일(PDF, 문서 등)을 첨부할 수 있는 기능을 추가합니다.
  - 기존 이미지(`PostImageUrl`) 레이어와 동일한 구조로 파일 레이어(`PostFileUrl`)를 신설하고, 생성, 조회, 수정 플로우 전체에 연동합니다.


## 📎 Issue 번호
<!-- closed #번호 -->
closed #299 

### 신규 파일 
 | 파일 | 설명 |
  |------|------|
  | `PostFileUrl` | 게시글 첨부파일 JPA 엔티티 (`fileUrl`, `originalFileName`, `sequence`) |
  | `PostFileUrlRepository` | `findByPostId(Long)` |
  | `PostFileCreateReqDTO` | 파일 생성 요청 record |
  | `PostFileResDTO` | 파일 응답 record + `from()` 팩토리 |
  | `PostFileCreateService` | 첨부파일 일괄 저장 |
  | `PostFileGetService` | 첨부파일 목록 조회 |
  | `PostFileDeleteService` | 첨부파일 일괄 삭제 |

 ### 기존 파일 수정

  **생성 (Create)**
  - `PostCreateReqDTO` — `fileList`, `hasFile()` 추가
  - `PostCreateService` — `hasFile()` 시 `PostFileCreateService.saveAll()` 호출

  **조회 (Get)**
  - `PostDetailResDTO` — `fileList: List<PostFileResDTO>` 필드 추가, `of()` 시그니처 변경
  - `PostGetService` — 게시글 상세 조회 시 파일 목록 포함

  **수정 (Patch)**
  - `PostUpdateReqDTO` — `isFileChanged`, `fileList` 필드 추가
  - `PostPatchService`
    - 이미지 수정 블록의 조기 `return` 제거 → 이미지·파일 모두 처리 후 단일 반환으로 구조 변경
    - `isFileChanged == true`: 기존 파일 전체 삭제 후 신규 파일 저장
    - `isFileChanged != true`: 기존 파일 목록 그대로 응답에 포함
    - `PostFileCreateService`, `PostFileDeleteService` 의존성 주입 추가

> 파일은 S3 업로드 후 URL을 전달받는 방식으로, 업로드 자체는 기존 `global/s3` 공통 모듈을 통해 클라이언트가 처리합니다.


### 테스트 화면

첨부 파일  추가 후 게시글 작성
<img width="906" height="715" alt="첨부파일 추가" src="https://github.com/user-attachments/assets/45fd9bab-89a2-4422-8142-dea64f7e2c69" />

게시글 상세 조회
<img width="854" height="713" alt="상세 조회" src="https://github.com/user-attachments/assets/03fa33dc-78d2-4f40-9bf9-f83b043e7d82" />

게시글 수정 (이미지 수정과 동일한 규칙)
<img width="769" height="803" alt="게시글 수정" src="https://github.com/user-attachments/assets/527876a7-ae22-46bb-986c-2f5bc61ff6a1" />

## 💣💥💥주의 사항 (병합 이후 주의 사항)
`PostImageUrl`, `PostFileUrl` 엔티티의 `nullable = false` 추가 적용 확인 필요
> ddl-auto: update 이기 때문에 방언에 따라 다르지만 현재 같은 경우의 미 적용으로 알고 있습니다. 병합 이후 쿼리를 통해 수정하겠습니다.

```
@Column(nullable = false)
    private Integer sequence;
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 게시물에 파일 첨부 기능 추가 — 작성·수정 시 파일 업로드/교체 가능.
  * 게시물 상세 조회에서 첨부 파일 목록 확인(순서 유지).
  * 첨부 파일 일괄 저장 및 일괄 삭제 지원.

* **개선**
  * 이미지·파일 처리 흐름 개선으로 수정 시 변경/유지 로직 명확화.
  * 이미지 응답에서 게시물 ID 제거 및 시퀀스 필드 검증 강화.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->