### PR TITLE
[FEAT] 뱃지 단건조회 api 및 track list 추가

### DIFF
--- a/src/main/java/com/tavemakers/surf/domain/badge/controller/BadgeCreateController.java
+++ b/src/main/java/com/tavemakers/surf/domain/badge/controller/BadgeCreateController.java
@@ -1,6 +1,7 @@
 package com.tavemakers.surf.domain.badge.controller;
 
 import com.tavemakers.surf.domain.badge.dto.request.BadgeCreateReqDTO;
+import com.tavemakers.surf.domain.badge.dto.response.BadgeCreateResDTO;
 import com.tavemakers.surf.domain.badge.usecase.BadgeUsecase;
 import com.tavemakers.surf.global.common.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -22,14 +23,14 @@ public class BadgeCreateController {
     /** 새로운 활동 배지 생성 */
     @Operation(summary = "배지 생성", description = "새로운 활동 배지를 생성합니다.")
     @PostMapping("/v1/admin/badges")
-    public ApiResponse<Void> create(@Valid @RequestBody BadgeCreateReqDTO dto) {
+    public ApiResponse<BadgeCreateResDTO> create(@Valid @RequestBody BadgeCreateReqDTO dto) {
 
-        badgeUsecase.create(dto);
+        Long badgeId = badgeUsecase.create(dto);
 
         return ApiResponse.response(
                 HttpStatus.CREATED,
                 BADGE_CREATED.getMessage(),
-                null
+                BadgeCreateResDTO.of(badgeId)
         );
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/badge/controller/BadgeCreateController.java
+++ b/src/main/java/com/tavemakers/surf/domain/badge/controller/BadgeCreateController.java
@@ -23,9 +23,9 @@ public class BadgeCreateController {
     /** 새로운 활동 배지 생성 */
     @Operation(summary = "배지 생성", description = "새로운 활동 배지를 생성합니다.")
     @PostMapping("/v1/admin/badges")
-    public ApiResponse<BadgeCreateResDTO> create(@Valid @RequestBody BadgeCreateReqDTO dto) {
+    public ApiResponse<BadgeCreateResDTO> createBadge(@Valid @RequestBody BadgeCreateReqDTO dto) {
 
-        Long badgeId = badgeUsecase.create(dto);
+        Long badgeId = badgeUsecase.createBadge(dto);
 
         return ApiResponse.response(
                 HttpStatus.CREATED,

--- a/src/main/java/com/tavemakers/surf/domain/badge/controller/BadgeDeleteController.java
+++ b/src/main/java/com/tavemakers/surf/domain/badge/controller/BadgeDeleteController.java
@@ -19,9 +19,9 @@ public class BadgeDeleteController {
 
     @Operation(summary = "배지 삭제", description = "배지를 삭제합니다.")
     @DeleteMapping("/v1/admin/badges/{badgeId}")
-    public ApiResponse<Void> delete(@PathVariable Long badgeId) {
+    public ApiResponse<Void> deleteBadge(@PathVariable Long badgeId) {
 
-        badgeUsecase.delete(badgeId);
+        badgeUsecase.deleteBadge(badgeId);
 
         return ApiResponse.response(
                 HttpStatus.OK,

--- a/src/main/java/com/tavemakers/surf/domain/badge/controller/BadgeGetController.java
+++ b/src/main/java/com/tavemakers/surf/domain/badge/controller/BadgeGetController.java
@@ -41,16 +41,16 @@ public class BadgeGetController {
     /** 배지 단건 조회 */
     @Operation(summary = "배지 단건 조회", description = "특정 배지의 상세 정보를 조회합니다.")
     @GetMapping("/v1/admin/badges/{badgeId}")
-    public ApiResponse<BadgeDetailResDTO> getBadge(
+    public ApiResponse<BadgeDetailResDTO> getBadgeSingle(
             @PathVariable Long badgeId
     ) {
 
         BadgeDetailResDTO response =
-                badgeUsecase.getBadge(badgeId);
+                badgeUsecase.getBadgeSingle(badgeId);
 
         return ApiResponse.response(
                 HttpStatus.OK,
-                BADGE_SINGLE_READ.getMessage(), // 필요하면 메시지 따로 분리
+                BADGE_SINGLE_READ.getMessage(),
                 response
         );
     }

--- a/src/main/java/com/tavemakers/surf/domain/badge/controller/BadgeGetController.java
+++ b/src/main/java/com/tavemakers/surf/domain/badge/controller/BadgeGetController.java
@@ -1,5 +1,6 @@
 package com.tavemakers.surf.domain.badge.controller;
 
+import com.tavemakers.surf.domain.badge.dto.response.BadgeDetailResDTO;
 import com.tavemakers.surf.domain.badge.dto.response.BadgeSliceResDTO;
 import com.tavemakers.surf.domain.badge.usecase.BadgeUsecase;
 import com.tavemakers.surf.global.common.response.ApiResponse;
@@ -10,6 +11,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
 import static com.tavemakers.surf.domain.badge.controller.ResponseMessage.BADGE_LIST_READ;
+import static com.tavemakers.surf.domain.badge.controller.ResponseMessage.BADGE_SINGLE_READ;
 
 @RestController
 @RequiredArgsConstructor
@@ -31,6 +33,22 @@ public class BadgeGetController {
         return ApiResponse.response(
                 HttpStatus.OK,
                 BADGE_LIST_READ.getMessage(),
+                response
+        );
+    }
+
+    @Operation(summary = "배지 단건 조회", description = "특정 배지의 상세 정보를 조회합니다.")
+    @GetMapping("/v1/admin/badges/{badgeId}")
+    public ApiResponse<BadgeDetailResDTO> getBadge(
+            @PathVariable Long badgeId
+    ) {
+
+        BadgeDetailResDTO response =
+                badgeUsecase.getBadge(badgeId);
+
+        return ApiResponse.response(
+                HttpStatus.OK,
+                BADGE_SINGLE_READ.getMessage(), // 필요하면 메시지 따로 분리
                 response
         );
     }

--- a/src/main/java/com/tavemakers/surf/domain/badge/controller/BadgeGetController.java
+++ b/src/main/java/com/tavemakers/surf/domain/badge/controller/BadgeGetController.java
@@ -20,6 +20,7 @@ public class BadgeGetController {
 
     private final BadgeUsecase badgeUsecase;
 
+    /** 배지 목록 조회 */
     @Operation(summary = "배지 목록 조회", description = "활성화된 배지를 무한스크롤로 조회합니다.")
     @GetMapping("/v1/admin/badges")
     public ApiResponse<BadgeSliceResDTO> getBadgeList(
@@ -37,6 +38,7 @@ public class BadgeGetController {
         );
     }
 
+    /** 배지 단건 조회 */
     @Operation(summary = "배지 단건 조회", description = "특정 배지의 상세 정보를 조회합니다.")
     @GetMapping("/v1/admin/badges/{badgeId}")
     public ApiResponse<BadgeDetailResDTO> getBadge(

--- a/src/main/java/com/tavemakers/surf/domain/badge/controller/BadgeUpdateController.java
+++ b/src/main/java/com/tavemakers/surf/domain/badge/controller/BadgeUpdateController.java
@@ -21,12 +21,12 @@ public class BadgeUpdateController {
 
     @Operation(summary = "배지 수정", description = "기존 배지 정보를 수정합니다.")
     @PatchMapping("/v1/admin/badges/{badgeId}")
-    public ApiResponse<Void> update(
+    public ApiResponse<Void> updateBadge(
             @PathVariable Long badgeId,
             @Valid @RequestBody BadgeUpdateReqDTO dto
     ) {
 
-        badgeUsecase.update(badgeId, dto);
+        badgeUsecase.updateBadge(badgeId, dto);
 
         return ApiResponse.response(
                 HttpStatus.OK,

--- a/src/main/java/com/tavemakers/surf/domain/badge/controller/MemberBadgeAssignController.java
+++ b/src/main/java/com/tavemakers/surf/domain/badge/controller/MemberBadgeAssignController.java
@@ -22,12 +22,12 @@ public class MemberBadgeAssignController {
     /** 회원들을 선택히여 활동 배지 부여 */
     @Operation(summary = "배지 부여", description = "활동 배지를 선택된 회원들에게 부여합니다.")
     @PostMapping("/v1/admin/badges/{badgeId}/members")
-    public ApiResponse<Void> assign(
+    public ApiResponse<Void> assignBadge(
             @PathVariable Long badgeId,
             @Valid @RequestBody MemberBadgeReqDTO dto
     ) {
 
-        memberBadgeUsecase.assign(badgeId, dto);
+        memberBadgeUsecase.assignBadge(badgeId, dto);
 
         return ApiResponse.response(
                 HttpStatus.CREATED,

--- a/src/main/java/com/tavemakers/surf/domain/badge/controller/MemberBadgeRevokeController.java
+++ b/src/main/java/com/tavemakers/surf/domain/badge/controller/MemberBadgeRevokeController.java
@@ -22,12 +22,12 @@ public class MemberBadgeRevokeController {
     /** 회원들을 선택히여 활동 배지 회수 */
     @Operation(summary = "배지 회수", description = "활동 배지를 선택된 회원들에게서 회수합니다.")
     @DeleteMapping("/v1/admin/badges/{badgeId}/members")
-    public ApiResponse<Void> remove(
+    public ApiResponse<Void> revokeBadge(
             @PathVariable Long badgeId,
             @Valid @RequestBody MemberBadgeReqDTO dto
     ) {
 
-        memberBadgeUsecase.revoke(badgeId, dto);
+        memberBadgeUsecase.revokeBadge(badgeId, dto);
 
         return ApiResponse.response(
                 HttpStatus.OK,

--- a/src/main/java/com/tavemakers/surf/domain/badge/controller/ResponseMessage.java
+++ b/src/main/java/com/tavemakers/surf/domain/badge/controller/ResponseMessage.java
@@ -9,7 +9,8 @@ public enum ResponseMessage {
 
     // 배지 관리
     BADGE_CREATED("[활동 배지]가 성공적으로 생성되었습니다."),
-    BADGE_LIST_READ("[활동 배지] 목록이 성공적으로 조회되었습니다."),
+    BADGE_LIST_READ("[활동 배지] 리스트가 성공적으로 조회되었습니다."),
+    BADGE_SINGLE_READ("[활동 배지] 상세 정보가 성공적으로 조회되었습니다."),
     BADGE_UPDATED("[활동 배지]가 성공적으로 수정되었습니다."),
     BADGE_DELETED("[활동 배지]가 성공적으로 삭제되었습니다."),
 

--- a/src/main/java/com/tavemakers/surf/domain/badge/dto/response/BadgeCreateResDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/badge/dto/response/BadgeCreateResDTO.java
@@ -1,0 +1,9 @@
+package com.tavemakers.surf.domain.badge.dto.response;
+
+public record BadgeCreateResDTO(
+        Long badgeId
+) {
+    public static BadgeCreateResDTO of(Long badgeId) {
+        return new BadgeCreateResDTO(badgeId);
+    }
+}

--- a/src/main/java/com/tavemakers/surf/domain/badge/dto/response/BadgeDetailResDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/badge/dto/response/BadgeDetailResDTO.java
@@ -2,25 +2,22 @@ package com.tavemakers.surf.domain.badge.dto.response;
 
 import com.tavemakers.surf.domain.badge.entity.Badge;
 import lombok.Builder;
-import lombok.Getter;
 
-@Getter
 @Builder
-public class BadgeDetailResDTO {
-
-    private Long badgeId;
-    private String name;
-    private String imageUrl;
-    private String description;
-    private String requirement;
-
+public record BadgeDetailResDTO(
+        Long badgeId,
+        String name,
+        String imageUrl,
+        String description,
+        String requirement
+) {
     public static BadgeDetailResDTO from(Badge badge) {
         return BadgeDetailResDTO.builder()
-                .badgeId(badge.getId())
-                .name(badge.getName())
-                .imageUrl(badge.getImageUrl())
-                .description(badge.getDescription())
-                .requirement(badge.getRequirement())
-                .build();
+                        .badgeId(badge.getId())
+                        .name(badge.getName())
+                        .imageUrl(badge.getImageUrl())
+                        .description(badge.getDescription())
+                        .requirement(badge.getRequirement())
+                        .build();
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/badge/dto/response/BadgeDetailResDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/badge/dto/response/BadgeDetailResDTO.java
@@ -1,0 +1,26 @@
+package com.tavemakers.surf.domain.badge.dto.response;
+
+import com.tavemakers.surf.domain.badge.entity.Badge;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class BadgeDetailResDTO {
+
+    private Long badgeId;
+    private String name;
+    private String imageUrl;
+    private String description;
+    private String requirement;
+
+    public static BadgeDetailResDTO from(Badge badge) {
+        return BadgeDetailResDTO.builder()
+                .badgeId(badge.getId())
+                .name(badge.getName())
+                .imageUrl(badge.getImageUrl())
+                .description(badge.getDescription())
+                .requirement(badge.getRequirement())
+                .build();
+    }
+}

--- a/src/main/java/com/tavemakers/surf/domain/badge/dto/response/BadgeDetailResDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/badge/dto/response/BadgeDetailResDTO.java
@@ -12,12 +12,12 @@ public record BadgeDetailResDTO(
         String requirement
 ) {
     public static BadgeDetailResDTO from(Badge badge) {
-        return BadgeDetailResDTO.builder()
-                        .badgeId(badge.getId())
-                        .name(badge.getName())
-                        .imageUrl(badge.getImageUrl())
-                        .description(badge.getDescription())
-                        .requirement(badge.getRequirement())
-                        .build();
+        return new BadgeDetailResDTO(
+                badge.getId(),
+                badge.getName(),
+                badge.getImageUrl(),
+                badge.getDescription(),
+                badge.getRequirement()
+        );
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/badge/dto/response/MemberBadgeResDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/badge/dto/response/MemberBadgeResDTO.java
@@ -1,17 +1,17 @@
 package com.tavemakers.surf.domain.badge.dto.response;
 
 import com.tavemakers.surf.domain.badge.entity.MemberBadge;
+import com.tavemakers.surf.domain.member.dto.response.TrackResDTO;
 import com.tavemakers.surf.domain.member.entity.Member;
-import com.tavemakers.surf.domain.member.entity.Track;
 
 import java.time.LocalDate;
-import java.util.Comparator;
+import java.util.List;
 
 public record MemberBadgeResDTO(
         Long memberId,
         String username,
         String profileImageUrl,
-        Integer generation,
+        List<TrackResDTO> trackList,
         LocalDate awardedAt
 ) {
 
@@ -19,17 +19,16 @@ public record MemberBadgeResDTO(
 
         Member member = memberBadge.getMember();
 
-        Integer firstGeneration = member.getTracks()
+        List<TrackResDTO> trackList = member.getTracks()
                 .stream()
-                .min(Comparator.comparing(Track::getGeneration))
-                .map(Track::getGeneration)
-                .orElse(null);
+                .map(TrackResDTO::from)
+                .toList();
 
         return new MemberBadgeResDTO(
                 member.getId(),
                 member.getName(),
                 member.getProfileImageUrl(),
-                firstGeneration,
+                trackList,
                 memberBadge.getAwardedAt()
         );
     }

--- a/src/main/java/com/tavemakers/surf/domain/badge/dto/response/MemberBadgeResDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/badge/dto/response/MemberBadgeResDTO.java
@@ -3,8 +3,10 @@ package com.tavemakers.surf.domain.badge.dto.response;
 import com.tavemakers.surf.domain.badge.entity.MemberBadge;
 import com.tavemakers.surf.domain.member.dto.response.TrackResDTO;
 import com.tavemakers.surf.domain.member.entity.Member;
+import com.tavemakers.surf.domain.member.entity.Track;
 
 import java.time.LocalDate;
+import java.util.Comparator;
 import java.util.List;
 
 public record MemberBadgeResDTO(
@@ -21,6 +23,7 @@ public record MemberBadgeResDTO(
 
         List<TrackResDTO> trackList = member.getTracks()
                 .stream()
+                .sorted(Comparator.comparing(Track::getGeneration)) // 기수 기준
                 .map(TrackResDTO::from)
                 .toList();
 

--- a/src/main/java/com/tavemakers/surf/domain/badge/service/BadgeCreateService.java
+++ b/src/main/java/com/tavemakers/surf/domain/badge/service/BadgeCreateService.java
@@ -13,7 +13,7 @@ public class BadgeCreateService {
     private final BadgeRepository badgeRepository;
 
     /** 배지 생성 */
-    public Long create(BadgeCreateReqDTO request) {
+    public Long createBadge(BadgeCreateReqDTO request) {
 
         // 요청 DTO 값을 기반으로 배지 엔티티 생성
         Badge badge = new Badge(

--- a/src/main/java/com/tavemakers/surf/domain/badge/service/BadgeCreateService.java
+++ b/src/main/java/com/tavemakers/surf/domain/badge/service/BadgeCreateService.java
@@ -5,7 +5,6 @@ import com.tavemakers.surf.domain.badge.entity.Badge;
 import com.tavemakers.surf.domain.badge.repository.BadgeRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -14,7 +13,6 @@ public class BadgeCreateService {
     private final BadgeRepository badgeRepository;
 
     /** 배지 생성 */
-    @Transactional
     public Long create(BadgeCreateReqDTO request) {
 
         // 요청 DTO 값을 기반으로 배지 엔티티 생성

--- a/src/main/java/com/tavemakers/surf/domain/badge/service/BadgeDeleteService.java
+++ b/src/main/java/com/tavemakers/surf/domain/badge/service/BadgeDeleteService.java
@@ -5,7 +5,6 @@ import com.tavemakers.surf.domain.badge.repository.BadgeRepository;
 import com.tavemakers.surf.domain.badge.repository.MemberBadgeRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import com.tavemakers.surf.domain.badge.exception.BadgeNotFoundException;
 
 @Service
@@ -16,7 +15,6 @@ public class BadgeDeleteService {
     private final MemberBadgeRepository memberBadgeRepository;
 
     /** 배지 하드 삭제 */
-    @Transactional
     public void delete(Long badgeId) {
 
         // 삭제 대상 배지 조회

--- a/src/main/java/com/tavemakers/surf/domain/badge/service/BadgeDeleteService.java
+++ b/src/main/java/com/tavemakers/surf/domain/badge/service/BadgeDeleteService.java
@@ -15,7 +15,7 @@ public class BadgeDeleteService {
     private final MemberBadgeRepository memberBadgeRepository;
 
     /** 배지 하드 삭제 */
-    public void delete(Long badgeId) {
+    public void deleteBadge(Long badgeId) {
 
         // 삭제 대상 배지 조회
         Badge badge = badgeRepository.findById(badgeId)

--- a/src/main/java/com/tavemakers/surf/domain/badge/service/BadgeGetService.java
+++ b/src/main/java/com/tavemakers/surf/domain/badge/service/BadgeGetService.java
@@ -3,11 +3,11 @@ package com.tavemakers.surf.domain.badge.service;
 import com.tavemakers.surf.domain.badge.entity.Badge;
 import com.tavemakers.surf.domain.badge.repository.BadgeRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import com.tavemakers.surf.domain.badge.exception.BadgeNotFoundException;
 
 @Service
 @RequiredArgsConstructor
@@ -19,5 +19,12 @@ public class BadgeGetService {
     @Transactional(readOnly = true)
     public Slice<Badge> getBadgeList(Pageable pageable) {
         return badgeRepository.findAllBy(pageable);
+    }
+
+    /** 배지 단건 조회 */
+    @Transactional(readOnly = true)
+    public Badge getBadgeDetail(Long badgeId) {
+        return badgeRepository.findById(badgeId)
+                .orElseThrow(BadgeNotFoundException::new);
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/badge/service/BadgeGetService.java
+++ b/src/main/java/com/tavemakers/surf/domain/badge/service/BadgeGetService.java
@@ -6,7 +6,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import com.tavemakers.surf.domain.badge.exception.BadgeNotFoundException;
 
 @Service
@@ -16,13 +15,11 @@ public class BadgeGetService {
     private final BadgeRepository badgeRepository;
 
     /** 배지 목록 조회 (무한스크롤) */
-    @Transactional(readOnly = true)
     public Slice<Badge> getBadgeList(Pageable pageable) {
         return badgeRepository.findAllBy(pageable);
     }
 
     /** 배지 단건 조회 */
-    @Transactional(readOnly = true)
     public Badge getBadgeDetail(Long badgeId) {
         return badgeRepository.findById(badgeId)
                 .orElseThrow(BadgeNotFoundException::new);

--- a/src/main/java/com/tavemakers/surf/domain/badge/service/BadgeUpdateService.java
+++ b/src/main/java/com/tavemakers/surf/domain/badge/service/BadgeUpdateService.java
@@ -5,7 +5,6 @@ import com.tavemakers.surf.domain.badge.entity.Badge;
 import com.tavemakers.surf.domain.badge.repository.BadgeRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import com.tavemakers.surf.domain.badge.exception.BadgeNotFoundException;
 
 @Service
@@ -15,7 +14,6 @@ public class BadgeUpdateService {
     private final BadgeRepository badgeRepository;
 
     /** 배지 정보 수정 */
-    @Transactional
     public void update(Long badgeId, BadgeUpdateReqDTO request) {
 
         // 수정 대상 배지 조회 (없으면 예외)

--- a/src/main/java/com/tavemakers/surf/domain/badge/service/BadgeUpdateService.java
+++ b/src/main/java/com/tavemakers/surf/domain/badge/service/BadgeUpdateService.java
@@ -14,7 +14,7 @@ public class BadgeUpdateService {
     private final BadgeRepository badgeRepository;
 
     /** 배지 정보 수정 */
-    public void update(Long badgeId, BadgeUpdateReqDTO request) {
+    public void updateBadge(Long badgeId, BadgeUpdateReqDTO request) {
 
         // 수정 대상 배지 조회 (없으면 예외)
         Badge badge = badgeRepository.findById(badgeId)

--- a/src/main/java/com/tavemakers/surf/domain/badge/service/MemberBadgeAssignService.java
+++ b/src/main/java/com/tavemakers/surf/domain/badge/service/MemberBadgeAssignService.java
@@ -24,7 +24,7 @@ public class MemberBadgeAssignService {
     private final MemberBadgeRepository memberBadgeRepository;
 
     /** 다수의 회원에게 배지 부여 */
-    public void assign(Long badgeId, List<Long> memberIds) {
+    public void assignBadge(Long badgeId, List<Long> memberIds) {
 
         Badge badge = badgeRepository.findById(badgeId)
                 .orElseThrow(BadgeNotFoundException::new);

--- a/src/main/java/com/tavemakers/surf/domain/badge/service/MemberBadgeGetService.java
+++ b/src/main/java/com/tavemakers/surf/domain/badge/service/MemberBadgeGetService.java
@@ -9,7 +9,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import com.tavemakers.surf.domain.badge.exception.BadgeNotFoundException;
 
 import java.util.List;
@@ -23,7 +22,6 @@ public class MemberBadgeGetService {
     private final MemberGetService memberGetService;
 
     /** 특정 배지를 받은 회원 목록 조회 */
-    @Transactional(readOnly = true)
     public Slice<MemberBadge> getMembersByBadge(Long badgeId, Pageable pageable) {
 
         // 배지 존재 여부 확인
@@ -34,7 +32,6 @@ public class MemberBadgeGetService {
     }
 
     /** 특정 회원의 배지 전체 조회 */
-    @Transactional(readOnly = true)
     public List<MemberOwnedBadgeResDTO> getAllByMemberId(Long memberId) {
 
         // 회원 존재 여부 확인

--- a/src/main/java/com/tavemakers/surf/domain/badge/service/MemberBadgeRevokeService.java
+++ b/src/main/java/com/tavemakers/surf/domain/badge/service/MemberBadgeRevokeService.java
@@ -5,7 +5,6 @@ import com.tavemakers.surf.domain.badge.exception.MemberBadgeNotFoundException;
 import com.tavemakers.surf.domain.badge.repository.MemberBadgeRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import com.tavemakers.surf.domain.badge.repository.BadgeRepository;
 import com.tavemakers.surf.domain.badge.exception.BadgeNotFoundException;
 
@@ -19,7 +18,6 @@ public class MemberBadgeRevokeService {
     private final BadgeRepository badgeRepository;
 
     /** 배지 회수 */
-    @Transactional
     public void revoke(Long badgeId, List<Long> memberIds) {
 
         // 중복 제거

--- a/src/main/java/com/tavemakers/surf/domain/badge/service/MemberBadgeRevokeService.java
+++ b/src/main/java/com/tavemakers/surf/domain/badge/service/MemberBadgeRevokeService.java
@@ -18,7 +18,7 @@ public class MemberBadgeRevokeService {
     private final BadgeRepository badgeRepository;
 
     /** 배지 회수 */
-    public void revoke(Long badgeId, List<Long> memberIds) {
+    public void revokeBadge(Long badgeId, List<Long> memberIds) {
 
         // 중복 제거
         List<Long> uniqueMemberIds = memberIds.stream().distinct().toList();

--- a/src/main/java/com/tavemakers/surf/domain/badge/usecase/BadgeUsecase.java
+++ b/src/main/java/com/tavemakers/surf/domain/badge/usecase/BadgeUsecase.java
@@ -23,8 +23,8 @@ public class BadgeUsecase {
 
     /** 배지 생성 */
     @Transactional
-    public Long create(BadgeCreateReqDTO dto) {
-        return badgeCreateService.create(dto);
+    public Long createBadge(BadgeCreateReqDTO dto) {
+        return badgeCreateService.createBadge(dto);
     }
 
     /** 배지 리스트 조회 */
@@ -46,20 +46,20 @@ public class BadgeUsecase {
 
     /** 배지 단건 조회 */
     @Transactional(readOnly = true)
-    public BadgeDetailResDTO getBadge(Long badgeId) {
+    public BadgeDetailResDTO getBadgeSingle(Long badgeId) {
         Badge badge = badgeGetService.getBadgeDetail(badgeId);
         return BadgeDetailResDTO.from(badge);
     }
 
     /** 배지 수정 */
     @Transactional
-    public void update(Long badgeId, BadgeUpdateReqDTO dto) {
-        badgeUpdateService.update(badgeId, dto);
+    public void updateBadge(Long badgeId, BadgeUpdateReqDTO dto) {
+        badgeUpdateService.updateBadge(badgeId, dto);
     }
 
     /** 배지 삭제 */
     @Transactional
-    public void delete(Long badgeId) {
-        badgeDeleteService.delete(badgeId);
+    public void deleteBadge(Long badgeId) {
+        badgeDeleteService.deleteBadge(badgeId);
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/badge/usecase/BadgeUsecase.java
+++ b/src/main/java/com/tavemakers/surf/domain/badge/usecase/BadgeUsecase.java
@@ -14,7 +14,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-@Transactional
 public class BadgeUsecase {
 
     private final BadgeCreateService badgeCreateService;
@@ -23,11 +22,13 @@ public class BadgeUsecase {
     private final BadgeGetService badgeGetService;
 
     /** 배지 생성 */
+    @Transactional
     public Long create(BadgeCreateReqDTO dto) {
         return badgeCreateService.create(dto);
     }
 
     /** 배지 리스트 조회 */
+    @Transactional(readOnly = true)
     public BadgeSliceResDTO getBadgeList(int pageSize, int pageNum) {
 
         // 페이지 번호, 사이즈, 정렬조건(id 내림차순) 기반 Pageable 생성
@@ -44,17 +45,20 @@ public class BadgeUsecase {
     }
 
     /** 배지 단건 조회 */
+    @Transactional(readOnly = true)
     public BadgeDetailResDTO getBadge(Long badgeId) {
         Badge badge = badgeGetService.getBadgeDetail(badgeId);
         return BadgeDetailResDTO.from(badge);
     }
 
     /** 배지 수정 */
+    @Transactional
     public void update(Long badgeId, BadgeUpdateReqDTO dto) {
         badgeUpdateService.update(badgeId, dto);
     }
 
     /** 배지 삭제 */
+    @Transactional
     public void delete(Long badgeId) {
         badgeDeleteService.delete(badgeId);
     }

--- a/src/main/java/com/tavemakers/surf/domain/badge/usecase/BadgeUsecase.java
+++ b/src/main/java/com/tavemakers/surf/domain/badge/usecase/BadgeUsecase.java
@@ -2,6 +2,7 @@ package com.tavemakers.surf.domain.badge.usecase;
 
 import com.tavemakers.surf.domain.badge.dto.request.BadgeCreateReqDTO;
 import com.tavemakers.surf.domain.badge.dto.request.BadgeUpdateReqDTO;
+import com.tavemakers.surf.domain.badge.dto.response.BadgeDetailResDTO;
 import com.tavemakers.surf.domain.badge.dto.response.BadgeResDTO;
 import com.tavemakers.surf.domain.badge.dto.response.BadgeSliceResDTO;
 import com.tavemakers.surf.domain.badge.entity.Badge;
@@ -26,7 +27,7 @@ public class BadgeUsecase {
         return badgeCreateService.create(dto);
     }
 
-    /** 활성 배지 목록 조회 */
+    /** 배지 리스트 조회 */
     public BadgeSliceResDTO getBadgeList(int pageSize, int pageNum) {
 
         // 페이지 번호, 사이즈, 정렬조건(id 내림차순) 기반 Pageable 생성
@@ -40,6 +41,12 @@ public class BadgeUsecase {
         Slice<Badge> slice = badgeGetService.getBadgeList(pageable);
 
         return BadgeSliceResDTO.from(slice.map(BadgeResDTO::from));
+    }
+
+    /** 배지 단건 조회 */
+    public BadgeDetailResDTO getBadge(Long badgeId) {
+        Badge badge = badgeGetService.getBadgeDetail(badgeId);
+        return BadgeDetailResDTO.from(badge);
     }
 
     /** 배지 수정 */

--- a/src/main/java/com/tavemakers/surf/domain/badge/usecase/MemberBadgeUsecase.java
+++ b/src/main/java/com/tavemakers/surf/domain/badge/usecase/MemberBadgeUsecase.java
@@ -23,8 +23,8 @@ public class MemberBadgeUsecase {
 
     /** 배지 부여 */
     @Transactional
-    public void assign(Long badgeId, MemberBadgeReqDTO dto) {
-        memberBadgeAssignService.assign(badgeId, dto.getMemberIds());
+    public void assignBadge(Long badgeId, MemberBadgeReqDTO dto) {
+        memberBadgeAssignService.assignBadge(badgeId, dto.getMemberIds());
     }
 
     /** 특정 배지 받은 회원 목록 조회 */
@@ -51,8 +51,8 @@ public class MemberBadgeUsecase {
 
     /** 배지 회수 */
     @Transactional
-    public void revoke(Long badgeId, MemberBadgeReqDTO dto) {
-        memberBadgeRevokeService.revoke(badgeId, dto.getMemberIds());
+    public void revokeBadge(Long badgeId, MemberBadgeReqDTO dto) {
+        memberBadgeRevokeService.revokeBadge(badgeId, dto.getMemberIds());
     }
 
     /** 특정 회원의 배지 전체 조회 */

--- a/src/main/java/com/tavemakers/surf/domain/badge/usecase/MemberBadgeUsecase.java
+++ b/src/main/java/com/tavemakers/surf/domain/badge/usecase/MemberBadgeUsecase.java
@@ -15,7 +15,6 @@ import java.util.List;
 
 @Service
 @RequiredArgsConstructor
-@Transactional
 public class MemberBadgeUsecase {
 
     private final MemberBadgeAssignService memberBadgeAssignService;
@@ -23,6 +22,7 @@ public class MemberBadgeUsecase {
     private final MemberBadgeGetService memberBadgeGetService;
 
     /** 배지 부여 */
+    @Transactional
     public void assign(Long badgeId, MemberBadgeReqDTO dto) {
         memberBadgeAssignService.assign(badgeId, dto.getMemberIds());
     }
@@ -50,6 +50,7 @@ public class MemberBadgeUsecase {
     }
 
     /** 배지 회수 */
+    @Transactional
     public void revoke(Long badgeId, MemberBadgeReqDTO dto) {
         memberBadgeRevokeService.revoke(badgeId, dto.getMemberIds());
     }


### PR DESCRIPTION
## 📄 작업 내용 요약
> 배지 단건 조회 API 추가
> 배지 받은 회원 조회 시 기존의 generation을 제거하고 trackList를 응답


### 1. 배지 단건 조회 API 추가 
- 기존: 배지 전체 리스트를 20개씩 조회하도록 함 
- 변경: `/v1/admin/badges/{badgeId}` (특정 배지를 상세조회 할 수 있는) API 추가
- 변경 사유: 배지 수정 화면, 배지 상세 화면에서 특정 배지 정보 조회가 필요하다는 프론트 요구사항


### 2. 배지 받은 회원 조회 시 trackList 응답
- 기존: 해당 회원이 처음으로 활동했던 기수(generation)를 반환
```
{
    "memberId": 1,
    "username": "홍길동",
    "profileImageUrl": "http://img1.kakaocdn.net/thumb/R640x640.q70/?fname=http://t1.kakaocdn.net/account_images/default_profile.jpeg",
    "generation": 15,
    "awardedAt": "2026-02-25"
}
```

- 변경: 기수 대신 회원의 기수와 트랙을 포함하고 있는 trackList로 응답하도록 수정

```
{
    "memberId": 1,
    "username": "홍길동",
    "profileImageUrl": "http://img1.kakaocdn.net/thumb/R640x640.q70/?fname=http://t1.kakaocdn.net/account_images/default_profile.jpeg",
    "trackList": [
      {
        "generation": 15,
        "part": "BACKEND"
      }
    ],
    "awardedAt": "2026-04-29"
}

```

- 변경 사유: 해당 배지를 받은 회원을 조회할 때, 그 응답에 회원 기수와 트랙 정보가 필요하다는 프론트 요구사항


## 📎 Issue 번호
closed #303

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 단일 배지 상세 조회 API 추가 (GET /v1/admin/badges/{badgeId})
  * 배지 생성 시 생성된 배지 ID 반환

* **개선 사항**
  * 멤버 배지 응답 구조 변경: 세대 정보 → 트랙 목록 포함으로 업데이트
  * 배지 목록 응답 문구를 “목록”→“리스트”로 표현 변경, 단일 조회 성공 메시지 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->