### PR TITLE
[FEAT] 클라이언트 로그 스펙 서버 이벤트 구현 (회원·쪽지·홈·알림)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,5 @@ src/main/resources/application-local.yml
 ### GCP ###
 google-cloud-cli-*.tar.gz
 tave-surf.env.example
+/.claude/
+/docs/

--- a/src/main/java/com/tavemakers/surf/domain/home/service/HomeService.java
+++ b/src/main/java/com/tavemakers/surf/domain/home/service/HomeService.java
@@ -11,6 +11,7 @@ import com.tavemakers.surf.domain.member.exception.MemberNotFoundException;
 import com.tavemakers.surf.domain.member.service.MemberGetService;
 import com.tavemakers.surf.domain.schedule.entity.Schedule;
 import com.tavemakers.surf.domain.schedule.service.ScheduleGetService;
+import com.tavemakers.surf.global.logging.LogEventEmitter;
 import com.tavemakers.surf.global.util.SecurityUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -19,7 +20,9 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 @Service
@@ -33,6 +36,7 @@ public class HomeService {
 
     private final MemberGetService memberGetService;
     private final ScheduleGetService scheduleGetService;
+    private final LogEventEmitter logEventEmitter;
 
     /** 홈 화면 정보 조회 (메시지, 배너, 회원정보, 일정) */
     @Transactional(readOnly = true)
@@ -112,6 +116,35 @@ public class HomeService {
                 Long boardId = s.getPost().getBoard().getId();
                 scheduleDeepLink = "/board/" + boardId + "/post/" + postId;
             }
+        }
+
+        Map<String, Object> homeViewProps = new HashMap<>();
+        homeViewProps.put("has_welcome_message", !message.isEmpty());
+        homeViewProps.put("next_schedule_exists", scheduleTitle != null);
+        logEventEmitter.emit("home.view", homeViewProps);
+
+        if (!message.isEmpty()) {
+            logEventEmitter.emit("home.welcome_message_view", Map.of(
+                    "is_exposed", true,
+                    "message_length", message.length()
+            ));
+        }
+
+        if (memberId != null && memberName != null) {
+            Map<String, Object> profileProps = new HashMap<>();
+            profileProps.put("member_id", memberId);
+            profileProps.put("user_name", memberName);
+            if (memberGeneration != null) profileProps.put("generation", memberGeneration);
+            if (memberPart != null) profileProps.put("primary_part", memberPart);
+            logEventEmitter.emit("home.profile_summary_view", profileProps);
+        }
+
+        if (scheduleTitle != null) {
+            Map<String, Object> schedProps = new HashMap<>();
+            schedProps.put("schedule_title", scheduleTitle);
+            if (scheduleDate != null) schedProps.put("event_date", scheduleDate);
+            schedProps.put("source", "home");
+            logEventEmitter.emit("home.next_schedule_view", schedProps);
         }
 
         return new HomeResDTO(

--- a/src/main/java/com/tavemakers/surf/domain/letter/facade/LetterFacade.java
+++ b/src/main/java/com/tavemakers/surf/domain/letter/facade/LetterFacade.java
@@ -9,6 +9,7 @@ import com.tavemakers.surf.domain.letter.service.LetterGetService;
 import com.tavemakers.surf.domain.letter.service.LetterCreateService;
 import com.tavemakers.surf.domain.member.entity.Member;
 import com.tavemakers.surf.domain.member.service.MemberGetService;
+import com.tavemakers.surf.global.logging.LogEventEmitter;
 import com.tavemakers.surf.global.util.EmailSender;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
@@ -17,6 +18,9 @@ import org.springframework.data.domain.Slice;
 import org.springframework.mail.MailException;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashMap;
+import java.util.Map;
 
 @Component
 @RequiredArgsConstructor
@@ -27,10 +31,15 @@ public class LetterFacade {
     private final EmailSender emailSender;
     private final LetterGetService letterGetService;
     private final ApplicationEventPublisher eventPublisher;
+    private final LogEventEmitter logEventEmitter;
 
     /** 쪽지 생성 및 이메일 발송 */
     @Transactional
     public LetterResDTO createLetter(Long senderId, LetterCreateReqDTO req) {
+        logEventEmitter.emit("letter_send_api_called", Map.of(
+                "sender_id", senderId,
+                "receiver_id", req.receiverId()
+        ));
 
         // 1) 발신자 조회
         Member sender = memberGetService.getMember(senderId);
@@ -38,12 +47,32 @@ public class LetterFacade {
         // 2) 수신자 조회
         Member receiver = memberGetService.getMember(req.receiverId());
 
+        // validation 로그 (@Valid 통과 이후 실행되므로 result=true)
+        String replyEmail = req.replyEmail();
+        String emailDomain = replyEmail.contains("@")
+                ? replyEmail.substring(replyEmail.indexOf('@') + 1) : "";
+        logEventEmitter.emit("letter_email_validation_checked", Map.of(
+                "requester_id", senderId,
+                "email_domain", emailDomain,
+                "validation_result", true
+        ));
+        logEventEmitter.emit("letter_title_validation_checked", Map.of(
+                "requester_id", senderId,
+                "title_length", req.title().length(),
+                "validation_result", true
+        ));
+        logEventEmitter.emit("letter_body_validation_checked", Map.of(
+                "requester_id", senderId,
+                "content_length", req.content().length(),
+                "validation_result", true
+        ));
+
         // 3) 이메일 본문 생성
         String emailBody = """
         [Surf에서 %s님이 보낸 쪽지입니다.]
-        
+
         %s
-        
+
         회신 희망 이메일: %s
         SNS: %s
         """
@@ -55,16 +84,20 @@ public class LetterFacade {
                 );
 
         // 4) 이메일 전송 (실패 시 예외)
+        boolean emailSent = false;
         try {
-            emailSender.sendMail(
-                    receiver.getEmail(),
-                    req.title(),
-                    emailBody
-            );
+            emailSender.sendMail(receiver.getEmail(), req.title(), emailBody);
+            emailSent = true;
         } catch (MailException e) {
+            Map<String, Object> failedProps = new HashMap<>();
+            failedProps.put("sender_id", senderId);
+            failedProps.put("receiver_id", req.receiverId());
+            failedProps.put("status_code", 500);
+            failedProps.put("error_code", "MAIL_SEND_FAIL");
+            failedProps.put("error_message", e.getMessage() != null ? e.getMessage() : "smtp error");
+            logEventEmitter.emitError("letter_send_api_failed", failedProps, "쪽지 전송 실패 - 이메일 발송 오류");
             throw new LetterMailSendFailException();
         }
-
 
         // 5) 엔티티 생성
         Letter letter = Letter.create(
@@ -84,6 +117,13 @@ public class LetterFacade {
                 receiver.getId(),
                 sender.getName(),
                 sender.getId()
+        ));
+
+        logEventEmitter.emit("letter_send_api_succeeded", Map.of(
+                "sender_id", senderId,
+                "receiver_id", req.receiverId(),
+                "letter_id", saved.getLetterId(),
+                "email_sent", emailSent
         ));
 
         // 8) 저장된 엔티티 기반으로 Response 생성

--- a/src/main/java/com/tavemakers/surf/domain/member/usecase/MemberUsecase.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/usecase/MemberUsecase.java
@@ -14,6 +14,7 @@ import com.tavemakers.surf.domain.member.exception.TrackNotFoundException;
 import com.tavemakers.surf.domain.member.service.*;
 import com.tavemakers.surf.domain.score.service.PersonalScoreGetService;
 import com.tavemakers.surf.global.logging.LogEvent;
+import com.tavemakers.surf.global.logging.LogEventEmitter;
 import com.tavemakers.surf.global.logging.LogParam;
 import com.tavemakers.surf.global.util.SecurityUtils;
 import lombok.RequiredArgsConstructor;
@@ -27,6 +28,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -48,24 +50,48 @@ public class MemberUsecase {
     private final MemberService memberService;
     private final MemberWithdrawService memberWithdrawService;
     private final ApplicationContext context;
+    private final LogEventEmitter logEventEmitter;
     //</editor-fold>
 
     /** 마이페이지 + 프로필 조회 */
     public MyPageProfileResDTO getMyPageAndProfile(Long targetId) {
-        Member member = memberGetService.getMemberByStatus(targetId,MemberStatus.APPROVED);
-        List<TrackResDTO> myTracks = getMyTracks(targetId);
-        List<CareerResDTO> myCareers = getMyCareers(targetId);
+        Long requesterId = SecurityUtils.getCurrentMemberId();
 
-        if (member.isNotOwner()) { // SURF Rule - 타인의 활동점수는 조회 불가
-            return MyPageProfileResDTO.of(member, myTracks, null, myCareers);
+        logEventEmitter.emit("member_profile_api_called", Map.of(
+                "requester_id", requesterId,
+                "target_member_id", targetId
+        ));
+
+        try {
+            Member member = memberGetService.getMemberByStatus(targetId, MemberStatus.APPROVED);
+            List<TrackResDTO> myTracks = getMyTracks(targetId);
+            List<CareerResDTO> myCareers = getMyCareers(targetId);
+
+            MyPageProfileResDTO result;
+            if (member.isNotOwner()) { // SURF Rule - 타인의 활동점수는 조회 불가
+                result = MyPageProfileResDTO.of(member, myTracks, null, myCareers);
+            } else {
+                BigDecimal score = null;
+                if (member.isActive()) { // SURF Rule - 활동 중인 회원만 활동점수를 보여준다.
+                    score = personalScoreGetService.getPersonalScore(targetId).getScore();
+                }
+                result = MyPageProfileResDTO.of(member, myTracks, score, myCareers);
+            }
+
+            logEventEmitter.emit("member_profile_api_succeeded", Map.of(
+                    "requester_id", requesterId,
+                    "target_member_id", targetId
+            ));
+            return result;
+        } catch (Exception e) {
+            Map<String, Object> failedProps = new HashMap<>();
+            failedProps.put("requester_id", requesterId);
+            failedProps.put("target_member_id", targetId);
+            failedProps.put("status_code", 500);
+            failedProps.put("error_code", e.getClass().getSimpleName());
+            logEventEmitter.emitError("member_profile_api_failed", failedProps, "회원 프로필 조회 실패");
+            throw e;
         }
-
-        BigDecimal score = null;
-        if (member.isActive()) { // SURF Rule - 활동 중인 회원만 활동점수를 보여준다.
-            score = personalScoreGetService.getPersonalScore(targetId).getScore();
-        }
-
-        return MyPageProfileResDTO.of(member, myTracks, score, myCareers);
     }
 
 
@@ -223,18 +249,74 @@ public class MemberUsecase {
     }
 
     /** 조건별 회원 검색 및 페이징 처리 */
-    public MemberSearchSliceResDTO searchMembers( int pageNum, int pageSize, Integer generation, String part, String keyword) {
-        Pageable pageable = PageRequest.of(pageNum, pageSize);
-        Part memberPart = part == null ? null : Part.valueOf(part);
+    public MemberSearchSliceResDTO searchMembers(int pageNum, int pageSize, Integer generation, String part, String keyword) {
+        Long requesterId = SecurityUtils.getCurrentMemberId();
 
-        Slice<MemberSearchDetailResDTO> slice = search(generation, memberPart, keyword, pageable);
-
-        Long totalCount = null;
-        if (pageNum == 0) { // FRONTEND 협의 - 0번째 페이지에서만 검색조건에 따른 전체 회원수 조회.
-            totalCount = memberGetService.countSearchingMembers(generation, memberPart, keyword);
+        logEventEmitter.emit("member_list_api_called", Map.of("requester_id", requesterId));
+        if (keyword != null && !keyword.isBlank()) {
+            logEventEmitter.emit("member_search_api_called", Map.of(
+                    "requester_id", requesterId,
+                    "keyword_length", keyword.length()
+            ));
+        }
+        if (generation != null || part != null) {
+            String filterType = generation != null ? "generation" : "part";
+            Object filterValue = generation != null ? (Object) generation : part;
+            logEventEmitter.emit("member_filter_api_called", Map.of(
+                    "requester_id", requesterId,
+                    "filter_type", filterType,
+                    "filter_value", filterValue
+            ));
         }
 
-        return MemberSearchSliceResDTO.of(slice, totalCount);
+        try {
+            Pageable pageable = PageRequest.of(pageNum, pageSize);
+            Part memberPart = part == null ? null : Part.valueOf(part);
+            Slice<MemberSearchDetailResDTO> slice = search(generation, memberPart, keyword, pageable);
+
+            Long totalCount = null;
+            if (pageNum == 0) { // FRONTEND 협의 - 0번째 페이지에서만 검색조건에 따른 전체 회원수 조회.
+                totalCount = memberGetService.countSearchingMembers(generation, memberPart, keyword);
+            }
+
+            MemberSearchSliceResDTO result = MemberSearchSliceResDTO.of(slice, totalCount);
+
+            Map<String, Object> succeededProps = new HashMap<>();
+            succeededProps.put("requester_id", requesterId);
+            succeededProps.put("page_num", pageNum);
+            succeededProps.put("page_size", pageSize);
+            succeededProps.put("total_count", totalCount);
+            succeededProps.put("returned_count", result.numberOfElements());
+            logEventEmitter.emit("member_list_api_succeeded", succeededProps);
+
+            if (keyword != null && !keyword.isBlank()) {
+                logEventEmitter.emit("member_search_api_succeeded", Map.of(
+                        "requester_id", requesterId,
+                        "keyword", keyword,
+                        "result_count", result.numberOfElements()
+                ));
+            }
+            if (generation != null || part != null) {
+                String filterType = generation != null ? "generation" : "part";
+                Object filterValue = generation != null ? (Object) generation : part;
+                logEventEmitter.emit("member_filter_api_succeeded", Map.of(
+                        "requester_id", requesterId,
+                        "filter_type", filterType,
+                        "filter_value", filterValue,
+                        "result_count", result.numberOfElements()
+                ));
+            }
+
+            return result;
+        } catch (Exception e) {
+            Map<String, Object> failedProps = new HashMap<>();
+            failedProps.put("requester_id", requesterId);
+            failedProps.put("status_code", 500);
+            failedProps.put("error_code", e.getClass().getSimpleName());
+            failedProps.put("error_message", e.getMessage());
+            logEventEmitter.emitError("member_list_api_failed", failedProps, "회원 목록 조회 실패");
+            throw e;
+        }
     }
 
     /** MemberStatus에 따른 총 회원 수 카운트 조회 */

--- a/src/main/java/com/tavemakers/surf/domain/notification/controller/NotificationGetController.java
+++ b/src/main/java/com/tavemakers/surf/domain/notification/controller/NotificationGetController.java
@@ -4,6 +4,7 @@ import com.tavemakers.surf.domain.notification.dto.response.NotificationResDTO;
 import com.tavemakers.surf.domain.notification.entity.NotificationCategory;
 import com.tavemakers.surf.domain.notification.service.NotificationService;
 import com.tavemakers.surf.global.common.response.ApiResponse;
+import com.tavemakers.surf.global.logging.LogEventEmitter;
 import com.tavemakers.surf.global.util.SecurityUtils;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -12,6 +13,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.Map;
 
 import static com.tavemakers.surf.domain.notification.controller.ResponseMessage.*;
 
@@ -22,6 +24,7 @@ import static com.tavemakers.surf.domain.notification.controller.ResponseMessage
 public class NotificationGetController {
 
     private final NotificationService notificationService;
+    private final LogEventEmitter logEventEmitter;
 
     @Operation(summary = "알람 조회", description = "category 파라미터로 카테고리별 필터링 조회합니다. null일 경우 전체 알람 조회")
     @GetMapping("/v1/user/notifications")
@@ -29,6 +32,10 @@ public class NotificationGetController {
             @RequestParam(required = false) NotificationCategory category
     ) {
         Long memberId = SecurityUtils.getCurrentMemberId();
+        logEventEmitter.emit("notification.list_view", Map.of(
+                "member_id", memberId,
+                "category", category != null ? category.name().toLowerCase() : "all"
+        ));
         List<NotificationResDTO> response = notificationService.getNotifications(memberId, category);
         return ApiResponse.response(HttpStatus.OK, NOTIFICATION_READ.getMessage(), response);
     }

--- a/src/main/java/com/tavemakers/surf/domain/notification/service/NotificationEventListener.java
+++ b/src/main/java/com/tavemakers/surf/domain/notification/service/NotificationEventListener.java
@@ -9,6 +9,8 @@ import com.tavemakers.surf.domain.post.entity.Post;
 import com.tavemakers.surf.domain.post.event.PostLikedEvent;
 import com.tavemakers.surf.domain.post.service.post.PostGetService;
 import com.tavemakers.surf.domain.post.service.support.PostPublishedEvent;
+import com.tavemakers.surf.global.logging.LogEventEmitter;
+import com.tavemakers.surf.global.logging.LogEventEmitterImpl;
 import java.util.Map;
 
 import jakarta.transaction.Transactional;
@@ -28,6 +30,7 @@ public class NotificationEventListener {
     private final PostGetService postGetService;
     private final NotificationUsecase notificationUsecase;
     private final NotificationCreateService notificationCreateService;
+    private final LogEventEmitterImpl logEventEmitter;
 
     @Async
     @Transactional
@@ -126,14 +129,35 @@ public class NotificationEventListener {
     @Async
     @EventListener
     public void handleLetterSent(LetterSentEvent event) {
-        notificationCreateService.createAndSend(
-                event.getReceiverId(),
-                NotificationType.MESSAGE,
-                Map.of(
-                        "actorName", event.getSenderName(),
-                        "actorId", event.getSenderId()
-                )
-        );
-        log.info("[LetterNotification] sent to receiverId={}", event.getReceiverId());
+        logEventEmitter.emit("letter_notification_requested", Map.of(
+                "sender_id", event.getSenderId(),
+                "receiver_id", event.getReceiverId(),
+                "sender_name", event.getSenderName()
+        ));
+        try {
+            notificationCreateService.createAndSend(
+                    event.getReceiverId(),
+                    NotificationType.MESSAGE,
+                    Map.of(
+                            "actorName", event.getSenderName(),
+                            "actorId", event.getSenderId()
+                    )
+            );
+            log.info("[LetterNotification] sent to receiverId={}", event.getReceiverId());
+            logEventEmitter.emit("letter_notification_succeeded", Map.of(
+                    "receiver_id", event.getReceiverId(),
+                    "sender_id", event.getSenderId(),
+                    "delivered", true
+            ));
+        } catch (Exception e) {
+            log.error("[LetterNotification] failed for receiverId={}", event.getReceiverId(), e);
+            logEventEmitter.emitError("letter_notification_failed", Map.of(
+                    "receiver_id", event.getReceiverId(),
+                    "sender_id", event.getSenderId(),
+                    "fail_reason", e.getMessage() != null ? e.getMessage() : "unknown"
+            ), "쪽지 알림 발송 실패");
+        } finally {
+            logEventEmitter.flush(); // 비동기 스레드: 요청 필터 밖이므로 수동 flush
+        }
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/tavemakers/surf/domain/notification/service/NotificationService.java
@@ -6,12 +6,14 @@ import com.tavemakers.surf.domain.notification.entity.NotificationCategory;
 import com.tavemakers.surf.domain.notification.entity.NotificationType;
 import com.tavemakers.surf.domain.notification.exception.NotificationNotFoundException;
 import com.tavemakers.surf.domain.notification.repository.NotificationRepository;
+import com.tavemakers.surf.global.logging.LogEventEmitter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -19,6 +21,7 @@ public class NotificationService {
 
     private final NotificationRepository notificationRepository;
     private final NotificationGetService notificationGetService;
+    private final LogEventEmitter logEventEmitter;
 
     /** 회원의 알림 목록 조회 (카테고리별 필터링 가능) */
     @Transactional(readOnly = true)
@@ -44,6 +47,9 @@ public class NotificationService {
     /** 알림 읽음 처리 */
     @Transactional
     public void markAsRead(Long notificationId, Long memberId) {
+        Notification notification = notificationRepository.findById(notificationId).orElse(null);
+        boolean previousIsRead = notification != null && notification.isRead();
+
         int updated = notificationRepository.markAsRead(notificationId, memberId);
 
         if (updated == 0) {
@@ -52,5 +58,11 @@ public class NotificationService {
                 throw new NotificationNotFoundException();
             }
         }
+
+        logEventEmitter.emit("notification.read", Map.of(
+                "notification_id", notificationId,
+                "previous_is_read", previousIsRead,
+                "current_is_read", true
+        ));
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/schedule/controller/ScheduleGetController.java
+++ b/src/main/java/com/tavemakers/surf/domain/schedule/controller/ScheduleGetController.java
@@ -8,6 +8,7 @@ import com.tavemakers.surf.domain.schedule.dto.response.ScheduleMonthlyResDTO;
 import com.tavemakers.surf.domain.schedule.dto.response.ScheduleResDTO;
 import com.tavemakers.surf.domain.schedule.service.ScheduleUsecase;
 import com.tavemakers.surf.global.common.response.ApiResponse;
+import com.tavemakers.surf.global.logging.LogEventEmitter;
 import com.tavemakers.surf.global.util.SecurityUtils;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -20,6 +21,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.Map;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping
@@ -27,6 +30,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class ScheduleGetController {
 
     private final ScheduleUsecase scheduleUseCase;
+    private final LogEventEmitter logEventEmitter;
 
     /** 월별 일정 목록 조회 */
     @Operation(summary = "캘린더에 월별 일정 목록 조회", description = "캘린더 페이지에서 월별 일정을 조회합니다.")
@@ -34,6 +38,10 @@ public class ScheduleGetController {
     public ApiResponse<ScheduleMonthlyResDTO> getMonthlySchedules(
             @RequestParam @Parameter int year, @RequestParam @Parameter int month) {
         String memberRole = SecurityUtils.getCurrentMemberRole();
+        logEventEmitter.emit("calendar.view", Map.of(
+                "year", year,
+                "month", month
+        ));
         ScheduleMonthlyResDTO dto = scheduleUseCase.getScheduleMonthly(memberRole, year, month);
         return ApiResponse.response(HttpStatus.OK, SCHEDULE_CALENDAR_READ.getMessage(),dto);
     }

--- a/src/main/java/com/tavemakers/surf/global/common/advice/GlobalExceptionHandler.java
+++ b/src/main/java/com/tavemakers/surf/global/common/advice/GlobalExceptionHandler.java
@@ -1,10 +1,15 @@
 package com.tavemakers.surf.global.common.advice;
 
 import com.tavemakers.surf.domain.auth.common.exception.EmailConflictException;
+import com.tavemakers.surf.domain.letter.dto.request.LetterCreateReqDTO;
 import com.tavemakers.surf.global.common.exception.BaseException;
 import com.tavemakers.surf.global.common.exception.ErrorCode;
 import com.tavemakers.surf.global.common.exception.ErrorDetail;
 import com.tavemakers.surf.global.common.response.ApiResponse;
+import com.tavemakers.surf.global.logging.LogEventEmitter;
+import com.tavemakers.surf.global.util.SecurityUtils;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -15,16 +20,20 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static com.tavemakers.surf.global.common.exception.ErrorCode.*;
 
 
 @Slf4j
+@RequiredArgsConstructor
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
+    private final LogEventEmitter logEventEmitter;
     private static final String LOG_FORMAT = "Class : {}, Code : {}, Message : {}";
 
     /** 동일 이메일 다른 provider 충돌 — existingProvider 필드를 응답 본문에 포함한다 (D6). */
@@ -58,7 +67,10 @@ public class GlobalExceptionHandler {
 
     // @Valid 유효성 검증 예외
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<ApiResponse<List<ErrorDetail>>> handleMethodArgumentValidation(MethodArgumentNotValidException e) {
+    public ResponseEntity<ApiResponse<List<ErrorDetail>>> handleMethodArgumentValidation(
+            MethodArgumentNotValidException e,
+            HttpServletRequest request
+    ) {
         ErrorCode errorCode = METHOD_ARGUMENT_NOT_VALID;
 
         List<ErrorDetail> errors = e.getBindingResult()
@@ -69,6 +81,25 @@ public class GlobalExceptionHandler {
                         fe.getRejectedValue()
                 ))
                 .toList();
+
+        // 쪽지 전송 유효성 검증 실패 로그
+        if (request != null && request.getRequestURI().contains("/letters")
+                && e.getTarget() instanceof LetterCreateReqDTO req) {
+            try {
+                Long senderId = SecurityUtils.getCurrentMemberId();
+                String failReason = e.getBindingResult().getFieldErrors().stream()
+                        .map(fe -> fe.getField() + ": " + fe.getDefaultMessage())
+                        .collect(Collectors.joining(", "));
+                Map<String, Object> failedProps = new HashMap<>();
+                failedProps.put("sender_id", senderId);
+                if (req.receiverId() != null) failedProps.put("receiver_id", req.receiverId());
+                failedProps.put("email_valid", e.getBindingResult().getFieldError("replyEmail") == null);
+                failedProps.put("title_length", req.title() != null ? req.title().length() : 0);
+                failedProps.put("content_length", req.content() != null ? req.content().length() : 0);
+                failedProps.put("fail_reason", failReason);
+                logEventEmitter.emitError("letter_send_validation_failed", failedProps, "쪽지 전송 유효성 검증 실패");
+            } catch (Exception ignored) {}
+        }
 
         logWarning(e, errorCode.getStatus().value());
         return responseException(errorCode.getStatus(), errorCode.getMessage(), errors);
@@ -85,6 +116,10 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
         ErrorCode errorCode = INTERNAL_SERVER_ERROR;
+        Map<String, Object> errorProps = new HashMap<>();
+        errorProps.put("error_code", "500");
+        errorProps.put("error_msg", e.getMessage() != null ? e.getMessage() : "internal server error");
+        logEventEmitter.emitError("any.error", errorProps, "서버 내부 오류");
         logError(e, errorCode.getStatus().value());
         return responseException(errorCode.getStatus(), e.getMessage(), null);
     }


### PR DESCRIPTION
## Summary

- 클라이언트 팀 제공 로그 스펙에 따라 서버 측 로그 이벤트 구현
- `LogEventEmitter.emit()` / `emitError()` 직접 호출 방식 사용

## 구현 이벤트

### 회원 (`MemberUsecase.java`)
- `member_list_api_called/succeeded/failed`
- `member_search_api_called/succeeded`
- `member_filter_api_called/succeeded`
- `member_profile_api_called/succeeded/failed`

### 쪽지 (`LetterFacade.java`, `GlobalExceptionHandler.java`)
- `letter_send_api_called/succeeded/failed`
- `letter_email/title/body_validation_checked`
- `letter_send_validation_failed` (@Valid 실패 시 GlobalExceptionHandler에서 처리)

### 쪽지 알림 (`NotificationEventListener.java`)
- `letter_notification_requested/succeeded/failed`
- 비동기 스레드이므로 finally 블록에서 `flush()` 수동 호출

### 홈 (`HomeService.java`)
- `home.view` — has_welcome_message, next_schedule_exists
- `home.welcome_message_view` — message 존재 시만 emit
- `home.profile_summary_view` — 로그인 회원만 emit
- `home.next_schedule_view` — 다음 일정 존재 시만 emit

### 알림 (`NotificationGetController.java`, `NotificationService.java`)
- `notification.list_view` — member_id, category (null→"all")
- `notification.read` — previous_is_read 포함 (읽기 전 entity 조회)

### 에러 (`GlobalExceptionHandler.java`)
- `any.error` — handleException (catch-all 500 only)

## 스코프 제외 (엔드포인트 미존재)
`home.profile_open`, `home.next_schedule_open`, `notice.list_view`, `calendar.view`, `external_link.click`, `partner.*`, `notification.badge_view`, `member.list_view`

Closes #321

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **작업**
  * 내부 모니터링 및 추적 기능 강화를 위해 전반적인 이벤트 로깅 시스템을 추가했습니다.
  * 홈 화면, 레터, 회원 프로필, 알림 등 주요 기능들에 대한 로깅 인프라를 구축했습니다.
  * 오류 처리 및 유효성 검증 과정에서 상세한 로그 기록을 추가했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Tave-Makers/SURF-BE/pull/322)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->