### PR TITLE
[FIX] 회원 제명 시 team_member FK 위반으로 500 발생 #317

### DIFF
--- a/src/main/java/com/tavemakers/surf/domain/member/usecase/MemberDismissUsecase.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/usecase/MemberDismissUsecase.java
@@ -26,6 +26,7 @@ import com.tavemakers.surf.domain.score.repository.PersonalActivityScoreReposito
 import com.tavemakers.surf.domain.scrap.service.ScrapService;
 import com.tavemakers.surf.domain.team.entity.Team;
 import com.tavemakers.surf.domain.team.entity.TeamMember;
+import com.tavemakers.surf.domain.team.repository.TeamMemberRepository;
 import com.tavemakers.surf.domain.team.repository.TeamRepository;
 import java.util.List;
 import java.util.Set;
@@ -40,6 +41,7 @@ public class MemberDismissUsecase {
 
     private final MemberRepository memberRepository;
     private final TeamRepository teamRepository;
+    private final TeamMemberRepository teamMemberRepository;
     private final CareerRepository careerRepository;
     private final TrackRepository trackRepository;
     private final ActivityRecordRepository activityRecordRepository;
@@ -69,6 +71,7 @@ public class MemberDismissUsecase {
         recentSearchService.clearAll(member.getId());
 
         cleanupTeams(member);
+        teamMemberRepository.deleteAllByMemberId(member.getId());
 
         Set<Long> deletedPostIds = deleteOwnedPosts(member.getId());
         postLikeService.unlikeAllByMemberId(member.getId());

--- a/src/main/java/com/tavemakers/surf/domain/team/repository/TeamMemberRepository.java
+++ b/src/main/java/com/tavemakers/surf/domain/team/repository/TeamMemberRepository.java
@@ -1,0 +1,15 @@
+package com.tavemakers.surf.domain.team.repository;
+
+import com.tavemakers.surf.domain.team.entity.TeamMember;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface TeamMemberRepository extends JpaRepository<TeamMember, Long> {
+
+    /** 회원 제명 안전망 — Team 컬렉션 처리에서 누락된 team_member 행 직접 정리 */
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("DELETE FROM TeamMember tm WHERE tm.member.id = :memberId")
+    void deleteAllByMemberId(@Param("memberId") Long memberId);
+}


### PR DESCRIPTION
## 관련 이슈
Close #317

## 문제 상황
`PATCH /v1/admin/members/{memberId}/dismiss` 호출 시 일부 회원에서 500 에러 발생

```
Cannot delete or update a parent row: a foreign key constraint fails
(tave_surf.team_member, FOREIGN KEY (member_id) REFERENCES member (member_id))
[delete from member where member_id=?]
```

## 원인
`MemberDismissUsecase.dismiss`의 마지막 단계 `memberRepository.delete(member)` 직전, `cleanupTeams(member)`가 일부 케이스에서 `team_member` 행을 정리하지 못함.

기존 구조는 `Team.teamMembers` 컬렉션(`@OneToMany ... orphanRemoval = true`) 조작에만 의존하기 때문에:
- EntityGraph 페치 결과에 대상 행이 빠져 있거나
- dismiss 흐름 중 `@Modifying(clearAutomatically=true)` 호출(예: `PostLikeRepository.deleteAllByMemberId`)로 영속성 컨텍스트가 비워지는 시점에 dirty 컬렉션 변경이 flush 사이클에서 누락되는 경우

`team_member.member_id`를 참조하는 행이 살아남은 채로 `delete from member` 실행 → FK 위반.

## 변경 내용
- `TeamMemberRepository` 추가
  - `deleteAllByMemberId(memberId)` — `@Modifying(clearAutomatically=true, flushAutomatically=true)`
  - 기존 `PostLikeRepository.deleteAllByMemberId`와 동일 패턴
- `MemberDismissUsecase.dismiss`에서 `cleanupTeams(member)` 직후 `teamMemberRepository.deleteAllByMemberId(member.getId())` 호출
- 기존 `cleanupTeams` 도메인 로직(리더 위임 / 팀 통째 삭제)은 그대로 유지, 안전망만 추가

## 동작 의미
- `flushAutomatically=true`: 컬렉션 조작 결과가 native delete 전에 DB에 반영
- `clearAutomatically=true`: 영속성 컨텍스트의 stale entity 정리
- 컬렉션 매핑/페치 결과와 무관하게 DB에서 직접 잔존 행 삭제 → FK 위반 차단

## 운영 데이터 정리 (필수 후속 작업)
영향받은 회원은 expel만 성공하고 dismiss는 실패한 어정쩡한 상태입니다. 잔존 행 직접 정리 필요:
```sql
SELECT * FROM team_member WHERE member_id = <memberId>;
DELETE FROM team_member WHERE id = <tmId>;
```

확인된 사례: 회원 19, team_member id=79 (team_id=35)

## 테스트
- [ ] dismiss API 재호출 시 정상 200 응답 확인
- [ ] 일반 팀원 케이스
- [ ] 팀장 + 다른 팀원 있음 (위임)
- [ ] 팀장 + 본인 혼자 (팀 삭제)
- [ ] 팀에 속하지 않은 회원

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
- 회원이 시스템에서 삭제될 때 팀 멤버 연관 데이터가 완전히 정리되도록 개선했습니다.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Tave-Makers/SURF-BE/pull/318)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->