### PR TITLE
fix: 약관 동의 API detached 엔티티 버그 수정

### DIFF
--- a/src/main/java/com/tavemakers/surf/domain/member/controller/MemberPatchController.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/controller/MemberPatchController.java
@@ -1,7 +1,6 @@
 package com.tavemakers.surf.domain.member.controller;
 
 import com.tavemakers.surf.domain.member.dto.request.ProfileUpdateReqDTO;
-import com.tavemakers.surf.domain.member.service.MemberGetService;
 import com.tavemakers.surf.domain.member.service.MemberPatchService;
 import com.tavemakers.surf.domain.member.usecase.MemberUsecase;
 import com.tavemakers.surf.global.common.response.ApiResponse;
@@ -22,7 +21,6 @@ import java.util.List;
 public class MemberPatchController {
 
     private final MemberUsecase memberUsecase;
-    private final MemberGetService memberGetService;
     private final MemberPatchService memberPatchService;
 
     @Operation(
@@ -31,8 +29,7 @@ public class MemberPatchController {
     @PatchMapping("/v1/user/members/terms/agree")
     public ApiResponse<Void> agreeTerms() {
         Long memberId = SecurityUtils.getCurrentMemberId();
-        var member = memberGetService.getMember(memberId);
-        memberPatchService.agreeTerms(member);
+        memberPatchService.agreeTerms(memberId);
         return ApiResponse.response(
                 HttpStatus.OK,
                 ResponseMessage.TERMS_AGREEMENT_SUCCESS.getMessage(),

--- a/src/main/java/com/tavemakers/surf/domain/member/controller/MemberPatchController.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/controller/MemberPatchController.java
@@ -1,6 +1,8 @@
 package com.tavemakers.surf.domain.member.controller;
 
 import com.tavemakers.surf.domain.member.dto.request.ProfileUpdateReqDTO;
+import com.tavemakers.surf.domain.member.service.MemberGetService;
+import com.tavemakers.surf.domain.member.service.MemberPatchService;
 import com.tavemakers.surf.domain.member.usecase.MemberUsecase;
 import com.tavemakers.surf.global.common.response.ApiResponse;
 import com.tavemakers.surf.global.util.SecurityUtils;
@@ -20,6 +22,22 @@ import java.util.List;
 public class MemberPatchController {
 
     private final MemberUsecase memberUsecase;
+    private final MemberGetService memberGetService;
+    private final MemberPatchService memberPatchService;
+
+    @Operation(
+            summary = "약관 동의",
+            description = "회원이 약관에 동의하는 API 입니다.")
+    @PatchMapping("/v1/user/members/terms/agree")
+    public ApiResponse<Void> agreeTerms() {
+        Long memberId = SecurityUtils.getCurrentMemberId();
+        var member = memberGetService.getMember(memberId);
+        memberPatchService.agreeTerms(member);
+        return ApiResponse.response(
+                HttpStatus.OK,
+                ResponseMessage.TERMS_AGREEMENT_SUCCESS.getMessage(),
+                null);
+    }
 
     @Operation(
             summary = "회원 프로필 수정하기",

--- a/src/main/java/com/tavemakers/surf/domain/member/controller/ResponseMessage.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/controller/ResponseMessage.java
@@ -27,6 +27,9 @@ public enum ResponseMessage {
     MYPAGE_MY_PROFILE_READ("본인 마이페이지에서 [프로필 정보]를 조회합니다."),
     MYPAGE_OTHERS_PROFILE_READ("타인 마이페이지에서 [프로필 정보]를 조회합니다."),
 
+    // 약관 동의
+    TERMS_AGREEMENT_SUCCESS("[약관 동의]를 완료했습니다."),
+
     // 프로필 수정
     MYPAGE_PROFILE_UPDATE_SUCCESS("마이페이지에서 [프로필 정보]를 수정했습니다."),
 

--- a/src/main/java/com/tavemakers/surf/domain/member/entity/Member.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/entity/Member.java
@@ -38,7 +38,7 @@ public class Member extends BaseEntity {
     @Column(name = "member_id")
     private Long id;
 
-    @Column(nullable = false, unique = true) // 이메일은 고유해야 함
+    @Column(nullable = false, unique = true)
     private Long kakaoId;
 
     @Column(nullable = false)
@@ -81,6 +81,9 @@ public class Member extends BaseEntity {
     private MemberType memberType; // OB, YB 구분
 
     private boolean activityStatus; // 활동/비활동 여부
+
+    @Column(nullable = false)
+    private boolean termsAgreed = false;
 
     @Column(name = "is_deleted", nullable = false)
     private boolean isDeleted = false;
@@ -181,6 +184,11 @@ public class Member extends BaseEntity {
      */
     public void approve() {
         this.status = MemberStatus.APPROVED;
+    }
+
+    /** 약관 동의 처리 */
+    public void agreeTerms() {
+        this.termsAgreed = true;
     }
 
     public void reject() {

--- a/src/main/java/com/tavemakers/surf/domain/member/service/MemberPatchService.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/service/MemberPatchService.java
@@ -25,6 +25,12 @@ public class MemberPatchService {
         member.exchangeRole(role);
     }
 
+    /** 약관 동의 처리 */
+    @Transactional
+    public void agreeTerms(Member member) {
+        member.agreeTerms();
+    }
+
     /** 여러 회원의 권한을 일괄 변경 version 2*/
     @Transactional
     public void grantRoleV2(List<Member> members, MemberRole role) {

--- a/src/main/java/com/tavemakers/surf/domain/member/service/MemberPatchService.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/service/MemberPatchService.java
@@ -3,6 +3,8 @@ package com.tavemakers.surf.domain.member.service;
 import com.tavemakers.surf.domain.member.dto.request.ProfileUpdateReqDTO;
 import com.tavemakers.surf.domain.member.entity.Member;
 import com.tavemakers.surf.domain.member.entity.enums.MemberRole;
+import com.tavemakers.surf.domain.member.exception.MemberNotFoundException;
+import com.tavemakers.surf.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -12,6 +14,8 @@ import java.util.List;
 @Service
 @RequiredArgsConstructor
 public class MemberPatchService {
+
+    private final MemberRepository memberRepository;
 
     /** 회원 프로필 정보 수정 */
     @Transactional
@@ -27,7 +31,9 @@ public class MemberPatchService {
 
     /** 약관 동의 처리 */
     @Transactional
-    public void agreeTerms(Member member) {
+    public void agreeTerms(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(MemberNotFoundException::new);
         member.agreeTerms();
     }
 

--- a/src/main/java/com/tavemakers/surf/global/config/AsyncConfig.java
+++ b/src/main/java/com/tavemakers/surf/global/config/AsyncConfig.java
@@ -1,0 +1,26 @@
+package com.tavemakers.surf.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@EnableAsync
+@Configuration
+public class AsyncConfig {
+
+    @Bean("logForwardExecutor")
+    public Executor logForwardExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(2);
+        executor.setMaxPoolSize(4);
+        executor.setQueueCapacity(500);
+        executor.setThreadNamePrefix("log-fwd-");
+        // 큐 초과 시 조용히 버림 — 로컬 파일에 이미 남아있으므로 서비스에 영향 없음
+        executor.setRejectedExecutionHandler((r, e) -> {});
+        executor.initialize();
+        return executor;
+    }
+}

--- a/src/main/java/com/tavemakers/surf/global/logging/LogEventEmitterImpl.java
+++ b/src/main/java/com/tavemakers/surf/global/logging/LogEventEmitterImpl.java
@@ -3,11 +3,14 @@ package com.tavemakers.surf.global.logging;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 @Component
@@ -15,9 +18,14 @@ public class LogEventEmitterImpl implements LogEventEmitter {
 
     private static final Logger log = LoggerFactory.getLogger("api-event");
     private final ObjectMapper objectMapper;
+    private final LogForwardingService forwardingService;
 
-    public LogEventEmitterImpl(ObjectMapper objectMapper) {
+    public LogEventEmitterImpl(
+            ObjectMapper objectMapper,
+            @Autowired(required = false) LogForwardingService forwardingService
+    ) {
         this.objectMapper = objectMapper;
+        this.forwardingService = forwardingService;
     }
 
     /** 성공 이벤트 적재 (요청 컨텍스트에 쌓아두고, 출력은 필터에서 flush) */
@@ -49,9 +57,10 @@ public class LogEventEmitterImpl implements LogEventEmitter {
         ctx.events.add(e);
     }
 
-    /** 요청 종료 시 필터(WebLoggingFilter)에서 호출: 공통 필드와 병합하여 JSON Line 출력 */
+    /** 요청 종료 시 필터(WebLoggingFilter)에서 호출: 공통 필드와 병합하여 JSON Line 출력 및 분석 서버 전송 */
     public void flush() {
         RequestLogContext ctx = RequestLogContext.get();
+        List<String> jsonLines = new ArrayList<>();
 
         for (Map<String, Object> e : ctx.events) {
             Map<String, Object> record = new HashMap<>();
@@ -67,17 +76,21 @@ public class LogEventEmitterImpl implements LogEventEmitter {
             record.put("path", ctx.path);
             record.put("duration_ms", ctx.durationMs);
             if (e.containsKey("message")) {
-                record.put("message", e.get("message")); // null이면 Jackson이 null로 직렬화
+                record.put("message", e.get("message"));
             }
             record.put("props", e.getOrDefault("props", Collections.emptyMap()));
 
             try {
-                log.info(objectMapper
-                        .writerWithDefaultPrettyPrinter()
-                        .writeValueAsString(record));
+                String json = objectMapper.writeValueAsString(record);
+                log.info(json);
+                jsonLines.add(json);
             } catch (Exception ex) {
                 log.warn("Failed to write log record: {}", ex.toString());
             }
+        }
+
+        if (forwardingService != null && !jsonLines.isEmpty()) {
+            forwardingService.forward(jsonLines);
         }
     }
 }

--- a/src/main/java/com/tavemakers/surf/global/logging/LogForwardingProperties.java
+++ b/src/main/java/com/tavemakers/surf/global/logging/LogForwardingProperties.java
@@ -1,0 +1,21 @@
+package com.tavemakers.surf.global.logging;
+
+import lombok.Getter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@ConfigurationProperties(prefix = "logging.forwarding")
+public class LogForwardingProperties {
+
+    private final boolean enabled;
+    private final String url;
+    private final int timeoutMs;
+    private final int maxRetries;
+
+    public LogForwardingProperties(boolean enabled, String url, int timeoutMs, int maxRetries) {
+        this.enabled = enabled;
+        this.url = url;
+        this.timeoutMs = timeoutMs <= 0 ? 3000 : timeoutMs;
+        this.maxRetries = maxRetries < 0 ? 1 : maxRetries;
+    }
+}

--- a/src/main/java/com/tavemakers/surf/global/logging/LogForwardingService.java
+++ b/src/main/java/com/tavemakers/surf/global/logging/LogForwardingService.java
@@ -1,0 +1,59 @@
+package com.tavemakers.surf.global.logging;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.http.MediaType;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.List;
+
+@Service
+@ConditionalOnProperty(name = "logging.forwarding.enabled", havingValue = "true")
+public class LogForwardingService {
+
+    private static final Logger log = LoggerFactory.getLogger(LogForwardingService.class);
+
+    private final HttpClient httpClient;
+    private final LogForwardingProperties props;
+
+    public LogForwardingService(LogForwardingProperties props) {
+        this.props = props;
+        this.httpClient = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofMillis(props.getTimeoutMs()))
+                .build();
+    }
+
+    /** flush() 한 번당 한 번 호출 — 한 요청의 모든 이벤트를 하나의 배치로 전송 */
+    @Async("logForwardExecutor")
+    public void forward(List<String> jsonLines) {
+        String body = "[" + String.join(",", jsonLines) + "]";
+
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(props.getUrl()))
+                .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                .timeout(Duration.ofMillis(props.getTimeoutMs()))
+                .POST(HttpRequest.BodyPublishers.ofString(body))
+                .build();
+
+        for (int attempt = 0; attempt <= props.getMaxRetries(); attempt++) {
+            try {
+                HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+                if (response.statusCode() >= 200 && response.statusCode() < 300) {
+                    return;
+                }
+                log.warn("[LogForward] 전송 실패 (status={}, attempt={}/{})",
+                        response.statusCode(), attempt, props.getMaxRetries());
+            } catch (Exception e) {
+                log.warn("[LogForward] 전송 예외 (attempt={}/{}): {}",
+                        attempt, props.getMaxRetries(), e.getMessage());
+            }
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -74,3 +74,10 @@ springdoc:
 
 server:
   forward-headers-strategy: framework
+
+logging:
+  forwarding:
+    enabled: false
+    url: ${LOG_FORWARD_URL:}
+    timeout-ms: 3000
+    max-retries: 1

--- a/src/test/java/com/tavemakers/surf/domain/member/entity/MemberTermsAgreementTest.java
+++ b/src/test/java/com/tavemakers/surf/domain/member/entity/MemberTermsAgreementTest.java
@@ -1,0 +1,61 @@
+package com.tavemakers.surf.domain.member.entity;
+
+import com.tavemakers.surf.domain.member.entity.enums.MemberRole;
+import com.tavemakers.surf.domain.member.entity.enums.MemberStatus;
+import com.tavemakers.surf.domain.member.entity.enums.MemberType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MemberTermsAgreementTest {
+
+    private Member createMember() {
+        return Member.builder()
+                .kakaoId(123456789L)
+                .name("테스트유저")
+                .email("test@test.com")
+                .status(MemberStatus.APPROVED)
+                .role(MemberRole.MEMBER)
+                .memberType(MemberType.YB)
+                .activityStatus(true)
+                .build();
+    }
+
+    @Test
+    @DisplayName("회원 생성 시 약관 동의 여부는 false이다")
+    void defaultTermsAgreedIsFalse() {
+        // given & when
+        Member member = createMember();
+
+        // then
+        assertThat(member.isTermsAgreed()).isFalse();
+    }
+
+    @Test
+    @DisplayName("agreeTerms 호출 시 약관 동의 여부가 true로 변경된다")
+    void agreeTermsChangesToTrue() {
+        // given
+        Member member = createMember();
+
+        // when
+        member.agreeTerms();
+
+        // then
+        assertThat(member.isTermsAgreed()).isTrue();
+    }
+
+    @Test
+    @DisplayName("이미 동의한 회원이 다시 agreeTerms를 호출해도 true를 유지한다")
+    void agreeTermsIdempotent() {
+        // given
+        Member member = createMember();
+        member.agreeTerms();
+
+        // when
+        member.agreeTerms();
+
+        // then
+        assertThat(member.isTermsAgreed()).isTrue();
+    }
+}


### PR DESCRIPTION
## 문제

`/v1/user/members/terms/agree` PATCH API에서 `termsAgreed` 변경이 DB에 저장되지 않는 버그가 있었습니다.

**원인**: 컨트롤러에서 `@Transactional`이 없는 `getMember()`로 조회한 `Member` 엔티티를 `agreeTerms(member)`에 넘기면, 서비스의 새 트랜잭션에서 그 엔티티는 **detached 상태**라 dirty checking이 동작하지 않음.

```
컨트롤러: getMember()       → 트랜잭션 없음 → detached entity 반환
          agreeTerms(member) → 새 트랜잭션   → detached member.termsAgreed=true
                                             → flush 시 저장 안 됨
```

## 수정 내용

- `MemberPatchService.agreeTerms(Member)` → `agreeTerms(Long memberId)`로 변경
  - 서비스 내부에서 직접 조회 후 수정 → 하나의 트랜잭션에서 처리
- `MemberPatchController`에서 불필요해진 `getMember()` 호출 및 `MemberGetService` 의존성 제거

## 테스트

- [ ] `MemberTermsAgreementTest` 단위 테스트 통과 확인
- [ ] `/v1/user/members/terms/agree` 호출 후 DB `terms_agreed` 컬럼 `true` 반영 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 약관 동의 기능이 추가되었습니다. 사용자는 이제 약관에 동의할 수 있으며, 동의 상태가 계정에 저장되고 추적됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->