### PR TITLE
[BUG] Apple 앱 로그인 시 authorizationCode 미수신으로 탈퇴 revoke 불가 #319

### DIFF
--- a/src/main/java/com/tavemakers/surf/domain/auth/apple/dto/AppleAppLoginReqDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/auth/apple/dto/AppleAppLoginReqDTO.java
@@ -18,6 +18,6 @@ public record AppleAppLoginReqDTO(
         @Schema(description = "사용자 이름 — Apple SDK 최초 로그인 시에만 제공. 이후 null.")
         String name,
 
-        @Schema(description = "Apple SDK 인가 코드 — 탈퇴 시 /auth/revoke 호출을 위해 서버에서 refresh_token 교환에 사용. 매 로그인 시 전달 필수.")
+        @Schema(description = "Apple SDK 인가 코드 — 탈퇴 시 /auth/revoke 호출을 위해 refresh_token 교환에 사용. 미전달 시 탈퇴 revoke 불가. 매 로그인 시 전달 권장.")
         String authorizationCode
 ) {}

--- a/src/main/java/com/tavemakers/surf/domain/auth/apple/dto/AppleAppLoginReqDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/auth/apple/dto/AppleAppLoginReqDTO.java
@@ -16,5 +16,8 @@ public record AppleAppLoginReqDTO(
         String nonce,
 
         @Schema(description = "사용자 이름 — Apple SDK 최초 로그인 시에만 제공. 이후 null.")
-        String name
+        String name,
+
+        @Schema(description = "Apple SDK 인가 코드 — 탈퇴 시 /auth/revoke 호출을 위해 서버에서 refresh_token 교환에 사용. 매 로그인 시 전달 필수.")
+        String authorizationCode
 ) {}

