### PR TITLE
[FEAT] MVP1 및 MVP2 로그 추가 및 로그 관련 작업

### DIFF
--- a/src/main/java/com/tavemakers/surf/domain/activity/usecase/ActivityRecordUsecase.java
+++ b/src/main/java/com/tavemakers/surf/domain/activity/usecase/ActivityRecordUsecase.java
@@ -69,19 +69,6 @@ public class ActivityRecordUsecase {
 
         try {
 
-            logEventEmitter.emit("activity.record.create", Map.of(
-                    "member_id_list_count",
-                    dto.isTeam()
-                            ? dto.teamIdList().size()
-                            : dto.memberIdList().size(),
-
-                    "activity_name",
-                    dto.activityName().name(),
-
-                    "activity_date",
-                    dto.activityDate()
-            ));
-
             ActivityType activityType = dto.activityName();
 
             if (dto.isTeam()) {
@@ -104,6 +91,12 @@ public class ActivityRecordUsecase {
 
                 activityRecordCreateService.saveActivityRecordList(recordList);
 
+                logEventEmitter.emit("activity.record.create", Map.of(
+                        "member_id_list_count", dto.teamIdList().size(),
+                        "activity_name", activityType.name(),
+                        "activity_date", dto.activityDate()
+                ));
+
                 return;
             }
 
@@ -124,6 +117,12 @@ public class ActivityRecordUsecase {
                     ).toList();
 
             activityRecordCreateService.saveActivityRecordList(recordList);
+
+            logEventEmitter.emit("activity.record.create", Map.of(
+                    "member_id_list_count", dto.memberIdList().size(),
+                    "activity_name", activityType.name(),
+                    "activity_date", dto.activityDate()
+            ));
 
         } catch (Exception e) {
 

--- a/src/main/java/com/tavemakers/surf/domain/activity/usecase/ActivityRecordUsecase.java
+++ b/src/main/java/com/tavemakers/surf/domain/activity/usecase/ActivityRecordUsecase.java
@@ -21,6 +21,9 @@ import com.tavemakers.surf.domain.activity.service.activityRecord.ActivityRecord
 import com.tavemakers.surf.domain.score.entity.PersonalActivityScore;
 import com.tavemakers.surf.domain.score.service.PersonalScoreGetService;
 import com.tavemakers.surf.domain.score.utils.ScoreCalculator;
+import com.tavemakers.surf.global.logging.LogEvent;
+import com.tavemakers.surf.global.logging.LogEventEmitter;
+import com.tavemakers.surf.global.logging.LogParam;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -31,6 +34,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.util.List;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -42,6 +46,7 @@ public class ActivityRecordUsecase {
     private final ActivityRecordDeleteService activityRecordDeleteService;
     private final PersonalScoreGetService personalScoreGetService;
     private final ScoreCalculator scoreCalculator;
+    private final LogEventEmitter logEventEmitter;
 
     /** 다수 회원의 활동기록 생성 및 점수 반영 */
     @Transactional
@@ -61,32 +66,88 @@ public class ActivityRecordUsecase {
     /** 활동기록 생성 및 점수 반영 */
     @Transactional
     public void applyActivityRecord(ActivityRecordReqDTOV2 dto) {
-        ActivityType activityType = dto.activityName();
 
-        if (dto.isTeam()) {
-            List<PersonalActivityScore> teamScoreList = personalScoreGetService.getTeamScoreListByIds(dto.teamIdList());
-            List<ActivityRecord> recordList = teamScoreList.stream()
-                    .map(teamScore -> {
-                        BigDecimal prefixSum = teamScore.updateScore(activityType);
-                        return ActivityRecord.ofTeam(teamScore.getTeam().getId(), dto, prefixSum);
+        try {
+
+            logEventEmitter.emit("activity.record.create", Map.of(
+                    "member_id_list_count",
+                    dto.isTeam()
+                            ? dto.teamIdList().size()
+                            : dto.memberIdList().size(),
+
+                    "activity_name",
+                    dto.activityName().name(),
+
+                    "activity_date",
+                    dto.activityDate()
+            ));
+
+            ActivityType activityType = dto.activityName();
+
+            if (dto.isTeam()) {
+
+                List<PersonalActivityScore> teamScoreList =
+                        personalScoreGetService.getTeamScoreListByIds(dto.teamIdList());
+
+                List<ActivityRecord> recordList = teamScoreList.stream()
+                        .map(teamScore -> {
+                                    BigDecimal prefixSum =
+                                            teamScore.updateScore(activityType);
+
+                                    return ActivityRecord.ofTeam(
+                                            teamScore.getTeam().getId(),
+                                            dto,
+                                            prefixSum
+                                    );
+                                }
+                        ).toList();
+
+                activityRecordCreateService.saveActivityRecordList(recordList);
+
+                return;
+            }
+
+            List<PersonalActivityScore> scoreList =
+                    personalScoreGetService.getPersonalScoreListByIds(dto.memberIdList());
+
+            List<ActivityRecord> recordList = scoreList.stream()
+                    .map(personalScore -> {
+                                BigDecimal prefixSum =
+                                        personalScore.updateScore(activityType);
+
+                                return ActivityRecord.ofPersonal(
+                                        personalScore.getMember().getId(),
+                                        dto,
+                                        prefixSum
+                                );
                             }
                     ).toList();
-            activityRecordCreateService.saveActivityRecordList(recordList);
-            return;
-        }
 
-        List<PersonalActivityScore> scoreList = personalScoreGetService.getPersonalScoreListByIds(dto.memberIdList());
-        List<ActivityRecord> recordList = scoreList.stream()
-                .map(personalScore -> {
-                            BigDecimal prefixSum = personalScore.updateScore(activityType);
-                            return ActivityRecord.ofPersonal(personalScore.getMember().getId(), dto, prefixSum);
-                        }
-                ).toList();
-        activityRecordCreateService.saveActivityRecordList(recordList);
+            activityRecordCreateService.saveActivityRecordList(recordList);
+
+        } catch (Exception e) {
+
+            logEventEmitter.emitError(
+                    "activity.record.create.failed",
+                    Map.of(
+                            "error_code", 500,
+                            "error_msg", e.getClass().getSimpleName()
+                    ),
+                    "활동 기록 생성 실패"
+            );
+
+            throw e;
+        }
     }
 
     /** 회원의 활동기록 목록 페이징 조회 */
-    public ActivityRecordSliceResDTO getActivityRecordList(Long memberId, ScoreType scoreType, int pageSize, int pageNum) {
+    @LogEvent(value = "activity.records.list", message = "활동 기록 목록 조회")
+    public ActivityRecordSliceResDTO getActivityRecordList(
+            Long memberId,
+            @LogParam("score_type") ScoreType scoreType,
+            @LogParam("page_size") int pageSize,
+            @LogParam("page_num") int pageNum
+    ) {
         Pageable pageable = PageRequest.of(pageNum, pageSize, Sort.by(Sort.Direction.DESC, "createdAt"));
         Slice<ActivityRecord> slice = activityRecordGetService.findActivityRecordList(memberId, scoreType, pageable);
 

--- a/src/main/java/com/tavemakers/surf/domain/auth/kakao/controller/KakaoLoginController.java
+++ b/src/main/java/com/tavemakers/surf/domain/auth/kakao/controller/KakaoLoginController.java
@@ -67,26 +67,38 @@ public class KakaoLoginController {
             @CookieValue(value = "oauth_state", required = false) String storedState,
             HttpServletRequest request
     ) {
-        if (storedState == null || !storedState.equals(state)) {
-            throw new KakaoAuthException(
-                    KakaoAuthErrorMessage.INVALID_STATE.getStatus(),
-                    KakaoAuthErrorMessage.INVALID_STATE.getMessage()
-            );
+        try {
+            if (storedState == null || !storedState.equals(state)) {
+                throw new KakaoAuthException(
+                        KakaoAuthErrorMessage.INVALID_STATE.getStatus(),
+                        KakaoAuthErrorMessage.INVALID_STATE.getMessage()
+                );
+            }
+            if (error != null) {
+                throw new KakaoAuthException(
+                        KakaoAuthErrorMessage.KAKAO_AUTH_CALLBACK_ERROR.getStatus(),
+                        KakaoAuthErrorMessage.KAKAO_AUTH_CALLBACK_ERROR.getMessage()
+                );
+            }
+
+            log.info("[LOGIN][KAKAO][CALLBACK] start codeLength={}", code.length());
+
+            LoginPayloadResDTO payload = kakaoLoginUsecase.execute(code, request);
+
+            log.info("[LOGIN][KAKAO][CALLBACK] success");
+            return payload.toWebResponseBuilder()
+                    .body(ApiResponse.response(HttpStatus.OK, "로그인 성공", payload.loginRes()));
+        } catch (Exception e) {
+            kakaoAuthService.logLoginFailed(resolveStatusCode(e), e.getClass().getSimpleName());
+            throw e;
         }
-        if (error != null) {
-            throw new KakaoAuthException(
-                    KakaoAuthErrorMessage.KAKAO_AUTH_CALLBACK_ERROR.getStatus(),
-                    KakaoAuthErrorMessage.KAKAO_AUTH_CALLBACK_ERROR.getMessage()
-            );
+    }
+
+    private int resolveStatusCode(Exception e) {
+        if (e instanceof KakaoAuthException kakaoAuthException) {
+            return kakaoAuthException.getStatus().value();
         }
-
-        log.info("[LOGIN][KAKAO][CALLBACK] start codeLength={}", code.length());
-
-        LoginPayloadResDTO payload = kakaoLoginUsecase.execute(code, request);
-
-        log.info("[LOGIN][KAKAO][CALLBACK] success");
-        return payload.toWebResponseBuilder()
-                .body(ApiResponse.response(HttpStatus.OK, "로그인 성공", payload.loginRes()));
+        return HttpStatus.INTERNAL_SERVER_ERROR.value();
     }
 
     private String generateState() {

--- a/src/main/java/com/tavemakers/surf/domain/auth/kakao/controller/KakaoLoginController.java
+++ b/src/main/java/com/tavemakers/surf/domain/auth/kakao/controller/KakaoLoginController.java
@@ -80,16 +80,17 @@ public class KakaoLoginController {
                         KakaoAuthErrorMessage.KAKAO_AUTH_CALLBACK_ERROR.getMessage()
                 );
             }
-
-            log.info("[LOGIN][KAKAO][CALLBACK] start codeLength={}", code.length());
-
             LoginPayloadResDTO payload = kakaoLoginUsecase.execute(code, request);
 
             log.info("[LOGIN][KAKAO][CALLBACK] success");
             return payload.toWebResponseBuilder()
                     .body(ApiResponse.response(HttpStatus.OK, "로그인 성공", payload.loginRes()));
         } catch (Exception e) {
-            kakaoAuthService.logLoginFailed(resolveStatusCode(e), e.getClass().getSimpleName());
+            try {
+                kakaoAuthService.logLoginFailed(resolveStatusCode(e), e.getClass().getSimpleName());
+            } catch (Exception logEx) {
+                log.warn("[LOGIN][KAKAO][CALLBACK] failure-log emit failed", logEx);
+            }
             throw e;
         }
     }

--- a/src/main/java/com/tavemakers/surf/domain/auth/kakao/service/KakaoAuthService.java
+++ b/src/main/java/com/tavemakers/surf/domain/auth/kakao/service/KakaoAuthService.java
@@ -51,4 +51,9 @@ public class KakaoAuthService {
     public void logLoginSuccess(Long userId, String issuedToken) {
         kakaoAuthLogService.logLoginSuccess(userId, issuedToken);
     }
+
+    /** 로그인 실패 로그 */
+    public void logLoginFailed(int errorCode, String errorMsg) {
+        kakaoAuthLogService.logLoginFailed(errorCode, errorMsg);
+    }
 }

--- a/src/main/java/com/tavemakers/surf/domain/badge/usecase/MemberBadgeUsecase.java
+++ b/src/main/java/com/tavemakers/surf/domain/badge/usecase/MemberBadgeUsecase.java
@@ -4,14 +4,18 @@ import com.tavemakers.surf.domain.badge.dto.request.MemberBadgeReqDTO;
 import com.tavemakers.surf.domain.badge.dto.response.MemberBadgeResDTO;
 import com.tavemakers.surf.domain.badge.dto.response.MemberBadgeSliceResDTO;
 import com.tavemakers.surf.domain.badge.dto.response.MemberOwnedBadgeResDTO;
+import com.tavemakers.surf.domain.badge.entity.Badge;
 import com.tavemakers.surf.domain.badge.entity.MemberBadge;
 import com.tavemakers.surf.domain.badge.service.*;
+import com.tavemakers.surf.global.logging.LogEventEmitter;
+import com.tavemakers.surf.global.util.SecurityUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.*;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -20,11 +24,22 @@ public class MemberBadgeUsecase {
     private final MemberBadgeAssignService memberBadgeAssignService;
     private final MemberBadgeRevokeService memberBadgeRevokeService;
     private final MemberBadgeGetService memberBadgeGetService;
+    private final BadgeGetService badgeGetService;
+    private final LogEventEmitter logEventEmitter;
 
     /** 배지 부여 */
     @Transactional
     public void assignBadge(Long badgeId, MemberBadgeReqDTO dto) {
+
         memberBadgeAssignService.assignBadge(badgeId, dto.getMemberIds());
+        Badge badge = badgeGetService.getBadgeDetail(badgeId);
+
+        logEventEmitter.emit("badge.granted", Map.of(
+                "badge_id", badgeId,
+                "badge_name", badge.getName(),
+                "member_ids", dto.getMemberIds(),
+                "awarded_by", SecurityUtils.getCurrentMemberId()
+        ));
     }
 
     /** 특정 배지 받은 회원 목록 조회 */

--- a/src/main/java/com/tavemakers/surf/domain/board/usecase/BoardUsecase.java
+++ b/src/main/java/com/tavemakers/surf/domain/board/usecase/BoardUsecase.java
@@ -4,11 +4,15 @@ import com.tavemakers.surf.domain.board.dto.request.BoardCreateReqDTO;
 import com.tavemakers.surf.domain.board.dto.request.BoardUpdateReqDTO;
 import com.tavemakers.surf.domain.board.dto.response.BoardResDTO;
 import com.tavemakers.surf.domain.board.service.BoardService;
+import com.tavemakers.surf.global.logging.LogEvent;
+import com.tavemakers.surf.global.logging.LogEventEmitter;
+import com.tavemakers.surf.global.logging.LogParam;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
 
 /** 게시판 Usecase */
 @Service
@@ -16,11 +20,21 @@ import java.util.List;
 public class BoardUsecase {
 
     private final BoardService boardService;
+    private final LogEventEmitter logEventEmitter;
 
     /** 게시판 생성 */
     @Transactional
     public BoardResDTO createBoard(BoardCreateReqDTO req) {
-        return boardService.createBoard(req);
+
+        BoardResDTO result = boardService.createBoard(req);
+
+        logEventEmitter.emit("board.create", Map.of(
+                "board_id", result.id(),
+                "title_length", req.name().length()
+        ));
+
+        return result;
+
     }
 
     /** 게시판 목록 조회 */
@@ -37,13 +51,20 @@ public class BoardUsecase {
 
     /** 게시판 수정 */
     @Transactional
-    public BoardResDTO updateBoard(Long boardId, BoardUpdateReqDTO req) {
+    @LogEvent(value = "board.update", message = "게시판 수정")
+    public BoardResDTO updateBoard(
+            @LogParam("board_id") Long boardId,
+            BoardUpdateReqDTO req
+    ) {
         return boardService.updateBoard(boardId, req);
     }
 
     /** 게시판 삭제 */
     @Transactional
-    public void deleteBoard(Long boardId) {
+    @LogEvent(value = "board.delete", message = "게시판 삭제")
+    public void deleteBoard(
+            @LogParam("board_id") Long boardId
+    ) {
         boardService.deleteBoard(boardId);
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/board/usecase/BoardUsecase.java
+++ b/src/main/java/com/tavemakers/surf/domain/board/usecase/BoardUsecase.java
@@ -4,15 +4,12 @@ import com.tavemakers.surf.domain.board.dto.request.BoardCreateReqDTO;
 import com.tavemakers.surf.domain.board.dto.request.BoardUpdateReqDTO;
 import com.tavemakers.surf.domain.board.dto.response.BoardResDTO;
 import com.tavemakers.surf.domain.board.service.BoardService;
-import com.tavemakers.surf.global.logging.LogEvent;
 import com.tavemakers.surf.global.logging.LogEventEmitter;
-import com.tavemakers.surf.global.logging.LogParam;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.Map;
 
 /** 게시판 Usecase */
 @Service
@@ -24,17 +21,10 @@ public class BoardUsecase {
 
     /** 게시판 생성 */
     @Transactional
-    public BoardResDTO createBoard(BoardCreateReqDTO req) {
-
-        BoardResDTO result = boardService.createBoard(req);
-
-        logEventEmitter.emit("board.create", Map.of(
-                "board_id", result.id(),
-                "title_length", req.name().length()
-        ));
-
-        return result;
-
+    public BoardResDTO createBoard(
+            BoardCreateReqDTO req
+    ) {
+        return boardService.createBoard(req);
     }
 
     /** 게시판 목록 조회 */
@@ -51,9 +41,8 @@ public class BoardUsecase {
 
     /** 게시판 수정 */
     @Transactional
-    @LogEvent(value = "board.update", message = "게시판 수정")
     public BoardResDTO updateBoard(
-            @LogParam("board_id") Long boardId,
+            Long boardId,
             BoardUpdateReqDTO req
     ) {
         return boardService.updateBoard(boardId, req);
@@ -61,9 +50,8 @@ public class BoardUsecase {
 
     /** 게시판 삭제 */
     @Transactional
-    @LogEvent(value = "board.delete", message = "게시판 삭제")
     public void deleteBoard(
-            @LogParam("board_id") Long boardId
+            Long boardId
     ) {
         boardService.deleteBoard(boardId);
     }

--- a/src/main/java/com/tavemakers/surf/domain/comment/controller/CommentGetController.java
+++ b/src/main/java/com/tavemakers/surf/domain/comment/controller/CommentGetController.java
@@ -3,8 +3,6 @@ package com.tavemakers.surf.domain.comment.controller;
 import com.tavemakers.surf.domain.comment.dto.response.CommentListResDTO;
 import com.tavemakers.surf.domain.comment.usecase.CommentUsecase;
 import com.tavemakers.surf.global.common.response.ApiResponse;
-import com.tavemakers.surf.global.logging.LogEvent;
-import com.tavemakers.surf.global.logging.LogParam;
 import com.tavemakers.surf.global.util.SecurityUtils;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -28,9 +26,8 @@ public class CommentGetController {
 
     @Operation(summary = "댓글 목록 조회 (페이징)", description = "루트 댓글과 대댓글 모두 포함. 페이징 처리")
     @GetMapping("/v1/user/posts/{postId}/comments")
-    @LogEvent("comment.list.expand")
     public ApiResponse<CommentListResDTO> getComments(
-            @LogParam("post_id") @PathVariable Long postId,
+            @PathVariable Long postId,
             @ParameterObject
             @PageableDefault(page = 0, size = 10, sort = "createdAt", direction = Sort.Direction.DESC)
             Pageable pageable

--- a/src/main/java/com/tavemakers/surf/domain/comment/service/CommentLikeService.java
+++ b/src/main/java/com/tavemakers/surf/domain/comment/service/CommentLikeService.java
@@ -51,7 +51,7 @@ public class CommentLikeService {
             comment.decreaseLikeCount();
             commentRepository.save(comment);
 
-            logEventEmitter.emit("comment_like_toggle", Map.of(
+            logEventEmitter.emit("comment.like.toggle", Map.of(
                     "comment_id", commentId,
                     "liked", false
             ));

--- a/src/main/java/com/tavemakers/surf/domain/comment/service/CommentLikeService.java
+++ b/src/main/java/com/tavemakers/surf/domain/comment/service/CommentLikeService.java
@@ -13,6 +13,7 @@ import com.tavemakers.surf.domain.post.entity.Post;
 import com.tavemakers.surf.domain.post.service.post.PostGetService;
 
 import com.tavemakers.surf.global.logging.LogEvent;
+import com.tavemakers.surf.global.logging.LogEventEmitter;
 import com.tavemakers.surf.global.logging.LogParam;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
@@ -21,6 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.dao.DataIntegrityViolationException;
 
 import java.util.List;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -30,12 +32,12 @@ public class CommentLikeService {
     private final CommentRepository commentRepository;
     private final MemberGetService memberGetService;
     private final PostGetService postGetService;
+    private final LogEventEmitter logEventEmitter;
 
     private final ApplicationEventPublisher eventPublisher;
 
     /** 좋아요 및 좋아요 취소 */
     @Transactional
-    @LogEvent("comment.like.toggle")
     public boolean toggleLike(@LogParam("comment_id") Long commentId, Long memberId) {
         Comment comment = commentRepository.findById(commentId)
                 .orElseThrow(CommentNotFoundException::new);
@@ -48,6 +50,12 @@ public class CommentLikeService {
         if (removed > 0) {
             comment.decreaseLikeCount();
             commentRepository.save(comment);
+
+            logEventEmitter.emit("comment_like_toggle", Map.of(
+                    "comment_id", commentId,
+                    "liked", false
+            ));
+
             return false; // 이미 눌러져 있었던 거라서 좋아요 취소됨
         }
 
@@ -56,6 +64,11 @@ public class CommentLikeService {
             comment.increaseLikeCount();
             commentRepository.save(comment);
             createNotificationAtCommentLike(member, commentId, post.getBoard().getId(), post.getId());
+
+            logEventEmitter.emit("comment_like_toggle", Map.of(
+                    "comment_id", commentId,
+                    "liked", true
+            ));
 
             return true; // 새로 좋아요 등록
         } catch (DataIntegrityViolationException e) {

--- a/src/main/java/com/tavemakers/surf/domain/comment/service/CommentLikeService.java
+++ b/src/main/java/com/tavemakers/surf/domain/comment/service/CommentLikeService.java
@@ -65,7 +65,7 @@ public class CommentLikeService {
             commentRepository.save(comment);
             createNotificationAtCommentLike(member, commentId, post.getBoard().getId(), post.getId());
 
-            logEventEmitter.emit("comment_like_toggle", Map.of(
+            logEventEmitter.emit("comment.like.toggle", Map.of(
                     "comment_id", commentId,
                     "liked", true
             ));

--- a/src/main/java/com/tavemakers/surf/domain/comment/service/CommentService.java
+++ b/src/main/java/com/tavemakers/surf/domain/comment/service/CommentService.java
@@ -44,9 +44,8 @@ public class CommentService {
 
     /** 댓글 작성 */
     @Transactional
-    @LogEvent(value = "comment.create", message = "댓글 생성 성공")
     public CommentResDTO createComment(
-            @LogParam("post_id") Long postId,
+            Long postId,
             Long memberId, CommentCreateReqDTO req) {
         Post post = postGetService.getPost(postId);
         Member member = memberGetService.getMember(memberId);
@@ -123,10 +122,9 @@ public class CommentService {
 
     /** 댓글 삭제 */
     @Transactional
-    @LogEvent("comment.delete")
     public void deleteComment(
             Long postId,
-            @LogParam("comment_id") Long commentId,
+            Long commentId,
             Long memberId
     ) {
         Comment comment = commentRepository.findById(commentId)

--- a/src/main/java/com/tavemakers/surf/domain/comment/usecase/CommentUsecase.java
+++ b/src/main/java/com/tavemakers/surf/domain/comment/usecase/CommentUsecase.java
@@ -4,10 +4,15 @@ import com.tavemakers.surf.domain.comment.dto.request.CommentCreateReqDTO;
 import com.tavemakers.surf.domain.comment.dto.response.CommentListResDTO;
 import com.tavemakers.surf.domain.comment.dto.response.CommentResDTO;
 import com.tavemakers.surf.domain.comment.service.CommentService;
+import com.tavemakers.surf.global.logging.LogEvent;
+import com.tavemakers.surf.global.logging.LogEventEmitter;
+import com.tavemakers.surf.global.logging.LogParam;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Map;
 
 /** 댓글 Usecase */
 @Service
@@ -15,22 +20,50 @@ import org.springframework.transaction.annotation.Transactional;
 public class CommentUsecase {
 
     private final CommentService commentService;
+    private final LogEventEmitter logEventEmitter;
 
     /** 댓글 생성 */
     @Transactional
     public CommentResDTO createComment(Long postId, Long memberId, CommentCreateReqDTO req) {
-        return commentService.createComment(postId, memberId, req);
+
+        CommentResDTO result =
+                commentService.createComment(postId, memberId, req);
+
+        logEventEmitter.emit("comment.create", Map.of(
+                "post_id", postId,
+                "comment_id", result.id()
+        ));
+
+        return result;
     }
 
     /** 댓글 삭제 */
     @Transactional
-    public void deleteComment(Long postId, Long commentId, Long memberId) {
+    @LogEvent(value = "comment.delete", message = "댓글 삭제")
+    public void deleteComment(
+            @LogParam("post_id") Long postId,
+            @LogParam("comment_id") Long commentId,
+            Long memberId
+    ) {
         commentService.deleteComment(postId, commentId, memberId);
     }
 
     /** 댓글 목록 조회 */
     @Transactional(readOnly = true)
     public CommentListResDTO getComments(Long postId, Pageable pageable, Long memberId) {
-        return commentService.getComments(postId, pageable, memberId);
+
+        CommentListResDTO result =
+                commentService.getComments(postId, pageable, memberId);
+
+        // 첫 진입 제외, 더보기만 로그
+        if (pageable.getPageNumber() > 0) {
+
+            logEventEmitter.emit("comment.list.expand", Map.of(
+                    "post_id", postId,
+                    "loaded_count", result.comments().size()
+            ));
+        }
+
+        return result;
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/member/controller/AdminMemberController.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/controller/AdminMemberController.java
@@ -40,7 +40,7 @@ public class AdminMemberController {
     public ApiResponse<Void> changeMembersRole(
             @RequestBody @Valid RoleChangeReqDTOV2 dto
     ) {
-        memberAdminUsecase.changeMembersRole(dto);
+        memberAdminUsecase.changeMembersRole(dto.memberIdList(), dto.role());
         return ApiResponse.response(HttpStatus.OK, "회원 역할이 성공적으로 변경되었습니다.",null);
     }
 

--- a/src/main/java/com/tavemakers/surf/domain/member/dto/request/ProfileUpdateReqDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/dto/request/ProfileUpdateReqDTO.java
@@ -42,19 +42,76 @@ public record ProfileUpdateReqDTO(
     public Map<String, Object> buildProps() {
         List<String> changedFields = new ArrayList<>();
 
-        if (email != null && !email.isBlank()) changedFields.add("email");
-        if (university != null && !university.isBlank()) changedFields.add("university");
-        if (graduateSchool != null && !graduateSchool.isBlank()) changedFields.add("graduateSchool");
-        if (phoneNumber != null && !phoneNumber.isBlank()) changedFields.add("phoneNumber");
-        if (phoneNumberPublic != null) changedFields.add("phoneNumberPublic");
+        if (email != null && !email.isBlank()) {
+            changedFields.add("email");
+        }
+
+        if (university != null && !university.isBlank()) {
+            changedFields.add("university");
+        }
+
+        if (graduateSchool != null && !graduateSchool.isBlank()) {
+            changedFields.add("graduateSchool");
+        }
+
+        if (selfIntroduction != null && !selfIntroduction.isBlank()) {
+            changedFields.add("selfIntroduction");
+        }
+
+        if (link != null && !link.isBlank()) {
+            changedFields.add("link");
+        }
+
+        if (phoneNumber != null && !phoneNumber.isBlank()) {
+            changedFields.add("phoneNumber");
+        }
+
+        if (phoneNumberPublic != null) {
+            changedFields.add("phoneNumberPublic");
+        }
+
+        if (profileImageUrl != null && !profileImageUrl.isBlank()) {
+            changedFields.add("profileImageUrl");
+        }
+
+        if (isProfileImageChanged != null) {
+            changedFields.add("isProfileImageChanged");
+        }
 
         return Map.of(
                 "changed_fields", changedFields,
-                "careers_created_count", careersToCreate == null ? 0 : careersToCreate.size(),
-                "careers_updated", careersToUpdate == null ? List.of() :
-                        careersToUpdate.stream().map(CareerUpdateReqDTO::careerId).toList(),
-                "careers_updated_count", careersToUpdate == null ? 0 : careersToUpdate.size(),
-                "careers_deleted", careerIdsToDelete == null ? List.of() : careerIdsToDelete
+
+                "careers_created",
+                careersToCreate == null
+                        ? List.of()
+                        : careersToCreate,
+
+                "careers_created_count",
+                careersToCreate == null
+                        ? 0
+                        : careersToCreate.size(),
+
+                "careers_updated",
+                careersToUpdate == null
+                        ? List.of()
+                        : careersToUpdate.stream()
+                        .map(CareerUpdateReqDTO::careerId)
+                        .toList(),
+
+                "careers_updated_count",
+                careersToUpdate == null
+                        ? 0
+                        : careersToUpdate.size(),
+
+                "careers_deleted",
+                careerIdsToDelete == null
+                        ? List.of()
+                        : careerIdsToDelete,
+
+                "careers_deleted_count",
+                careerIdsToDelete == null
+                        ? 0
+                        : careerIdsToDelete.size()
         );
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/member/dto/request/ProfileUpdateReqDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/dto/request/ProfileUpdateReqDTO.java
@@ -40,78 +40,59 @@ public record ProfileUpdateReqDTO(
         List<Long> careerIdsToDelete
 ) implements LogPropsProvider {
     public Map<String, Object> buildProps() {
-        List<String> changedFields = new ArrayList<>();
+        List<String> updatedFields = new ArrayList<>();
 
         if (email != null && !email.isBlank()) {
-            changedFields.add("email");
+            updatedFields.add("email");
         }
-
         if (university != null && !university.isBlank()) {
-            changedFields.add("university");
+            updatedFields.add("university");
         }
-
         if (graduateSchool != null && !graduateSchool.isBlank()) {
-            changedFields.add("graduateSchool");
+            updatedFields.add("graduateSchool");
         }
-
         if (selfIntroduction != null && !selfIntroduction.isBlank()) {
-            changedFields.add("selfIntroduction");
+            updatedFields.add("selfIntroduction");
         }
-
         if (link != null && !link.isBlank()) {
-            changedFields.add("link");
+            updatedFields.add("link");
         }
-
         if (phoneNumber != null && !phoneNumber.isBlank()) {
-            changedFields.add("phoneNumber");
+            updatedFields.add("phoneNumber");
         }
-
         if (phoneNumberPublic != null) {
-            changedFields.add("phoneNumberPublic");
+            updatedFields.add("phoneNumberPublic");
         }
-
         if (profileImageUrl != null && !profileImageUrl.isBlank()) {
-            changedFields.add("profileImageUrl");
+            updatedFields.add("profileImageUrl");
         }
-
         if (isProfileImageChanged != null) {
-            changedFields.add("isProfileImageChanged");
+            updatedFields.add("isProfileImageChanged");
         }
 
-        return Map.of(
-                "changed_fields", changedFields,
+        List<CareerCreateReqDTO> createdCareers =
+                careersToCreate == null ? List.of() : careersToCreate;
 
-                "careers_created",
-                careersToCreate == null
-                        ? List.of()
-                        : careersToCreate,
-
-                "careers_created_count",
-                careersToCreate == null
-                        ? 0
-                        : careersToCreate.size(),
-
-                "careers_updated",
+        List<Long> updatedCareers =
                 careersToUpdate == null
                         ? List.of()
                         : careersToUpdate.stream()
                         .map(CareerUpdateReqDTO::careerId)
-                        .toList(),
+                        .toList();
 
-                "careers_updated_count",
-                careersToUpdate == null
-                        ? 0
-                        : careersToUpdate.size(),
+        List<Long> deletedCareers =
+                careerIdsToDelete == null ? List.of() : careerIdsToDelete;
 
-                "careers_deleted",
-                careerIdsToDelete == null
-                        ? List.of()
-                        : careerIdsToDelete,
+        return Map.of(
+                "updated_fields", updatedFields,
 
-                "careers_deleted_count",
-                careerIdsToDelete == null
-                        ? 0
-                        : careerIdsToDelete.size()
+                "careers_create", createdCareers.isEmpty() ? 0 : 1,
+                "careers_update", updatedCareers.isEmpty() ? 0 : 1,
+                "careers_delete", deletedCareers.isEmpty() ? 0 : 1,
+
+                "careers_created", createdCareers,
+                "careers_updated", updatedCareers,
+                "careers_deleted", deletedCareers
         );
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/member/usecase/MemberAdminUsecase.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/usecase/MemberAdminUsecase.java
@@ -56,16 +56,24 @@ public class MemberAdminUsecase {
 
     /** 회원 권한 변경 */
     @Transactional
-    public void changeRole (Long memberId, MemberRole role) {
+    @LogEvent(value = "role.grant", message = "회원 권한 변경")
+    public void changeRole (
+            @LogParam("member_id") Long memberId,
+            @LogParam("role") MemberRole role
+    ) {
         Member member = memberGetService.getMember(memberId);
         memberPatchService.grantRole(member, role);
     }
 
-    /** 회원 권한 변경 Version 2 */
+    /** 회원 권한 변경 Version 2 (한 번에 여러명 변경) */
     @Transactional
-    public void changeMembersRole(RoleChangeReqDTOV2 dto) {
-        List<Member> members = memberGetService.findMembersByIds(dto.memberIdList());
-        memberPatchService.grantRoleV2(members, dto.role());
+    @LogEvent(value = "role.bulk_grant", message = "회원 다중 권한 변경")
+    public void changeMembersRole(
+            @LogParam("member_ids") List<Long> memberIds,
+            @LogParam("role") MemberRole role
+    ) {
+        List<Member> members = memberGetService.findMembersByIds(memberIds);
+        memberPatchService.grantRoleV2(members, role);
     }
 
     /** 회원가입 승인 처리 */

--- a/src/main/java/com/tavemakers/surf/domain/member/usecase/MemberAdminUsecase.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/usecase/MemberAdminUsecase.java
@@ -17,6 +17,7 @@ import com.tavemakers.surf.domain.score.service.PersonalScoreGetService;
 import com.tavemakers.surf.domain.score.service.PersonalScoreCreateService;
 import com.tavemakers.surf.global.jwt.JwtService;
 import com.tavemakers.surf.global.logging.LogEvent;
+import com.tavemakers.surf.global.logging.LogEventEmitter;
 import com.tavemakers.surf.global.logging.LogParam;
 import com.tavemakers.surf.global.util.SecurityUtils;
 import jakarta.servlet.http.HttpServletResponse;
@@ -30,6 +31,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 @Service
@@ -52,6 +54,7 @@ public class MemberAdminUsecase {
     private final RefreshTokenService refreshTokenService;
     private final TrackGetService trackGetService;
     private final MemberWithdrawService memberWithdrawService;
+    private final LogEventEmitter logEventEmitter;
     //</editor-fold>
 
     /** 회원 권한 변경 */
@@ -88,6 +91,16 @@ public class MemberAdminUsecase {
         Integer activeGeneration = activeGenerationGetService.getActiveGeneration();
         members.forEach(member -> memberGenerationSyncService.syncApprovedMember(member, activeGeneration));
         personalScoreCreateService.savePersonalScores(members);
+
+        for (Member member : members) {
+            logEventEmitter.emit(
+                    "signup.succeeded",
+                    Map.of(
+                            "member_id", member.getId(),
+                            "approver_id", approverId
+                    )
+            );
+        }
     }
 
     /** 회원가입 거절 처리 */
@@ -99,6 +112,17 @@ public class MemberAdminUsecase {
     ) {
         List<Member> members = memberGetService.getMembersByStatus(memberIds, MemberStatus.WAITING);
         members.forEach(Member::reject);
+
+        for (Member member : members) {
+            logEventEmitter.emit(
+                    "signup.failed",
+                    Map.of(
+                            "member_id", member.getId(),
+                            "approver_id", approverId
+                    ),
+                    "회원가입 거절"
+            );
+        }
     }
 
     /** 회원 제명 처리 */

--- a/src/main/java/com/tavemakers/surf/domain/member/usecase/MemberAdminUsecase.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/usecase/MemberAdminUsecase.java
@@ -67,7 +67,7 @@ public class MemberAdminUsecase {
 
     /** 회원 권한 변경 Version 2 (한 번에 여러명 변경) */
     @Transactional
-    @LogEvent(value = "role.bulk_grant", message = "회원 다중 권한 변경")
+    @LogEvent(value = "role.bulk.grant", message = "회원 다중 권한 변경")
     public void changeMembersRole(
             @LogParam("member_ids") List<Long> memberIds,
             @LogParam("role") MemberRole role

--- a/src/main/java/com/tavemakers/surf/domain/member/usecase/MemberUsecase.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/usecase/MemberUsecase.java
@@ -24,9 +24,11 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import com.tavemakers.surf.global.logging.LogEventEmitter;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -48,10 +50,14 @@ public class MemberUsecase {
     private final MemberService memberService;
     private final MemberWithdrawService memberWithdrawService;
     private final ApplicationContext context;
+    private final LogEventEmitter logEventEmitter;
     //</editor-fold>
 
     /** 마이페이지 + 프로필 조회 */
-    public MyPageProfileResDTO getMyPageAndProfile(Long targetId) {
+    @LogEvent(value = "profile.get", message = "프로필 조회")
+    public MyPageProfileResDTO getMyPageAndProfile(
+            @LogParam("member_id") Long targetId
+    ) {
         Member member = memberGetService.getMemberByStatus(targetId,MemberStatus.APPROVED);
         List<TrackResDTO> myTracks = getMyTracks(targetId);
         List<CareerResDTO> myCareers = getMyCareers(targetId);
@@ -112,29 +118,62 @@ public class MemberUsecase {
     }
 
     /** 회원 프로필 및 경력 정보 수정 */
-    @LogEvent(value = "member.profile_update", message = "회원 정보 수정")
     @Transactional
-    public void updateProfile(@LogParam("member_id") Long memberId,
+    public void updateProfile(Long memberId,
                               ProfileUpdateReqDTO dto) {
 
-        Member member = memberGetService.getMember(memberId);
+        try {
 
-        // 프로필 정보 수정
-        memberPatchService.updateProfile(member, dto);
+            Member member = memberGetService.getMember(memberId);
 
-        // 경력 수정
-        if (dto.careersToUpdate() != null) {
-            careerPatchService.updateCareer(member, dto.careersToUpdate());
-        }
+            // 프로필 정보 수정
+            memberPatchService.updateProfile(member, dto);
 
-        // 경력 삭제
-        if (dto.careerIdsToDelete() != null) {
-            careerDeleteService.deleteCareer(member, dto.careerIdsToDelete());
-        }
+            // 경력 수정
+            if (dto.careersToUpdate() != null) {
+                careerPatchService.updateCareer(member, dto.careersToUpdate());
+            }
 
-        // 경력 생성
-        if (dto.careersToCreate() != null) {
-            careerCreateService.createCareer(member, dto.careersToCreate());
+            // 경력 삭제
+            if (dto.careerIdsToDelete() != null) {
+                careerDeleteService.deleteCareer(member, dto.careerIdsToDelete());
+            }
+
+            // 경력 생성
+            if (dto.careersToCreate() != null) {
+                careerCreateService.createCareer(member, dto.careersToCreate());
+            }
+
+            Map<String, Object> props = new HashMap<>(dto.buildProps());
+
+            props.put("member_id", memberId);
+
+            List<?> changedFields =
+                    (List<?>) props.getOrDefault("changed_fields", List.of());
+
+            props.put(
+                    "updated_fields_count",
+                    changedFields.size()
+            );
+
+            logEventEmitter.emit(
+                    "profile.update.succeeded",
+                    props
+            );
+
+        } catch (Exception e) {
+
+            logEventEmitter.emitError(
+                    "profile.update.failed",
+                    Map.of(
+                            "member_id", memberId,
+                            "error_code", 500,
+                            "error_msg", e.getClass().getSimpleName()
+                    ),
+                    "회원 프로필 수정 실패"
+            );
+
+            throw e;
         }
     }
 
@@ -149,6 +188,10 @@ public class MemberUsecase {
         MemberStatus memberStatus = member.getStatus();
 
         MemberRole memberRole = SecurityUtils.getCurrentMember().getRole();
+
+        logEventEmitter.emit("onboarding.valid_status", Map.of(
+                "need_onboarding", needOnboarding
+        ));
 
         return OnboardingCheckResDTO.of(memberId, needOnboarding, memberStatus, memberRole);
     }
@@ -187,7 +230,6 @@ public class MemberUsecase {
     @Transactional
     @LogEvent(value = "signup.succeeded", message = "회원가입 성공")
     public MemberSignupResDTO signupSucceeded(
-            @LogParam("member_id") Long memberId,
             MemberSignupResDTO response
     ) {
         return response;
@@ -197,8 +239,13 @@ public class MemberUsecase {
     @Transactional
     @LogEvent(value = "signup.failed", message = "회원가입 실패")
     public MemberSignupResDTO signupFailed(
+            @LogParam("member_id")
             Long memberId,
+
+            @LogParam("error_code")
             int statusCode,
+
+            @LogParam("error_msg")
             String errorReason
     ) {
         throw new RuntimeException(errorReason);

--- a/src/main/java/com/tavemakers/surf/domain/member/usecase/MemberUsecase.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/usecase/MemberUsecase.java
@@ -161,13 +161,14 @@ public class MemberUsecase {
                     props
             );
 
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
 
+            int errorCode = 500; // 기본값
             logEventEmitter.emitError(
                     "profile.update.failed",
                     Map.of(
                             "member_id", memberId,
-                            "error_code", 500,
+                            "error_code", errorCode,
                             "error_msg", e.getClass().getSimpleName()
                     ),
                     "회원 프로필 수정 실패"

--- a/src/main/java/com/tavemakers/surf/domain/member/usecase/MemberUsecase.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/usecase/MemberUsecase.java
@@ -210,13 +210,21 @@ public class MemberUsecase {
 
             props.put("member_id", memberId);
 
-            List<?> changedFields =
-                    (List<?>) props.getOrDefault("changed_fields", List.of());
+            List<?> createdCareers =
+                    (List<?>) props.getOrDefault("careers_created", List.of());
+            List<?> updatedCareers =
+                    (List<?>) props.getOrDefault("careers_updated", List.of());
+            List<?> deletedCareers =
+                    (List<?>) props.getOrDefault("careers_deleted", List.of());
 
-            props.put(
-                    "updated_fields_count",
-                    changedFields.size()
-            );
+            props.put("careers_create", createdCareers.isEmpty() ? 0 : 1);
+            props.put("careers_update", updatedCareers.isEmpty() ? 0 : 1);
+            props.put("careers_delete", deletedCareers.isEmpty() ? 0 : 1);
+
+            List<?> updatedFields =
+                    (List<?>) props.getOrDefault("updated_fields", List.of());
+
+            props.put("updated_fields_count", updatedFields.size());
 
             logEventEmitter.emit(
                     "profile.update.succeeded",

--- a/src/main/java/com/tavemakers/surf/domain/member/usecase/MemberUsecase.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/usecase/MemberUsecase.java
@@ -227,31 +227,6 @@ public class MemberUsecase {
         return memberService.signup(member, request);
     }
 
-    /** 회원가입 성공 */
-    @Transactional
-    @LogEvent(value = "signup.succeeded", message = "회원가입 성공")
-    public MemberSignupResDTO signupSucceeded(
-            MemberSignupResDTO response
-    ) {
-        return response;
-    }
-
-    /** 회원가입 실패 */
-    @Transactional
-    @LogEvent(value = "signup.failed", message = "회원가입 실패")
-    public MemberSignupResDTO signupFailed(
-            @LogParam("member_id")
-            Long memberId,
-
-            @LogParam("error_code")
-            int statusCode,
-
-            @LogParam("error_msg")
-            String errorReason
-    ) {
-        throw new RuntimeException(errorReason);
-    }
-
     /** 회원 탈퇴 처리 */
     @Transactional
     public void withdraw(Long memberId) {

--- a/src/main/java/com/tavemakers/surf/domain/post/service/like/PostLikeService.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/service/like/PostLikeService.java
@@ -42,7 +42,7 @@ public class PostLikeService {
                 .orElseThrow(PostNotFoundException::new);
 
         if (post.getBoard().getType() == BoardType.NOTICE) {
-            LogEventContext.overrideEvent("notice_like_toggle");
+            LogEventContext.overrideEvent("notice.like.toggle");
             LogEventContext.overrideMessage("좋아요 버튼 클릭");
         }
 
@@ -80,7 +80,7 @@ public class PostLikeService {
                 .orElseThrow(PostNotFoundException::new);
 
         if (post.getBoard().getType() == BoardType.NOTICE) {
-            LogEventContext.overrideEvent("notice_like_toggle");
+            LogEventContext.overrideEvent("notice.like.toggle");
             LogEventContext.overrideMessage("좋아요 버튼 클릭");
         }
 

--- a/src/main/java/com/tavemakers/surf/domain/post/service/post/PostCreateService.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/service/post/PostCreateService.java
@@ -51,7 +51,6 @@ public class PostCreateService {
      * 게시글 생성 및 저장 (예약 처리는 Usecase에서 담당)
      */
     @Transactional
-    @LogEvent(value = "post.create", message = "게시글 생성 성공")
     public PostDetailResDTO createPost(PostCreateReqDTO req, Long memberId) {
         Board board = boardGetService.getBoard(req.boardId());
         Member writer = memberGetService.getMember(memberId);

--- a/src/main/java/com/tavemakers/surf/domain/post/service/post/PostCreateUsecase.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/service/post/PostCreateUsecase.java
@@ -31,7 +31,7 @@ public class PostCreateUsecase {
                 "post_id", result.postId(),
                 "board_id", req.boardId(),
                 "title_length", req.title().length(),
-                "has_Fimage", req.hasImage()
+                "has_image", req.hasImage()
         ));
 
         return result;

--- a/src/main/java/com/tavemakers/surf/domain/post/service/post/PostCreateUsecase.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/service/post/PostCreateUsecase.java
@@ -3,9 +3,12 @@ package com.tavemakers.surf.domain.post.service.post;
 import com.tavemakers.surf.domain.post.dto.request.PostCreateReqDTO;
 import com.tavemakers.surf.domain.post.dto.response.PostDetailResDTO;
 import com.tavemakers.surf.domain.reservation.usecase.ReservationUsecase;
+import com.tavemakers.surf.global.logging.LogEventEmitter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Map;
 
 /** 게시글 생성 Usecase */
 @Service
@@ -14,6 +17,7 @@ public class PostCreateUsecase {
 
     private final PostCreateService postCreateService;
     private final ReservationUsecase reservationUsecase;
+    private final LogEventEmitter logEventEmitter;
 
     /** 게시글 생성 (예약 포함) */
     @Transactional
@@ -22,6 +26,14 @@ public class PostCreateUsecase {
         if (req.isReserved()) {
             reservationUsecase.reservePost(result.postId(), req.reservedAt());
         }
+
+        logEventEmitter.emit("post_create", Map.of(
+                "post_id", result.postId(),
+                "board_id", req.boardId(),
+                "title_length", req.title().length(),
+                "has_Fimage", req.hasImage()
+        ));
+
         return result;
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/post/service/post/PostCreateUsecase.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/service/post/PostCreateUsecase.java
@@ -27,7 +27,7 @@ public class PostCreateUsecase {
             reservationUsecase.reservePost(result.postId(), req.reservedAt());
         }
 
-        logEventEmitter.emit("post_create", Map.of(
+        logEventEmitter.emit("post.create", Map.of(
                 "post_id", result.postId(),
                 "board_id", req.boardId(),
                 "title_length", req.title().length(),

--- a/src/main/java/com/tavemakers/surf/domain/post/service/post/PostDeleteUsecase.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/service/post/PostDeleteUsecase.java
@@ -5,6 +5,8 @@ import com.tavemakers.surf.domain.post.entity.Post;
 import com.tavemakers.surf.domain.reservation.repository.ReservationRepository;
 import com.tavemakers.surf.domain.schedule.service.ScheduleDeleteService;
 import com.tavemakers.surf.domain.scrap.service.ScrapGetService;
+import com.tavemakers.surf.global.logging.LogEvent;
+import com.tavemakers.surf.global.logging.LogParam;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/src/main/java/com/tavemakers/surf/domain/post/service/post/PostDeleteUsecase.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/service/post/PostDeleteUsecase.java
@@ -5,8 +5,6 @@ import com.tavemakers.surf.domain.post.entity.Post;
 import com.tavemakers.surf.domain.reservation.repository.ReservationRepository;
 import com.tavemakers.surf.domain.schedule.service.ScheduleDeleteService;
 import com.tavemakers.surf.domain.scrap.service.ScrapGetService;
-import com.tavemakers.surf.global.logging.LogEvent;
-import com.tavemakers.surf.global.logging.LogParam;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/src/main/java/com/tavemakers/surf/domain/post/service/post/PostListService.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/service/post/PostListService.java
@@ -86,11 +86,11 @@ public class PostListService {
         }
 
         if (isNotice) {
-            LogEventContext.overrideEvent("notice_list_view");
+            LogEventContext.overrideEvent("notice.list.view");
             LogEventContext.overrideMessage("공지 리스트 화면 진입");
             LogEventContext.put("category", "notice");
         } else {
-            LogEventContext.overrideEvent("post_list_view");
+            LogEventContext.overrideEvent("post.list.view");
             LogEventContext.overrideMessage("게시판 리스트 화면 진입");
 
             LogEventContext.put("board_id", boardId);

--- a/src/main/java/com/tavemakers/surf/domain/post/service/post/PostListService.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/service/post/PostListService.java
@@ -55,7 +55,7 @@ public class PostListService {
     }
 
     /** 게시판 및 카테고리별 게시글 목록 조회 (slug 기반) */
-    @LogEvent(value = "post_list_view", message = "게시판 리스트 화면 진입")
+    @LogEvent(value = "post.list.view", message = "게시판 리스트 화면 진입")
     public Slice<PostResDTO> getPostsByBoardAndCategory(
             Long boardId,
             String categorySlug,

--- a/src/main/java/com/tavemakers/surf/domain/schedule/service/ScheduleGetService.java
+++ b/src/main/java/com/tavemakers/surf/domain/schedule/service/ScheduleGetService.java
@@ -25,7 +25,6 @@ public class ScheduleGetService {
 
     /** 월별 일정 목록 조회 */
     @Transactional(readOnly = true)
-    @LogEvent("calendar.view")
     public ScheduleMonthlyResDTO getScheduleMonthly(
             String memberRole,
             int year,

--- a/src/main/java/com/tavemakers/surf/domain/schedule/service/ScheduleGetService.java
+++ b/src/main/java/com/tavemakers/surf/domain/schedule/service/ScheduleGetService.java
@@ -85,7 +85,7 @@ public class ScheduleGetService {
 
     /** 캘린더에서 일정 상세 조회 */
     @Transactional(readOnly = true)
-    @LogEvent("calendar_summary_open")
+    @LogEvent("calendar.summary.open")
     public ScheduleResDTO getScheduleSingleAtCalendar(@LogParam("schedule_id") Long scheduleId) {
         Schedule schedule = scheduleRepository.findById(scheduleId)
                 .orElseThrow(ScheduleNotFoundException::new);

--- a/src/main/java/com/tavemakers/surf/domain/score/usecase/PersonalScoreUsecase.java
+++ b/src/main/java/com/tavemakers/surf/domain/score/usecase/PersonalScoreUsecase.java
@@ -7,10 +7,12 @@ import com.tavemakers.surf.domain.activity.service.activityRecord.ActivityRecord
 import com.tavemakers.surf.domain.score.dto.response.PersonalScoreWithPinnedResDto;
 import com.tavemakers.surf.domain.score.entity.PersonalActivityScore;
 import com.tavemakers.surf.domain.score.service.PersonalScoreGetService;
+import com.tavemakers.surf.global.logging.LogEventEmitter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -19,6 +21,7 @@ public class PersonalScoreUsecase {
     private final PersonalScoreGetService personalScoreGetService;
     private final ActivityRecordGetService activityRecordGetService;
     private final ActivityRecordMapper activityRecordMapper;
+    private final LogEventEmitter logEventEmitter;
 
     /** 회원의 개인 점수와 고정 활동기록 조회 */
     public PersonalScoreWithPinnedResDto findPersonalScoreAndPinned(Long memberId) {
@@ -26,6 +29,15 @@ public class PersonalScoreUsecase {
 
         List<ActivityRecord> list = activityRecordGetService.findAllByMemberId(memberId);
         ActivityRecordSummaryResDTO dto = activityRecordMapper.mapPinnedActivityRecord(list);
+
+        List<String> topTypes = list.stream()
+                .map(record -> record.getActivityType().name())
+                .toList();
+
+        logEventEmitter.emit("personal.score.pinned5", Map.of(
+                "score", personalScore.getScore(),
+                "top_types", topTypes
+        ));
 
         return PersonalScoreWithPinnedResDto.of(personalScore.getScore(), dto);
     }

--- a/src/main/java/com/tavemakers/surf/domain/score/usecase/PersonalScoreUsecase.java
+++ b/src/main/java/com/tavemakers/surf/domain/score/usecase/PersonalScoreUsecase.java
@@ -32,6 +32,7 @@ public class PersonalScoreUsecase {
 
         List<String> topTypes = list.stream()
                 .map(record -> record.getActivityType().name())
+                .limit(5)
                 .toList();
 
         logEventEmitter.emit("personal.score.pinned5", Map.of(


### PR DESCRIPTION
## 📄 작업 내용 요약

- **게시판/게시글/댓글/회원/배지** 관련 부분 이벤트 로그 추가
- 단순 성공 이벤트는 `@LogEvent` 적용
- 메서드 파라미터만으로 처리하기 어려운 경우 `logEventEmitter.emit()` 방식으로 적용

```
2026-05-15 17:44:38 [default] INFO  [http-nio-8080-exec-6] api-event - {"message":"��ũ�� ���� ����","props": {"post_id":3,"user_id":1},"result":"success","duration_ms":56,"path":"/v1/user/scraps/3","event_type":"INFO","http_method":"DELETE","user_id":"1","event":"scrap.remove","request_id":"c30216bd-04b5-4eff-94e0-2f1563d5dada","timestamp":"2026-05-15T08:44:38.727860400Z","status":200,"actor_role":"ROLE_MANAGER"}

```


## 기타 사항

### 생략
- 데분 문서에서 중복된 부분 
- 요구 데이터가 의미 없는 경우
- 클릭, 스크롤 등 백엔드에 적합하지 않은 경우 

### 참고 자료
- 노션 '데분 문서'의 백엔드 MVP1, MVP2 문서 

## 📎 Issue 번호
closed #316 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 활동 기록·배지 부여·댓글·게시글·회원 관련 주요 작업에 대한 이벤트 로깅 추가·강화
  * 프로필 수정 시 더 상세한 변경 내역(추가 필드·커리어 플래그 포함) 기록
  * 개인 점수·게시글 목록·댓글 목록 등의 행동 추적 이벤트 추가

* **기타**
  * 일부 기존 로깅 어노테이션을 수동 이벤트 발행으로 전환하고 이벤트 명칭 표준화 적용
  * 로그인·회원 승인/거절 등 실패 로그 기록 강화

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Tave-Makers/SURF-BE/pull/323?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->