### PR TITLE
[Feat] 승인회원 제명/퇴출 및 블랙리스트 도입

### DIFF
--- a/src/main/java/com/tavemakers/surf/domain/activity/repository/ActivityRecordRepository.java
+++ b/src/main/java/com/tavemakers/surf/domain/activity/repository/ActivityRecordRepository.java
@@ -14,6 +14,10 @@ import java.util.List;
 @Repository
 public interface ActivityRecordRepository extends JpaRepository<ActivityRecord, Long> {
 
+    void deleteByMemberId(Long memberId);
+
+    void deleteByTeamId(Long teamId);
+
     @Query("SELECT ar " +
             "FROM ActivityRecord ar " +
             "WHERE ar.memberId = :memberId " +

--- a/src/main/java/com/tavemakers/surf/domain/badge/repository/MemberBadgeRepository.java
+++ b/src/main/java/com/tavemakers/surf/domain/badge/repository/MemberBadgeRepository.java
@@ -31,4 +31,6 @@ public interface MemberBadgeRepository extends JpaRepository<MemberBadge, Long> 
 
     // 배지 삭제 전 해당 배지 부여 기록 먼저 삭제
     void deleteByBadgeId(Long badgeId);
+
+    void deleteByMemberId(Long memberId);
 }

--- a/src/main/java/com/tavemakers/surf/domain/comment/repository/CommentLikeRepository.java
+++ b/src/main/java/com/tavemakers/surf/domain/comment/repository/CommentLikeRepository.java
@@ -17,6 +17,14 @@ public interface CommentLikeRepository extends JpaRepository<CommentLike, Long> 
     @Query("SELECT cl.member FROM CommentLike cl WHERE cl.comment.id = :commentId")
     List<Member> findMembersWhoLiked(@Param("commentId") Long commentId);
 
+    @Query("""
+        select cl
+        from CommentLike cl
+        join fetch cl.comment c
+        where cl.member.id = :memberId
+    """)
+    List<CommentLike> findAllByMemberId(@Param("memberId") Long memberId);
+
     /** 특정 댓글에 특정 회원이 좋아요를 눌렀는지 여부 */
     boolean existsByCommentAndMember(Comment comment, Member member);
 

--- a/src/main/java/com/tavemakers/surf/domain/comment/repository/CommentMentionRepository.java
+++ b/src/main/java/com/tavemakers/surf/domain/comment/repository/CommentMentionRepository.java
@@ -24,6 +24,11 @@ public interface CommentMentionRepository extends JpaRepository<CommentMention, 
     /** 특정 회원이 멘션된 CommentMention 목록 조회 */
     List<CommentMention> findAllByMentionedMember(Member member);
 
+    @Transactional
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM CommentMention cm WHERE cm.mentionedMember.id = :memberId")
+    void deleteAllByMentionedMemberId(@Param("memberId") Long memberId);
+
     /** 특정 댓글에 달린 멘션 데이터를 모두 삭제 (JPQL 명시) */
     @Transactional
     @Modifying(clearAutomatically = true)

--- a/src/main/java/com/tavemakers/surf/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/tavemakers/surf/domain/comment/repository/CommentRepository.java
@@ -1,6 +1,7 @@
 package com.tavemakers.surf.domain.comment.repository;
 
 import com.tavemakers.surf.domain.comment.entity.Comment;
+import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,6 +10,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
+    List<Comment> findAllByMemberId(Long memberId);
 
     /** 게시글 내 모든 댓글 + 대댓글 조회 (작성 시간순) */
     Slice<Comment> findByPostIdOrderByCreatedAtAsc(Long postId, Pageable pageable);

--- a/src/main/java/com/tavemakers/surf/domain/comment/service/CommentDeleteService.java
+++ b/src/main/java/com/tavemakers/surf/domain/comment/service/CommentDeleteService.java
@@ -1,8 +1,10 @@
 package com.tavemakers.surf.domain.comment.service;
 
+import com.tavemakers.surf.domain.comment.entity.Comment;
 import com.tavemakers.surf.domain.comment.repository.CommentLikeRepository;
 import com.tavemakers.surf.domain.comment.repository.CommentMentionRepository;
 import com.tavemakers.surf.domain.comment.repository.CommentRepository;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,5 +25,26 @@ public class CommentDeleteService {
         commentMentionRepository.deleteAllByPostId(postId);
         commentRepository.deleteRepliesByPostId(postId);
         commentRepository.deleteRootCommentsByPostId(postId);
+    }
+
+    /** 특정 회원이 남긴 댓글 삭제 (이미 삭제 예정인 게시글은 제외) */
+    @Transactional
+    public void deleteAllByMemberId(Long memberId, Set<Long> deletedPostIds) {
+        for (Comment comment : commentRepository.findAllByMemberId(memberId)) {
+            if (deletedPostIds.contains(comment.getPost().getId())) {
+                continue;
+            }
+            deleteComment(comment);
+        }
+    }
+
+    /** 댓글 단건 강제 삭제 */
+    @Transactional
+    public void deleteComment(Comment comment) {
+        commentRepository.detachChildren(comment.getId());
+        commentLikeRepository.deleteAllByComment(comment);
+        commentMentionRepository.deleteAllByComment(comment);
+        commentRepository.delete(comment);
+        comment.getPost().decreaseCommentCount();
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/comment/service/CommentLikeService.java
+++ b/src/main/java/com/tavemakers/surf/domain/comment/service/CommentLikeService.java
@@ -92,6 +92,17 @@ public class CommentLikeService {
                 .toList();
     }
 
+    /** 특정 회원이 누른 댓글 좋아요 전체 제거 */
+    @Transactional
+    public void removeAllByMemberId(Long memberId) {
+        for (CommentLike commentLike : commentLikeRepository.findAllByMemberId(memberId)) {
+            Comment comment = commentLike.getComment();
+            comment.decreaseLikeCount();
+            commentLikeRepository.delete(commentLike);
+            commentRepository.save(comment);
+        }
+    }
+
     /** 좋아요 생성시 알림 - 댓글 작성자에게 */
     protected void createNotificationAtCommentLike(
             Member member,

--- a/src/main/java/com/tavemakers/surf/domain/letter/repository/LetterRepository.java
+++ b/src/main/java/com/tavemakers/surf/domain/letter/repository/LetterRepository.java
@@ -10,4 +10,6 @@ import org.springframework.data.repository.query.Param;
 public interface LetterRepository extends JpaRepository<Letter, Long> {
     @Query("SELECT l FROM Letter l JOIN FETCH l.sender JOIN FETCH l.receiver WHERE l.sender.id = :senderId")
     Slice<Letter> findBySenderId(@Param("senderId") Long senderId, Pageable pageable);
+
+    void deleteBySenderIdOrReceiverId(Long senderId, Long receiverId);
 }

--- a/src/main/java/com/tavemakers/surf/domain/member/controller/AdminMemberController.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/controller/AdminMemberController.java
@@ -8,6 +8,7 @@ import com.tavemakers.surf.domain.member.dto.response.MemberRegistrationSliceRes
 import com.tavemakers.surf.domain.member.usecase.MemberAdminUsecase;
 import io.swagger.v3.oas.annotations.Operation;
 import com.tavemakers.surf.global.common.response.ApiResponse;
+import com.tavemakers.surf.global.util.SecurityUtils;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -41,6 +42,22 @@ public class AdminMemberController {
     ) {
         memberAdminUsecase.changeMembersRole(dto);
         return ApiResponse.response(HttpStatus.OK, "회원 역할이 성공적으로 변경되었습니다.",null);
+    }
+
+    @Operation(summary = "회원 제명", description = "가입 단계 회원을 하드 딜리트하고 블랙리스트에 등록합니다.")
+    @PatchMapping("/v1/admin/members/{memberId}/dismiss")
+    public ApiResponse<Void> dismissMember(@PathVariable Long memberId) {
+        Long actorId = SecurityUtils.getCurrentMemberId();
+        memberAdminUsecase.dismissMember(memberId, actorId);
+        return ApiResponse.response(HttpStatus.OK, MEMBER_DISMISS_SUCCESS.getMessage(), null);
+    }
+
+    @Operation(summary = "회원 퇴출", description = "회원을 소프트 딜리트하고 블랙리스트에 등록합니다.")
+    @PatchMapping("/v1/admin/members/{memberId}/expel")
+    public ApiResponse<Void> expelMember(@PathVariable Long memberId) {
+        Long actorId = SecurityUtils.getCurrentMemberId();
+        memberAdminUsecase.expelMember(memberId, actorId);
+        return ApiResponse.response(HttpStatus.OK, MEMBER_EXPEL_SUCCESS.getMessage(), null);
     }
 
     @Operation(summary = "가입신청 목록", description = "가입신청 목록을 조회합니다.")

--- a/src/main/java/com/tavemakers/surf/domain/member/controller/MemberSignupController.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/controller/MemberSignupController.java
@@ -3,6 +3,7 @@ package com.tavemakers.surf.domain.member.controller;
 import com.tavemakers.surf.domain.member.dto.request.MemberSignupReqDTO;
 import com.tavemakers.surf.domain.member.dto.response.MemberSignupResDTO;
 import com.tavemakers.surf.domain.member.exception.MemberAlreadyExistsException;
+import com.tavemakers.surf.domain.member.exception.MemberBlacklistedException;
 import com.tavemakers.surf.domain.member.dto.response.OnboardingCheckResDTO;
 import com.tavemakers.surf.domain.member.usecase.MemberUsecase;
 import com.tavemakers.surf.global.common.response.ApiResponse;
@@ -58,6 +59,9 @@ public class MemberSignupController {
             if (e instanceof MemberAlreadyExistsException) {
                 statusCode = 409;
                 errorReason = "MEMBER_ALREADY_EXISTS";
+            } else if (e instanceof MemberBlacklistedException) {
+                statusCode = 403;
+                errorReason = "MEMBER_BLACKLISTED";
             } else if (e instanceof IllegalArgumentException) {
                 statusCode = 400;
                 errorReason = "INVALID_ARGUMENT";

--- a/src/main/java/com/tavemakers/surf/domain/member/controller/ResponseMessage.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/controller/ResponseMessage.java
@@ -30,6 +30,10 @@ public enum ResponseMessage {
     // 약관 동의
     TERMS_AGREEMENT_SUCCESS("[약관 동의]를 완료했습니다."),
 
+    // 관리자 제재
+    MEMBER_DISMISS_SUCCESS("[회원 제명]을 완료했습니다."),
+    MEMBER_EXPEL_SUCCESS("[회원 퇴출]을 완료했습니다."),
+
     // 프로필 수정
     MYPAGE_PROFILE_UPDATE_SUCCESS("마이페이지에서 [프로필 정보]를 수정했습니다."),
 

--- a/src/main/java/com/tavemakers/surf/domain/member/entity/MemberBlacklist.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/entity/MemberBlacklist.java
@@ -1,0 +1,84 @@
+package com.tavemakers.surf.domain.member.entity;
+
+import com.tavemakers.surf.domain.member.entity.enums.MemberBlacklistActionType;
+import com.tavemakers.surf.global.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(
+        indexes = {
+                @Index(name = "idx_member_blacklist_kakao_id", columnList = "kakao_id"),
+                @Index(name = "idx_member_blacklist_email", columnList = "email"),
+                @Index(name = "idx_member_blacklist_phone_number", columnList = "phone_number")
+        }
+)
+public class MemberBlacklist extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_blacklist_id")
+    private Long id;
+
+    private Long memberId;
+
+    @Column(nullable = false)
+    private Long kakaoId;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private String email;
+
+    private String phoneNumber;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private MemberBlacklistActionType actionType;
+
+    @Column(nullable = false)
+    private Long processedBy;
+
+    @Builder
+    private MemberBlacklist(
+            Long memberId,
+            Long kakaoId,
+            String name,
+            String email,
+            String phoneNumber,
+            MemberBlacklistActionType actionType,
+            Long processedBy
+    ) {
+        this.memberId = memberId;
+        this.kakaoId = kakaoId;
+        this.name = name;
+        this.email = email;
+        this.phoneNumber = phoneNumber;
+        this.actionType = actionType;
+        this.processedBy = processedBy;
+    }
+
+    public static MemberBlacklist of(
+            Member member,
+            MemberBlacklistActionType actionType,
+            Long processedBy,
+            String normalizedEmail,
+            String normalizedPhoneNumber
+    ) {
+        return MemberBlacklist.builder()
+                .memberId(member.getId())
+                .kakaoId(member.getKakaoId())
+                .name(member.getName())
+                .email(normalizedEmail)
+                .phoneNumber(normalizedPhoneNumber)
+                .actionType(actionType)
+                .processedBy(processedBy)
+                .build();
+    }
+}

--- a/src/main/java/com/tavemakers/surf/domain/member/entity/enums/MemberBlacklistActionType.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/entity/enums/MemberBlacklistActionType.java
@@ -1,0 +1,6 @@
+package com.tavemakers.surf.domain.member.entity.enums;
+
+public enum MemberBlacklistActionType {
+    DISMISS,
+    EXPEL
+}

--- a/src/main/java/com/tavemakers/surf/domain/member/exception/ErrorMessage.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/exception/ErrorMessage.java
@@ -11,6 +11,8 @@ public enum ErrorMessage {
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 [회원]입니다."),
     MEMBER_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 존재하는 [회원]입니다."),
     INVALID_MEMBER_INFO(HttpStatus.BAD_REQUEST, "유효하지 않은 [회원 정보]입니다."),
+    MEMBER_BLACKLISTED(HttpStatus.FORBIDDEN, "블랙리스트에 등록된 [회원]은 가입할 수 없습니다."),
+    MEMBER_DISMISS_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "[승인된 회원]만 제명할 수 있습니다."),
     TRACK_NOT_FOUND(HttpStatus.NOT_FOUND, "회원의 [트랙]이 존재하지 않습니다."),
     CAREER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않은 [경력]입니다."),
     MEMBER_STATUS_CANNOT_CONVERT(HttpStatus.BAD_REQUEST, "잘못된 [MemberStatus]입니다."),

--- a/src/main/java/com/tavemakers/surf/domain/member/exception/MemberBlacklistedException.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/exception/MemberBlacklistedException.java
@@ -1,0 +1,11 @@
+package com.tavemakers.surf.domain.member.exception;
+
+import com.tavemakers.surf.global.common.exception.BaseException;
+
+import static com.tavemakers.surf.domain.member.exception.ErrorMessage.MEMBER_BLACKLISTED;
+
+public class MemberBlacklistedException extends BaseException {
+    public MemberBlacklistedException() {
+        super(MEMBER_BLACKLISTED.getStatus(), MEMBER_BLACKLISTED.getMessage());
+    }
+}

--- a/src/main/java/com/tavemakers/surf/domain/member/exception/MemberDismissNotAllowedException.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/exception/MemberDismissNotAllowedException.java
@@ -1,0 +1,11 @@
+package com.tavemakers.surf.domain.member.exception;
+
+import com.tavemakers.surf.global.common.exception.BaseException;
+
+import static com.tavemakers.surf.domain.member.exception.ErrorMessage.MEMBER_DISMISS_NOT_ALLOWED;
+
+public class MemberDismissNotAllowedException extends BaseException {
+    public MemberDismissNotAllowedException() {
+        super(MEMBER_DISMISS_NOT_ALLOWED.getStatus(), MEMBER_DISMISS_NOT_ALLOWED.getMessage());
+    }
+}

--- a/src/main/java/com/tavemakers/surf/domain/member/repository/MemberBlacklistRepository.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/repository/MemberBlacklistRepository.java
@@ -1,0 +1,15 @@
+package com.tavemakers.surf.domain.member.repository;
+
+import com.tavemakers.surf.domain.member.entity.MemberBlacklist;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MemberBlacklistRepository extends JpaRepository<MemberBlacklist, Long> {
+
+    boolean existsByKakaoId(Long kakaoId);
+
+    boolean existsByEmail(String email);
+
+    boolean existsByPhoneNumber(String phoneNumber);
+}

--- a/src/main/java/com/tavemakers/surf/domain/member/service/MemberBlacklistCreateService.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/service/MemberBlacklistCreateService.java
@@ -1,0 +1,54 @@
+package com.tavemakers.surf.domain.member.service;
+
+import com.tavemakers.surf.domain.member.entity.Member;
+import com.tavemakers.surf.domain.member.entity.MemberBlacklist;
+import com.tavemakers.surf.domain.member.entity.enums.MemberBlacklistActionType;
+import com.tavemakers.surf.domain.member.repository.MemberBlacklistRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import java.util.Locale;
+
+@Service
+@RequiredArgsConstructor
+public class MemberBlacklistCreateService {
+
+    private final MemberBlacklistRepository memberBlacklistRepository;
+
+    @Transactional
+    public void createIfAbsent(Member member, MemberBlacklistActionType actionType, Long processedBy) {
+        Long kakaoId = member.getKakaoId();
+        String normalizedEmail = normalizeEmail(member.getEmail());
+        String normalizedPhoneNumber = normalizePhoneNumber(member.getPhoneNumber());
+
+        if (isBlacklisted(kakaoId, normalizedEmail, normalizedPhoneNumber)) {
+            return;
+        }
+
+        memberBlacklistRepository.save(
+                MemberBlacklist.of(member, actionType, processedBy, normalizedEmail, normalizedPhoneNumber)
+        );
+    }
+
+    private boolean isBlacklisted(Long kakaoId, String email, String phoneNumber) {
+        return (kakaoId != null && memberBlacklistRepository.existsByKakaoId(kakaoId))
+                || (StringUtils.hasText(email) && memberBlacklistRepository.existsByEmail(email))
+                || (StringUtils.hasText(phoneNumber) && memberBlacklistRepository.existsByPhoneNumber(phoneNumber));
+    }
+
+    private String normalizeEmail(String email) {
+        if (!StringUtils.hasText(email)) {
+            return null;
+        }
+        return email.trim().toLowerCase(Locale.ROOT);
+    }
+
+    private String normalizePhoneNumber(String phoneNumber) {
+        if (!StringUtils.hasText(phoneNumber)) {
+            return null;
+        }
+        return phoneNumber.replaceAll("\\D", "");
+    }
+}

--- a/src/main/java/com/tavemakers/surf/domain/member/service/MemberBlacklistGetService.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/service/MemberBlacklistGetService.java
@@ -1,0 +1,45 @@
+package com.tavemakers.surf.domain.member.service;
+
+import com.tavemakers.surf.domain.member.exception.MemberBlacklistedException;
+import com.tavemakers.surf.domain.member.repository.MemberBlacklistRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import java.util.Locale;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MemberBlacklistGetService {
+
+    private final MemberBlacklistRepository memberBlacklistRepository;
+
+    public void validateNotBlacklisted(Long kakaoId, String email, String phoneNumber) {
+        String normalizedEmail = normalizeEmail(email);
+        String normalizedPhoneNumber = normalizePhoneNumber(phoneNumber);
+
+        boolean blacklisted = (kakaoId != null && memberBlacklistRepository.existsByKakaoId(kakaoId))
+                || (StringUtils.hasText(normalizedEmail) && memberBlacklistRepository.existsByEmail(normalizedEmail))
+                || (StringUtils.hasText(normalizedPhoneNumber) && memberBlacklistRepository.existsByPhoneNumber(normalizedPhoneNumber));
+
+        if (blacklisted) {
+            throw new MemberBlacklistedException();
+        }
+    }
+
+    private String normalizeEmail(String email) {
+        if (!StringUtils.hasText(email)) {
+            return null;
+        }
+        return email.trim().toLowerCase(Locale.ROOT);
+    }
+
+    private String normalizePhoneNumber(String phoneNumber) {
+        if (!StringUtils.hasText(phoneNumber)) {
+            return null;
+        }
+        return phoneNumber.replaceAll("\\D", "");
+    }
+}

--- a/src/main/java/com/tavemakers/surf/domain/member/service/MemberDismissService.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/service/MemberDismissService.java
@@ -1,0 +1,126 @@
+package com.tavemakers.surf.domain.member.service;
+
+import com.tavemakers.surf.domain.activity.repository.ActivityRecordRepository;
+import com.tavemakers.surf.domain.badge.repository.MemberBadgeRepository;
+import com.tavemakers.surf.domain.comment.service.CommentDeleteService;
+import com.tavemakers.surf.domain.comment.service.CommentLikeService;
+import com.tavemakers.surf.domain.comment.repository.CommentMentionRepository;
+import com.tavemakers.surf.domain.letter.repository.LetterRepository;
+import com.tavemakers.surf.domain.member.entity.Member;
+import com.tavemakers.surf.domain.member.entity.enums.MemberBlacklistActionType;
+import com.tavemakers.surf.domain.member.entity.enums.MemberStatus;
+import com.tavemakers.surf.domain.member.exception.MemberDismissNotAllowedException;
+import com.tavemakers.surf.domain.member.repository.CareerRepository;
+import com.tavemakers.surf.domain.member.repository.MemberRepository;
+import com.tavemakers.surf.domain.member.repository.TrackRepository;
+import com.tavemakers.surf.domain.notification.repository.DeviceTokenRepository;
+import com.tavemakers.surf.domain.notification.repository.NotificationRepository;
+import com.tavemakers.surf.domain.post.entity.Post;
+import com.tavemakers.surf.domain.post.repository.PostRepository;
+import com.tavemakers.surf.domain.post.service.like.PostLikeService;
+import com.tavemakers.surf.domain.post.service.post.PostDeleteUsecase;
+import com.tavemakers.surf.domain.post.service.search.RecentSearchService;
+import com.tavemakers.surf.domain.score.repository.PersonalActivityScoreRepository;
+import com.tavemakers.surf.domain.scrap.service.ScrapService;
+import com.tavemakers.surf.domain.team.entity.Team;
+import com.tavemakers.surf.domain.team.entity.TeamMember;
+import com.tavemakers.surf.domain.team.repository.TeamRepository;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MemberDismissService {
+
+    private final MemberRepository memberRepository;
+    private final TeamRepository teamRepository;
+    private final CareerRepository careerRepository;
+    private final TrackRepository trackRepository;
+    private final ActivityRecordRepository activityRecordRepository;
+    private final NotificationRepository notificationRepository;
+    private final DeviceTokenRepository deviceTokenRepository;
+    private final MemberBadgeRepository memberBadgeRepository;
+    private final PersonalActivityScoreRepository personalActivityScoreRepository;
+    private final LetterRepository letterRepository;
+    private final CommentMentionRepository commentMentionRepository;
+    private final MemberBlacklistCreateService memberBlacklistCreateService;
+    private final MemberWithdrawService memberWithdrawService;
+    private final RecentSearchService recentSearchService;
+    private final PostRepository postRepository;
+    private final PostDeleteUsecase postDeleteUsecase;
+    private final PostLikeService postLikeService;
+    private final ScrapService scrapService;
+    private final CommentDeleteService commentDeleteService;
+    private final CommentLikeService commentLikeService;
+
+    @Transactional
+    public void dismiss(Member member, Long processedBy) {
+        validateDismissible(member);
+
+        memberBlacklistCreateService.createIfAbsent(member, MemberBlacklistActionType.DISMISS, processedBy);
+        memberWithdrawService.disconnectMember(member);
+        recentSearchService.clearAll(member.getId());
+
+        cleanupTeams(member);
+
+        Set<Long> deletedPostIds = deleteOwnedPosts(member.getId());
+        postLikeService.unlikeAllByMemberId(member.getId());
+        scrapService.removeAllByMemberId(member.getId());
+        commentLikeService.removeAllByMemberId(member.getId());
+        commentDeleteService.deleteAllByMemberId(member.getId(), deletedPostIds);
+        commentMentionRepository.deleteAllByMentionedMemberId(member.getId());
+
+        letterRepository.deleteBySenderIdOrReceiverId(member.getId(), member.getId());
+        memberBadgeRepository.deleteByMemberId(member.getId());
+        activityRecordRepository.deleteByMemberId(member.getId());
+        notificationRepository.deleteByMemberId(member.getId());
+        deviceTokenRepository.deleteByMemberId(member.getId());
+        personalActivityScoreRepository.deleteByMemberId(member.getId());
+        careerRepository.deleteAll(careerRepository.findByMemberId(member.getId()));
+        trackRepository.deleteAll(trackRepository.findByMemberId(member.getId()));
+        memberRepository.delete(member);
+    }
+
+    private void validateDismissible(Member member) {
+        if (member.getStatus() != MemberStatus.APPROVED) {
+            throw new MemberDismissNotAllowedException();
+        }
+    }
+
+    private void cleanupTeams(Member member) {
+        for (Team team : teamRepository.findAllByMemberIdForDismissal(member.getId())) {
+            List<Member> otherMembers = team.getTeamMembers().stream()
+                    .map(TeamMember::getMember)
+                    .filter(teamMember -> !teamMember.getId().equals(member.getId()))
+                    .toList();
+
+            if (team.getLeader().getId().equals(member.getId())) {
+                if (otherMembers.isEmpty()) {
+                    activityRecordRepository.deleteByTeamId(team.getId());
+                    personalActivityScoreRepository.deleteByTeamId(team.getId());
+                    teamRepository.delete(team);
+                    continue;
+                }
+                team.changeLeader(otherMembers.get(0));
+            }
+
+            team.removeMember(member.getId());
+        }
+    }
+
+    private Set<Long> deleteOwnedPosts(Long memberId) {
+        List<Long> postIds = postRepository.findAllByMemberId(memberId).stream()
+                .map(Post::getId)
+                .toList();
+
+        for (Long postId : postIds) {
+            postDeleteUsecase.deletePost(postId);
+        }
+
+        return postIds.stream().collect(Collectors.toSet());
+    }
+}

--- a/src/main/java/com/tavemakers/surf/domain/member/service/MemberService.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/service/MemberService.java
@@ -15,6 +15,8 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class MemberService {
 
+    private final MemberBlacklistGetService memberBlacklistGetService;
+
     /** 자체 회원가입 신청 완료 */
     @Transactional
     public MemberSignupResDTO signup(
@@ -26,6 +28,8 @@ public class MemberService {
         final String normalizedPhone = request.getPhoneNumber() == null
                 ? null
                 : request.getPhoneNumber().replaceAll("\\D", "");
+
+        memberBlacklistGetService.validateNotBlacklisted(null, normalizedEmail, normalizedPhone);
 
         // 회원가입 정보 반영
         member.applySignup(request, normalizedEmail, normalizedPhone);

--- a/src/main/java/com/tavemakers/surf/domain/member/service/MemberUpsertService.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/service/MemberUpsertService.java
@@ -12,11 +12,14 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberUpsertService {
 
     private final MemberRepository memberRepository;
+    private final MemberBlacklistGetService memberBlacklistGetService;
 
     /** 카카오 정보로 회원 생성 또는 기존 회원 반환 */
     @Transactional
     public Member upsertRegisteringFromKakao(OAuthUserInfoDTO info) {
         Long kakaoId = Long.parseLong(info.oauthId());
+        memberBlacklistGetService.validateNotBlacklisted(kakaoId, info.email(), null);
+
         return memberRepository.findByKakaoId(kakaoId).orElseGet(() -> {
             Member toSave = Member.createRegisteringFromKakao(info);
             try {

--- a/src/main/java/com/tavemakers/surf/domain/member/service/MemberWithdrawService.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/service/MemberWithdrawService.java
@@ -37,14 +37,20 @@ public class MemberWithdrawService {
     @Transactional
     public void withdraw(Long memberId) {
         Member member = memberGetService.getMember(memberId);
+        expel(member);
+    }
 
-        refreshTokenService.invalidateAll(memberId);
-
-        unlinkKakao(member.getKakaoId());
-
+    @Transactional
+    public void expel(Member member) {
+        disconnectMember(member);
         if (member.getStatus() != MemberStatus.WITHDRAWN) {
             member.withdraw();
         }
+    }
+
+    public void disconnectMember(Member member) {
+        refreshTokenService.invalidateAll(member.getId());
+        unlinkKakao(member.getKakaoId());
     }
 
     private void unlinkKakao(Long kakaoId) {

--- a/src/main/java/com/tavemakers/surf/domain/member/usecase/MemberAdminUsecase.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/usecase/MemberAdminUsecase.java
@@ -6,6 +6,7 @@ import com.tavemakers.surf.domain.member.dto.request.PasswordReqDTO;
 import com.tavemakers.surf.domain.member.dto.request.RoleChangeReqDTOV2;
 import com.tavemakers.surf.domain.member.dto.response.*;
 import com.tavemakers.surf.domain.member.entity.Member;
+import com.tavemakers.surf.domain.member.entity.enums.MemberBlacklistActionType;
 import com.tavemakers.surf.domain.member.entity.enums.MemberRole;
 import com.tavemakers.surf.domain.member.entity.enums.MemberStatus;
 import com.tavemakers.surf.domain.member.exception.AdminPageRoleException;
@@ -38,12 +39,15 @@ public class MemberAdminUsecase {
     //<editor-fold desc="MemberAdminUsecase Dependency Summary">
     private final MemberPatchService memberPatchService;
     private final MemberGetService memberGetService;
+    private final MemberBlacklistCreateService memberBlacklistCreateService;
+    private final MemberDismissService memberDismissService;
     private final CareerGetService careerGetService;
     private final PersonalScoreCreateService personalScoreCreateService;
     private final PersonalScoreGetService scoreGetService;
     private final JwtService jwtService;
     private final RefreshTokenService refreshTokenService;
     private final TrackGetService trackGetService;
+    private final MemberWithdrawService memberWithdrawService;
     //</editor-fold>
 
     /** 회원 권한 변경 */
@@ -81,6 +85,29 @@ public class MemberAdminUsecase {
     ) {
         List<Member> members = memberGetService.getMembersByStatus(memberIds, MemberStatus.WAITING);
         members.forEach(Member::reject);
+    }
+
+    /** 회원 제명 처리 */
+    @Transactional
+    @LogEvent(value = "member.dismiss", message = "회원 제명 처리")
+    public void dismissMember(
+            @LogParam("member_id") Long memberId,
+            @LogParam("actor_id") Long actorId
+    ) {
+        Member member = memberGetService.getMember(memberId);
+        memberDismissService.dismiss(member, actorId);
+    }
+
+    /** 회원 퇴출 처리 */
+    @Transactional
+    @LogEvent(value = "member.expel", message = "회원 퇴출 처리")
+    public void expelMember(
+            @LogParam("member_id") Long memberId,
+            @LogParam("actor_id") Long actorId
+    ) {
+        Member member = memberGetService.getMember(memberId);
+        memberBlacklistCreateService.createIfAbsent(member, MemberBlacklistActionType.EXPEL, actorId);
+        memberWithdrawService.expel(member);
     }
 
     /** 관리자 비밀번호 설정 */

--- a/src/main/java/com/tavemakers/surf/domain/notification/repository/DeviceTokenRepository.java
+++ b/src/main/java/com/tavemakers/surf/domain/notification/repository/DeviceTokenRepository.java
@@ -12,4 +12,6 @@ public interface DeviceTokenRepository extends JpaRepository<DeviceToken, Long> 
 
     List<DeviceToken> findAllByMemberIdAndEnabledTrue(Long memberId);
 
+    void deleteByMemberId(Long memberId);
+
 }

--- a/src/main/java/com/tavemakers/surf/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/tavemakers/surf/domain/notification/repository/NotificationRepository.java
@@ -29,4 +29,6 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
     int markAsRead(@Param("id") Long id, @Param("memberId") Long memberId);
 
     boolean existsByIdAndMemberId(Long id, Long memberId);
+
+    void deleteByMemberId(Long memberId);
 }

--- a/src/main/java/com/tavemakers/surf/domain/post/repository/PostLikeRepository.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/repository/PostLikeRepository.java
@@ -19,6 +19,13 @@ public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
            select pl.post.id
            from PostLike pl
            where pl.member.id = :memberId
+           """)
+    List<Long> findPostIdsByMemberId(@Param("memberId") Long memberId);
+
+    @Query("""
+           select pl.post.id
+           from PostLike pl
+           where pl.member.id = :memberId
              and pl.post.id in :postIds
            """)
     Set<Long> findLikedPostIdsByMemberAndPostIds(Long memberId, Collection<Long> postIds);

--- a/src/main/java/com/tavemakers/surf/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/repository/PostRepository.java
@@ -1,6 +1,7 @@
 package com.tavemakers.surf.domain.post.repository;
 
 import com.tavemakers.surf.domain.post.entity.Post;
+import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,6 +10,8 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
+    List<Post> findAllByMemberId(Long memberId);
+
     Slice<Post> findByBoardId(Long boardId, Pageable pageable);
 
     Slice<Post> findByBoardIdAndCategoryId(Long boardId, Long categoryId, Pageable pageable);

--- a/src/main/java/com/tavemakers/surf/domain/post/service/like/PostLikeService.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/service/like/PostLikeService.java
@@ -13,6 +13,7 @@ import com.tavemakers.surf.global.logging.LogEvent;
 import com.tavemakers.surf.global.logging.LogEventContext;
 import com.tavemakers.surf.global.logging.LogParam;
 import jakarta.persistence.OptimisticLockException;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -98,6 +99,15 @@ public class PostLikeService {
     @Transactional(readOnly = true)
     public boolean isLikedByMe(Long memberId, Long postId) {
         return postLikeRepository.existsByPostIdAndMemberId(postId, memberId);
+    }
+
+    /** 특정 회원이 누른 게시글 좋아요 전체 제거 */
+    @Transactional
+    public void unlikeAllByMemberId(Long memberId) {
+        List<Long> postIds = postLikeRepository.findPostIdsByMemberId(memberId);
+        for (Long postId : postIds) {
+            unlike(postId, memberId);
+        }
     }
 
     /** 좋아요 생성시 알림 - 게시글 작성자에게 */

--- a/src/main/java/com/tavemakers/surf/domain/post/service/post/PostDeleteService.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/service/post/PostDeleteService.java
@@ -2,11 +2,14 @@ package com.tavemakers.surf.domain.post.service.post;
 
 import com.tavemakers.surf.domain.member.entity.Member;
 import com.tavemakers.surf.domain.member.service.MemberGetService;
+import com.tavemakers.surf.domain.post.entity.PostFileUrl;
 import com.tavemakers.surf.domain.post.entity.Post;
 import com.tavemakers.surf.domain.post.entity.PostImageUrl;
 import com.tavemakers.surf.domain.post.exception.PostDeleteAccessDeniedException;
 import com.tavemakers.surf.domain.post.repository.PostLikeRepository;
 import com.tavemakers.surf.domain.post.repository.PostRepository;
+import com.tavemakers.surf.domain.post.service.file.PostFileDeleteService;
+import com.tavemakers.surf.domain.post.service.file.PostFileGetService;
 import com.tavemakers.surf.domain.post.service.image.PostImageDeleteService;
 import com.tavemakers.surf.domain.post.service.image.PostImageGetService;
 import com.tavemakers.surf.global.logging.LogEvent;
@@ -30,6 +33,8 @@ public class PostDeleteService {
     private final PostGetService postGetService;
     private final PostImageGetService postImageGetService;
     private final PostImageDeleteService postImageDeleteService;
+    private final PostFileGetService postFileGetService;
+    private final PostFileDeleteService postFileDeleteService;
     private final MemberGetService memberGetService;
 
     /** 게시글 삭제 - Post 도메인 내부 데이터만 삭제 (좋아요, 이미지, 게시글) */
@@ -47,6 +52,11 @@ public class PostDeleteService {
         List<PostImageUrl> postImageUrls = postImageGetService.getPostImageUrls(post.getId());
         if (postImageUrls != null && !postImageUrls.isEmpty()) {
             postImageDeleteService.deleteAll(postImageUrls);
+        }
+
+        List<PostFileUrl> postFileUrls = postFileGetService.getPostFileUrls(post.getId());
+        if (postFileUrls != null && !postFileUrls.isEmpty()) {
+            postFileDeleteService.deleteAll(postFileUrls);
         }
 
         postRepository.delete(post);

--- a/src/main/java/com/tavemakers/surf/domain/post/service/post/PostDeleteUsecase.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/service/post/PostDeleteUsecase.java
@@ -2,6 +2,7 @@ package com.tavemakers.surf.domain.post.service.post;
 
 import com.tavemakers.surf.domain.comment.service.CommentDeleteService;
 import com.tavemakers.surf.domain.post.entity.Post;
+import com.tavemakers.surf.domain.reservation.repository.ReservationRepository;
 import com.tavemakers.surf.domain.schedule.service.ScheduleDeleteService;
 import com.tavemakers.surf.domain.scrap.service.ScrapGetService;
 import lombok.RequiredArgsConstructor;
@@ -18,6 +19,7 @@ public class PostDeleteUsecase {
     private final CommentDeleteService commentDeleteService;
     private final ScheduleDeleteService scheduleDeleteService;
     private final ScrapGetService scrapGetService;
+    private final ReservationRepository reservationRepository;
 
     /** 게시글 및 연관 데이터 삭제 */
     @Transactional
@@ -26,6 +28,7 @@ public class PostDeleteUsecase {
 
         // 연관 데이터 먼저 삭제
         scheduleDeleteService.deleteByPost(post);
+        reservationRepository.deleteByPostId(postId);
         scrapGetService.deleteByPostId(postId);
         commentDeleteService.deleteAllByPostId(postId);
 

--- a/src/main/java/com/tavemakers/surf/domain/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/tavemakers/surf/domain/reservation/repository/ReservationRepository.java
@@ -17,4 +17,6 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
 
     Optional<Reservation> findByPostIdAndStatus(Long postId, ReservationStatus status);
 
+    void deleteByPostId(Long postId);
+
 }

--- a/src/main/java/com/tavemakers/surf/domain/score/repository/PersonalActivityScoreRepository.java
+++ b/src/main/java/com/tavemakers/surf/domain/score/repository/PersonalActivityScoreRepository.java
@@ -16,4 +16,8 @@ public interface PersonalActivityScoreRepository extends JpaRepository<PersonalA
 
     List<PersonalActivityScore> findAllByTeamIdIn(List<Long> teamIds);
 
+    void deleteByMemberId(Long memberId);
+
+    void deleteByTeamId(Long teamId);
+
 }

--- a/src/main/java/com/tavemakers/surf/domain/scrap/repository/ScrapRepository.java
+++ b/src/main/java/com/tavemakers/surf/domain/scrap/repository/ScrapRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Set;
 
 public interface ScrapRepository extends JpaRepository<Scrap, Long> {
@@ -15,6 +16,13 @@ public interface ScrapRepository extends JpaRepository<Scrap, Long> {
     boolean existsByMemberIdAndPostId(Long memberId, Long postId);
 
     int deleteByMemberIdAndPostId(Long memberId, Long postId);
+
+    @Query("""
+           select s.post.id
+           from Scrap s
+           where s.member.id = :memberId
+           """)
+    List<Long> findPostIdsByMemberId(Long memberId);
 
     @Query(
             value = """
@@ -39,4 +47,6 @@ public interface ScrapRepository extends JpaRepository<Scrap, Long> {
     Set<Long> findScrappedPostIdsByMemberAndPostIds(Long memberId, Collection<Long> postIds);
 
     void deleteByPostId(Long postId);
+
+    void deleteByMemberId(Long memberId);
 }

--- a/src/main/java/com/tavemakers/surf/domain/scrap/service/ScrapService.java
+++ b/src/main/java/com/tavemakers/surf/domain/scrap/service/ScrapService.java
@@ -92,4 +92,13 @@ public class ScrapService {
 
         return result;
     }
+
+    /** 특정 회원의 스크랩 전체 제거 */
+    @Transactional
+    public void removeAllByMemberId(Long memberId) {
+        List<Long> postIds = scrapRepository.findPostIdsByMemberId(memberId);
+        for (Long postId : postIds) {
+            removeScrap(memberId, postId);
+        }
+    }
 }

--- a/src/main/java/com/tavemakers/surf/domain/team/repository/TeamRepository.java
+++ b/src/main/java/com/tavemakers/surf/domain/team/repository/TeamRepository.java
@@ -1,6 +1,7 @@
 package com.tavemakers.surf.domain.team.repository;
 
 import com.tavemakers.surf.domain.team.entity.Team;
+import com.tavemakers.surf.domain.team.entity.TeamMember;
 import com.tavemakers.surf.domain.team.entity.TeamType;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -32,4 +33,18 @@ public interface TeamRepository extends JpaRepository<Team, Long> {
     @EntityGraph(attributePaths = {"teamMembers", "teamMembers.member"})
     @Query("select distinct t from Team t where (:generation is null or t.generation = :generation)")
     List<Team> findTeamsWithMembers(@Param("generation") Integer generation);
+
+    @EntityGraph(attributePaths = {"leader", "teamMembers", "teamMembers.member"})
+    @Query("""
+        select distinct t
+        from Team t
+        where t.leader.id = :memberId
+           or exists (
+               select 1
+               from TeamMember tm
+               where tm.team = t
+                 and tm.member.id = :memberId
+           )
+    """)
+    List<Team> findAllByMemberIdForDismissal(@Param("memberId") Long memberId);
 }


### PR DESCRIPTION
Closes #308

## 승인회원 제명 / 퇴출 / 블랙리스트 구현 및 논의 포인트

이번 작업에서는 `승인된 회원(APPROVED)`에 대해 아래 두 가지 제재 흐름을 기준으로 구현을 진행했습니다.

- `제명`: 블랙리스트 저장 후 연관 활동 데이터를 포함한 **hard delete**
- `퇴출`: 블랙리스트 저장 후 계정 접근을 막는 **soft delete**

또한 재가입 방지를 위해 `블랙리스트`를 별도 저장하고,  
카카오 로그인 진입 시점과 회원가입 온보딩 시점에서 모두 차단하도록 반영했습니다.

### 전체 구조

```mermaid
flowchart TD
    A["관리자 제재 요청"] --> B{"제재 종류"}

    B -- "제명" --> C["블랙리스트 스냅샷 저장"]
    B -- "퇴출" --> D["블랙리스트 스냅샷 저장"]

    C --> E["인증/접속 차단<br/>- refresh token 무효화<br/>- 카카오 unlink<br/>- 최근 검색어 삭제"]
    D --> F["인증/접속 차단<br/>- refresh token 무효화<br/>- 카카오 unlink"]

    E --> G["팀 정리"]
    G --> G1{"제명 대상이 팀장인가?"}
    G1 -- "아니오" --> G2["팀에서 해당 회원 제거"]
    G1 -- "예" --> G3{"다른 팀원 존재?"}
    G3 -- "예" --> G4["다른 팀원에게 팀장 위임 후 제거"]
    G3 -- "아니오" --> G5["팀 삭제<br/>- 팀 점수/팀 활동기록도 함께 삭제"]

    G2 --> H["회원 작성 게시글 삭제"]
    G4 --> H
    G5 --> H
    H --> H1["게시글 연관 데이터 삭제<br/>- 댓글/대댓글<br/>- 스크랩<br/>- 좋아요<br/>- 예약/일정<br/>- 이미지/첨부파일"]
    H1 --> I["회원이 남긴 반응 데이터 삭제<br/>- 게시글 좋아요<br/>- 댓글 좋아요<br/>- 스크랩"]
    I --> J["회원이 남긴 댓글 삭제"]
    J --> K["회원 직속 데이터 삭제<br/>- track/career/badge/score<br/>- letter/notification/device token<br/>- activity record"]
    K --> L["member hard delete"]

    F --> M["member soft delete<br/>- status = WITHDRAWN<br/>- isDeleted = true<br/>- 개인정보 익명화"]
```

### 블랙리스트 기준

블랙리스트에는 아래 식별 정보를 스냅샷으로 저장합니다.

- `kakaoId`
- `email`
- `phoneNumber`
- `actionType` (`DISMISS` / `EXPEL`)
- `processedBy`

재가입 차단은 아래 두 시점에서 수행합니다.

```mermaid
flowchart LR
    A["카카오 로그인 콜백"] --> B["kakaoId / email 블랙리스트 검사"]
    B -->|차단| C["로그인/회원 생성 중단"]
    B -->|통과| D["REGISTERING upsert"]

    E["회원가입 온보딩 요청"] --> F["email / phoneNumber 블랙리스트 검사"]
    F -->|차단| G["회원가입 요청 거절"]
    F -->|통과| H["WAITING 전환 및 가입 요청 진행"]
```

### 현재 구현 기준

- `제명` 대상은 `APPROVED` 회원만 허용합니다.
- `퇴출`도 동일하게 블랙리스트에 등록하여 재가입을 막습니다.
- `제명` 시:
  - 팀장이고 다른 팀원이 있으면 첫 번째 다른 팀원에게 팀장을 위임합니다.
  - 팀장이고 다른 팀원이 없으면 팀 자체를 함께 삭제합니다.
  - 회원이 작성한 게시글은 hard delete 되며, 해당 게시글에 달린 댓글/대댓글도 함께 삭제됩니다.
  - 회원이 남긴 좋아요/스크랩/알림/활동기록 등 회원 기반 데이터도 함께 정리됩니다.
- `퇴출` 시:
  - 계정은 soft delete 됩니다.
  - 로그인/재가입은 블랙리스트로 차단됩니다.
  - 기존 활동 기록은 유지됩니다.

### 논의가 필요한 부분

현재 구현에서 **제명 회원이 다른 사람 게시글에 남긴 댓글**은 삭제되지만,  
그 댓글 아래에 **다른 사람이 작성한 대댓글**은 `parent` 연결만 끊고 남기도록 처리되어 있습니다.

즉, 아래 케이스가 남아 있습니다.

```mermaid
flowchart TD
    P["타인 게시글"] --> C1["제명 회원 댓글"]
    C1 --> C2["다른 회원 대댓글"]
    C2 --> C3["다른 회원의 추가 대댓글"]
```

현재 동작:

- `제명 회원 댓글(C1)`은 삭제
- `다른 회원 대댓글(C2, C3)`은 완전 삭제되지 않고, 상위 댓글 연결이 끊긴 상태로 남을 수 있음

### 확인 요청

아래 중 어떤 정책으로 갈지 결정이 필요합니다.

1. 제명 회원 댓글 아래 달린 **타인 대댓글까지 전부 삭제**
2. 제명 회원 본인 댓글만 삭제하고, **타인 대댓글은 orphan 형태로 유지**

만약 기획 의도가 “제명 회원 관련 흔적을 가능한 한 모두 제거”라면,  
`1번`으로 가는 것이 더 일관된 정책입니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **New Features**
  - 관리자용 회원 관리 기능 추가 (제명, 퇴출)
  - 회원 블랙리스트 시스템 도입으로 제명/퇴출된 회원의 재가입 차단

* **Improvements**
  - 회원 계정 제거 시 게시물, 댓글, 좋아요 등 관련 데이터 일괄 정리
  - 회원 생명주기 관리 및 상태 추적 개선
  - 회원 제거 시 알림, 배지 등 모든 관련 데이터 처리 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->