--- a/src/main/java/com/tavemakers/surf/domain/auth/apple/service/AppleApiClient.java
+++ b/src/main/java/com/tavemakers/surf/domain/auth/apple/service/AppleApiClient.java
@@ -37,26 +37,50 @@ public class AppleApiClient {
 
     /** 인가 코드로 Apple /auth/token 호출 — id_token 포함 응답 반환 */
     public AppleTokenResDTO exchangeCodeForToken(String code) {
-        log.info("[APPLE][TOKEN] exchange start");
-        try {
-            String url = "https://appleid.apple.com/auth/token";
+        return doExchange("[APPLE][TOKEN]", code,
+                props.getServiceClientId(), clientSecretGenerator.generate(), props.getRedirectUri());
+    }
 
+    /** App authorizationCode 교환 — client_id=appBundleId, redirect_uri 없음 */
+    public AppleTokenResDTO exchangeAppCodeForToken(String code) {
+        return doExchange("[APPLE][TOKEN][APP]", code,
+                props.getAppBundleId(), clientSecretGenerator.generateForApp(), null);
+    }
+
+    /** Web 계정 연결 해제 — client_id=serviceClientId */
+    public void revokeToken(String refreshToken) {
+        doRevoke("[APPLE][REVOKE]", refreshToken,
+                props.getServiceClientId(), clientSecretGenerator.generate());
+    }
+
+    /** App 계정 연결 해제 — client_id=appBundleId */
+    public void revokeAppToken(String refreshToken) {
+        doRevoke("[APPLE][REVOKE][APP]", refreshToken,
+                props.getAppBundleId(), clientSecretGenerator.generateForApp());
+    }
+
+    private AppleTokenResDTO doExchange(String logPrefix, String code, String clientId, String clientSecret, String redirectUri) {
+        log.info("{} exchange start", logPrefix);
+        try {
             HttpHeaders headers = new HttpHeaders();
             headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
 
             MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
-            params.add("client_id", props.getServiceClientId());
-            params.add("client_secret", clientSecretGenerator.generate());
+            params.add("client_id", clientId);
+            params.add("client_secret", clientSecret);
             params.add("code", code);
             params.add("grant_type", "authorization_code");
-            params.add("redirect_uri", props.getRedirectUri());
+            if (redirectUri != null) {
+                params.add("redirect_uri", redirectUri);
+            }
 
-            HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(params, headers);
-            ResponseEntity<AppleTokenResDTO> response =
-                    appleRestTemplate.postForEntity(url, request, AppleTokenResDTO.class);
+            ResponseEntity<AppleTokenResDTO> response = appleRestTemplate.postForEntity(
+                    "https://appleid.apple.com/auth/token",
+                    new HttpEntity<>(params, headers),
+                    AppleTokenResDTO.class
+            );
 
-            log.info("[APPLE][TOKEN] exchange success status={}", response.getStatusCode());
-
+            log.info("{} exchange success status={}", logPrefix, response.getStatusCode());
             return Optional.ofNullable(response.getBody())
                     .orElseThrow(() -> new AppleAuthException(
                             AppleAuthErrorMessage.APPLE_TOKEN_EXCHANGE_FAILED.getStatus(),
@@ -65,13 +89,13 @@ public class AppleApiClient {
         } catch (AppleAuthException e) {
             throw e;
         } catch (HttpClientErrorException | HttpServerErrorException e) {
-            log.error("[APPLE][TOKEN] apple error status={} body={}", e.getStatusCode(), e.getResponseBodyAsString());
+            log.error("{} apple error status={} body={}", logPrefix, e.getStatusCode(), e.getResponseBodyAsString());
             throw new AppleAuthException(
                     AppleAuthErrorMessage.APPLE_TOKEN_EXCHANGE_FAILED.getStatus(),
                     AppleAuthErrorMessage.APPLE_TOKEN_EXCHANGE_FAILED.getMessage()
             );
         } catch (Exception e) {
-            log.error("[APPLE][TOKEN] unexpected error", e);
+            log.error("{} unexpected error", logPrefix, e);
             throw new AppleAuthException(
                     AppleAuthErrorMessage.APPLE_TOKEN_EXCHANGE_FAILED.getStatus(),
                     AppleAuthErrorMessage.APPLE_TOKEN_EXCHANGE_FAILED.getMessage()
@@ -79,29 +103,29 @@ public class AppleApiClient {
         }
     }
 
-    /** Apple 계정 연결 해제 — 탈퇴 시 refresh_token 폐기. 실패해도 탈퇴 트랜잭션은 롤백하지 않는다. */
-    public void revokeToken(String refreshToken) {
-        log.info("[APPLE][REVOKE] start");
+    private void doRevoke(String logPrefix, String refreshToken, String clientId, String clientSecret) {
+        log.info("{} start", logPrefix);
         try {
-            String url = "https://appleid.apple.com/auth/revoke";
-
             HttpHeaders headers = new HttpHeaders();
             headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
 
             MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
-            params.add("client_id", props.getServiceClientId());
-            params.add("client_secret", clientSecretGenerator.generate());
+            params.add("client_id", clientId);
+            params.add("client_secret", clientSecret);
             params.add("token", refreshToken);
             params.add("token_type_hint", "refresh_token");
 
-            HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(params, headers);
-            appleRestTemplate.postForEntity(url, request, String.class);
+            appleRestTemplate.postForEntity(
+                    "https://appleid.apple.com/auth/revoke",
+                    new HttpEntity<>(params, headers),
+                    String.class
+            );
 
-            log.info("[APPLE][REVOKE] success");
+            log.info("{} success", logPrefix);
         } catch (HttpClientErrorException | HttpServerErrorException e) {
-            log.error("[APPLE][REVOKE] 실패: status={}, body={}", e.getStatusCode(), e.getResponseBodyAsString(), e);
+            log.error("{} 실패: status={}, body={}", logPrefix, e.getStatusCode(), e.getResponseBodyAsString(), e);
         } catch (Exception e) {
-            log.error("[APPLE][REVOKE] 예기치 못한 오류", e);
+            log.error("{} 예기치 못한 오류", logPrefix, e);
         }
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/auth/apple/service/AppleApiClient.java
+++ b/src/main/java/com/tavemakers/surf/domain/auth/apple/service/AppleApiClient.java
@@ -47,13 +47,13 @@ public class AppleApiClient {
                 props.getAppBundleId(), clientSecretGenerator.generateForApp(), null);
     }
 
-    /** Web 계정 연결 해제 — client_id=serviceClientId */
+    /** Apple 계정 연결 해제 (Web 흐름) — client_id=serviceClientId  */
     public void revokeToken(String refreshToken) {
         doRevoke("[APPLE][REVOKE]", refreshToken,
                 props.getServiceClientId(), clientSecretGenerator.generate());
     }
 
-    /** App 계정 연결 해제 — client_id=appBundleId */
+    /** Apple 계정 연결 해제 (App 흐름) — client_id=appBundleId */
     public void revokeAppToken(String refreshToken) {
         doRevoke("[APPLE][REVOKE][APP]", refreshToken,
                 props.getAppBundleId(), clientSecretGenerator.generateForApp());

--- a/src/main/java/com/tavemakers/surf/domain/auth/apple/service/AppleAuthService.java
+++ b/src/main/java/com/tavemakers/surf/domain/auth/apple/service/AppleAuthService.java
@@ -37,9 +37,14 @@ public class AppleAuthService {
                 .toUriString();
     }
 
-    /** 인가 코드로 Apple 토큰 교환 */
+    /** Web 인가 코드로 Apple 토큰 교환 */
     public AppleTokenResDTO exchangeCodeForToken(String code) {
         return appleApiClient.exchangeCodeForToken(code);
+    }
+
+    /** App 인가 코드로 Apple 토큰 교환 — client_id=appBundleId, redirect_uri 없음 */
+    public AppleTokenResDTO exchangeAppCodeForToken(String code) {
+        return appleApiClient.exchangeAppCodeForToken(code);
     }
 
     /** Apple 콜백 로그 */

--- a/src/main/java/com/tavemakers/surf/domain/auth/apple/service/AppleClientSecretGenerator.java
+++ b/src/main/java/com/tavemakers/surf/domain/auth/apple/service/AppleClientSecretGenerator.java
@@ -56,8 +56,17 @@ public class AppleClientSecretGenerator {
         }
     }
 
-    /** Apple /auth/token 호출용 client_secret JWT를 생성한다 (ES256, exp 5분). */
+    /** Web 흐름용 client_secret — sub = serviceClientId */
     public String generate() {
+        return generateWithSubject(props.getServiceClientId());
+    }
+
+    /** App 흐름용 client_secret — sub = appBundleId */
+    public String generateForApp() {
+        return generateWithSubject(props.getAppBundleId());
+    }
+
+    private String generateWithSubject(String subject) {
         if (privateKey == null) {
             throw new AppleAuthException(
                     AppleAuthErrorMessage.APPLE_TOKEN_EXCHANGE_FAILED.getStatus(),
@@ -74,7 +83,7 @@ public class AppleClientSecretGenerator {
                     .issueTime(new Date(now * 1000))
                     .expirationTime(new Date((now + 300) * 1000))
                     .audience(List.of("https://appleid.apple.com"))
-                    .subject(props.getServiceClientId())
+                    .subject(subject)
                     .build();
             SignedJWT jwt = new SignedJWT(header, claims);
             jwt.sign(new ECDSASigner(privateKey));

--- a/src/main/java/com/tavemakers/surf/domain/auth/apple/usecase/AppleLoginUsecase.java
+++ b/src/main/java/com/tavemakers/surf/domain/auth/apple/usecase/AppleLoginUsecase.java
@@ -65,7 +65,7 @@ public class AppleLoginUsecase {
 
     /**
      * Apple SDK 앱 로그인 처리 (iOS identityToken 직접 검증).
-     * @param req        identityToken + nonce 원문 (+ name 최초 로그인 시)
+     * @param req        identityToken + nonce 원문 (+ name 최초 로그인 시 + authorizationCode)
      * @param clientType resolver 주입 — APP=본문 RefreshToken 전달
      */
     @Transactional
@@ -78,6 +78,18 @@ public class AppleLoginUsecase {
         );
 
         Member member = memberUpsertService.upsertRegisteringFromOAuth(Provider.APPLE, userInfo);
+
+        // authorizationCode로 Apple refresh_token 교환 후 저장 — 탈퇴 시 /auth/revoke 호출에 사용
+        if (req.authorizationCode() != null && !req.authorizationCode().isBlank()) {
+            AppleTokenResDTO appleToken = appleAuthService.exchangeCodeForToken(req.authorizationCode());
+            if (appleToken.refreshToken() != null) {
+                member.updateAppleRefreshToken(appleToken.refreshToken());
+                log.info("[LOGIN][APPLE][APP] refresh_token 저장 완료 memberId={}", member.getId());
+            }
+        } else {
+            log.warn("[LOGIN][APPLE][APP] authorizationCode 미전달 — 탈퇴 시 revoke 불가 memberId={}", member.getId());
+        }
+
         LoginPayloadResDTO payload = loginTokenIssuer.issue(member, userInfo, clientType, request);
 
         String accessToken = payload.loginRes().accessToken();

--- a/src/main/java/com/tavemakers/surf/domain/auth/apple/usecase/AppleLoginUsecase.java
+++ b/src/main/java/com/tavemakers/surf/domain/auth/apple/usecase/AppleLoginUsecase.java
@@ -81,10 +81,12 @@ public class AppleLoginUsecase {
 
         // authorizationCode로 Apple refresh_token 교환 후 저장 — 탈퇴 시 /auth/revoke 호출에 사용
         if (req.authorizationCode() != null && !req.authorizationCode().isBlank()) {
-            AppleTokenResDTO appleToken = appleAuthService.exchangeCodeForToken(req.authorizationCode());
+            AppleTokenResDTO appleToken = appleAuthService.exchangeAppCodeForToken(req.authorizationCode());
             if (appleToken.refreshToken() != null) {
                 member.updateAppleRefreshToken(appleToken.refreshToken());
                 log.info("[LOGIN][APPLE][APP] refresh_token 저장 완료 memberId={}", member.getId());
+            } else {
+                log.warn("[LOGIN][APPLE][APP] Apple이 refresh_token 미반환 — 탈퇴 시 revoke 불가 memberId={}", member.getId());
             }
         } else {
             log.warn("[LOGIN][APPLE][APP] authorizationCode 미전달 — 탈퇴 시 revoke 불가 memberId={}", member.getId());

--- a/src/main/java/com/tavemakers/surf/domain/member/entity/Member.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/entity/Member.java
@@ -64,7 +64,7 @@ public class Member extends BaseEntity {
     @Column
     private String name;
 
-    /** Apple 계정 탈퇴(revoke) 시 사용. Web 로그인 최초 코드 교환 시 저장, 탈퇴 시 null 처리. */
+    /** Apple 계정 탈퇴(revoke) 시 사용. 로그인 시 코드 교환 후 저장, 탈퇴 시 null 처리. */
     @Column(name = "apple_refresh_token", length = 1024)
     private String appleRefreshToken;
 
@@ -361,7 +361,7 @@ public class Member extends BaseEntity {
         this.appleRefreshToken = null;
     }
 
-    /** Apple refresh_token 갱신 — Web 로그인 코드 교환 시 호출 */
+    /** Apple refresh_token 갱신 — 로그인 코드 교환 시 호출 */
     public void updateAppleRefreshToken(String refreshToken) {
         this.appleRefreshToken = refreshToken;
     }

--- a/src/main/java/com/tavemakers/surf/domain/member/service/MemberWithdrawService.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/service/MemberWithdrawService.java
@@ -64,10 +64,12 @@ public class MemberWithdrawService {
 
     private void revokeApple(String appleRefreshToken) {
         if (appleRefreshToken == null) {
-            // App 로그인 회원은 authorizationCode 미전달로 refresh_token 미보유 → revoke 생략
-            log.warn("[APPLE][REVOKE] appleRefreshToken 없음 — revoke 생략 (App 로그인 회원)");
+            log.warn("[APPLE][REVOKE] appleRefreshToken 없음 — revoke 생략");
             return;
         }
+        // App(Bundle ID) 기준으로 먼저 시도, 이후 Web(Service ID) 기준으로 시도
+        // Apple /auth/revoke는 잘못된 client_id로 호출해도 HTTP 200을 반환하므로 에러 로그 오염 없음
+        appleApiClient.revokeAppToken(appleRefreshToken);
         appleApiClient.revokeToken(appleRefreshToken);
     }
 


### PR DESCRIPTION
## 📄 작업 내용 요약

Apple 앱 로그인 시 `authorizationCode` 수신·교환·저장 로직 추가와, App/Web 흐름 간 `client_id` 혼용 버그 수정을 통해 탈퇴 시 Apple 계정 연결 해제(revoke)를 정상 동작하도록 수정합니다.

---

## 1. 한 줄 요약

Apple 앱 로그인(`POST /login/apple/app`)에서 `authorizationCode` 미수신 및 `client_id` 혼용으로 인해 탈퇴 시 `/auth/revoke`가 호출되지 않던 문제를 수정합니다.

---

## 2. 작업 배경

| | |
|---|---|
| **Apple DPLA 의무** | Sign in with Apple을 사용하는 앱은 계정 삭제 시 `https://appleid.apple.com/auth/revoke` API를 반드시 호출해야 함. 미이행 시 App Store 심사 거절 가능 |
| **버그 1 — authorizationCode 미수신** | App 로그인은 `authorizationCode`를 수신하지 않아 `apple_refresh_token` 컬럼이 항상 `null` → 탈퇴 시 revoke 생략 |
| **버그 2 — client_id 혼용** | `exchangeCodeForToken()`이 Web 전용(`client_id=serviceClientId`, `redirect_uri` 포함)으로 설계됐으나 App 흐름에 그대로 재사용 → Apple API `invalid_client` 오류 → 토큰 교환 실패, 로그인 불가 |

---

## 3. 설계 결정과 의도

### 3-1. App/Web 교환 메서드 분리

Apple `/auth/token` 교환 파라미터가 흐름에 따라 다르므로 메서드를 분리한다.

| 파라미터 | Web 교환 | App 교환 |
|---|---|---|
| `client_id` | `serviceClientId` | `appBundleId` |
| `client_secret` sub | `serviceClientId` | `appBundleId` |
| `redirect_uri` | 포함 | **포함하면 안 됨** |

`AppleClientSecretGenerator`는 공통 로직을 `generateWithSubject(subject)`로 추출하고 `generate()`(Web) / `generateForApp()`(App)으로 분리한다.

### 3-2. `authorizationCode` nullable 처리

Apple SDK는 매 로그인 시 `authorizationCode`를 제공한다. DTO 필드는 `nullable`로 선언해 기존 클라이언트와의 하위 호환을 유지하되, 미전달 시 경고 로그를 남겨 모니터링한다.

```java
if (req.authorizationCode() != null && !req.authorizationCode().isBlank()) {
    AppleTokenResDTO appleToken = appleAuthService.exchangeAppCodeForToken(req.authorizationCode());
    if (appleToken.refreshToken() != null) {
        member.updateAppleRefreshToken(appleToken.refreshToken());
    }
} else {
    log.warn("[LOGIN][APPLE][APP] authorizationCode 미전달 — 탈퇴 시 revoke 불가 memberId={}", member.getId());
}
```

### 3-3. try-catch 미사용 — GlobalExceptionHandler 정책 준수

`authorizationCode` 교환 실패(`AppleAuthException`)는 try-catch로 감싸지 않고 `GlobalExceptionHandler`까지 전파한다. 유효하지 않은 코드로 로그인을 허용하면서 revoke 불가 상태가 되는 것이 더 위험하다.

### 3-4. revoke 시 두 client_id 순차 시도

App/Web 로그인 이력을 별도 컬럼으로 추적하는 대신, revoke 시 App(Bundle ID) → Web(Service ID) 순으로 두 번 호출한다. Apple `/auth/revoke`는 잘못된 `client_id`로 요청해도 HTTP 200을 반환하므로 에러 로그 오염 없이 처리된다.

`member` 테이블에 `apple_refresh_token_client_type` 컬럼을 추가하는 방식이 설계상 더 정확하지만, **회원 탈퇴는 드물게 발생하는 작업**이므로 API 2회 호출의 비용이 미미하다. DB 스키마 변경과 운영 DDL 실행 비용이 더 크다고 판단해 두 번 시도 방식을 채택했다.

```java
// App(Bundle ID) 기준으로 먼저 시도, 이후 Web(Service ID) 기준으로 시도
appleApiClient.revokeAppToken(appleRefreshToken);
appleApiClient.revokeToken(appleRefreshToken);
```

### 3-5. 기존 App 로그인 회원(`apple_refresh_token = null`) 자동 해소

배포 후 클라이언트가 `authorizationCode`를 전달하면 매 로그인 시 `updateAppleRefreshToken()`이 갱신되므로, 기존 회원도 다음 로그인 이후 자연스럽게 revoke 가능 상태가 된다.

---

## 4. 변경 파일

| 파일 | 변경 내용 |
|---|---|
| `domain/auth/apple/dto/AppleAppLoginReqDTO.java` | `authorizationCode` 필드 추가 (nullable) |
| `domain/auth/apple/service/AppleClientSecretGenerator.java` | `generate()` / `generateForApp()` 분리, 공통 로직 `generateWithSubject()` 추출 |
| `domain/auth/apple/service/AppleApiClient.java` | `exchangeAppCodeForToken()` 추가 (appBundleId, redirect_uri 없음) / `revokeAppToken()` 추가 (appBundleId) |
| `domain/auth/apple/service/AppleAuthService.java` | `exchangeAppCodeForToken()` 위임 추가 |
| `domain/auth/apple/usecase/AppleLoginUsecase.java` | App 흐름에서 `exchangeAppCodeForToken()` 사용, `refresh_token` 저장 |
| `domain/member/service/MemberWithdrawService.java` | `revokeApple()`에서 App → Web 순으로 두 번 revoke 시도 |

**DB 변경 없음**

---

## 5. iOS 클라이언트 요청사항

`POST /login/apple/app` 요청 body에 `authorizationCode` 추가 전달이 필요합니다.

```swift
// ASAuthorizationAppleIDCredential에서 authorizationCode 추출
guard let codeData = credential.authorizationCode,
      let authorizationCode = String(data: codeData, encoding: .utf8) else { return }

// 기존 필드에 authorizationCode 추가
let body = AppleLoginRequest(
    identityToken: identityToken,
    nonce: nonce,
    name: fullName,
    authorizationCode: authorizationCode  // 추가
)
```

> `authorizationCode`는 Apple이 **1회만** 발급하며 단시간 내 만료됩니다. 로그인 직후 즉시 서버로 전달해야 합니다.

---

## 6. 테스트 플랜

- [ ] Apple 앱 로그인 시 `authorizationCode` 전달 → Apple `/auth/token` 교환 성공 (Bundle ID 기준) → DB `apple_refresh_token` 저장 확인
- [ ] Apple 앱 로그인 시 `authorizationCode` 미전달 → 경고 로그 출력, 로그인 정상 응답 확인
- [ ] Apple 앱 로그인 시 유효하지 않은 `authorizationCode` 전달 → `AppleAuthException` → GlobalExceptionHandler 오류 응답 확인
- [ ] `apple_refresh_token` 저장된 App 로그인 회원 탈퇴 → `/auth/revoke` App · Web 두 번 호출 확인
- [ ] Web 로그인 회원 탈퇴 — 기존 동작 회귀 없음 확인

---

## 📎 Issue 번호
closed #319


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * Apple 모바일 앱 로그인 시 인증 코드 기반으로 리프레시 토큰을 교환·저장하는 동작 추가(앱 전용 코드 지원).

* **개선사항**
  * Apple 인증 토큰 교환 및 철회 흐름 개선(앱/웹 구분, 클라이언트 시크릿 처리).
  * Apple 로그인 시 이름(name)이 첫 로그인에만 제공될 수 있음을 명시적으로 반영.

* **버그 수정**
  * 리프레시 토큰 부재 시 계정 탈퇴(토큰 철회) 처리 안전성 강화 및 관련 로그 정비.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Tave-Makers/SURF-BE/pull/320)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->