### PR TITLE
[Refactor]  배지 수정 API 부분 업데이트 개선

### DIFF
--- a/src/main/java/com/tavemakers/surf/domain/badge/controller/BadgeUpdateController.java
+++ b/src/main/java/com/tavemakers/surf/domain/badge/controller/BadgeUpdateController.java
@@ -19,7 +19,7 @@ public class BadgeUpdateController {
 
     private final BadgeUsecase badgeUsecase;
 
-    @Operation(summary = "배지 수정", description = "기존 배지 정보를 수정합니다.")
+    @Operation(summary = "배지 (부분) 수정", description = "기존 배지 정보를 수정합니다. 일부 필드 수정 요청도 가능합니다.")
     @PatchMapping("/v1/admin/badges/{badgeId}")
     public ApiResponse<Void> updateBadge(
             @PathVariable Long badgeId,

--- a/src/main/java/com/tavemakers/surf/domain/badge/dto/request/BadgeUpdateReqDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/badge/dto/request/BadgeUpdateReqDTO.java
@@ -1,7 +1,6 @@
 package com.tavemakers.surf.domain.badge.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
 
@@ -9,21 +8,17 @@ import lombok.Getter;
 public class BadgeUpdateReqDTO {
 
     @Schema(description = "수정할 배지 이름", example = "16기 우수회원 (1위)")
-    @NotBlank
     @Size(max = 100)
     private String name;
 
     @Schema(description = "수정할 배지 이미지 URL", example = "https://example.png")
-    @NotBlank
     @Size(max = 255)
     private String imageUrl;
 
     @Schema(description = "수정할 배지 설명", example = "한 기수 동안 우수한 활동을 한 회원에게 수여되는 배지입니다.")
-    @NotBlank
     private String description;
 
     @Schema(description = "수정할 배지 획득 조건", example = "활동점수 1위")
-    @NotBlank
     @Size(max = 255)
     private String requirement;
 }

--- a/src/main/java/com/tavemakers/surf/domain/badge/entity/Badge.java
+++ b/src/main/java/com/tavemakers/surf/domain/badge/entity/Badge.java
@@ -35,9 +35,21 @@ public class Badge {
     }
 
     public void update(String name, String imageUrl, String description, String requirement) {
-        this.name = name;
-        this.imageUrl = imageUrl;
-        this.description = description;
-        this.requirement = requirement;
+
+        if (name != null && !name.isBlank()) {
+            this.name = name;
+        }
+
+        if (imageUrl != null && !imageUrl.isBlank()) {
+            this.imageUrl = imageUrl;
+        }
+
+        if (description != null && !description.isBlank()) {
+            this.description = description;
+        }
+
+        if (requirement != null && !requirement.isBlank()) {
+            this.requirement = requirement;
+        }
     }
 }


### PR DESCRIPTION
## 📄 작업 내용 요약
> 배지 수정 API (`/v1/admin/badges/{badgeId}`)가 `PATCH`임에도 부분적인 업데이트가 불가하여, 부분 업데이트도 가능하도록 하였습니다. 

- BadgeUpdateReqDTO에서 `@NotBlank` 제거하여 선택적 필드 전달 허용
- Badge 엔티티 update 메서드에 `null/blank` 체크 추가 (데이터 유실 방지)
- Swagger 설명을 `PATCH`에 맞게 수정

예를 들어, 이전에는 이렇게 모든 필드에 값이 있어야 수정이 가능했지만
```
{
  "name": "16기 우수회원 (1위)",
  "imageUrl": "https://example.png",
  "description": "한 기수 동안 우수한 활동을 한 회원에게 수여되는 배지입니다.",
  "requirement": "활동점수 1위"
}
```

이제는 아래와 같이 수정하고 싶은 일부 필드 값만 있어도 수정이 가능합니다. 
```
{
  "name": "20기 우수회원 (1위)",
  "imageUrl": "https://exampleeeee.png"
}
```

또한 수정할 때 필드 값이 `null`이면 수정에 반영되지 않습니다.

## 📎 Issue 번호
closed #310 