### PR TITLE
[FEAT] S3 첨부파일 삭제 기능 추가

### DIFF
--- a/src/main/java/com/tavemakers/surf/domain/post/controller/ResponseMessage.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/controller/ResponseMessage.java
@@ -11,6 +11,7 @@ public enum ResponseMessage {
     POST_UPDATED("[게시글]이 성공적으로 수정되었습니다."),
     POST_DELETED("[게시글]이 성공적으로 삭제되었습니다."),
     POST_READ("[게시글]이 성공적으로 조회되었습니다."),
+    POST_FILE_DELETED("[게시글] 첨부파일이 성공적으로 삭제되었습니다."),
     MY_POSTS_READ("내가 작성한 [게시글] 목록을 성공적으로 조회했습니다."),
     POSTS_BY_BOARD_READ("[게시판]별 [게시글] 목록을 성공적으로 조회했습니다."),
     POSTS_BY_MEMBER_READ("특정 회원이 작성한 [게시글] 목록을 성공적으로 조회했습니다."),

--- a/src/main/java/com/tavemakers/surf/domain/post/controller/file/PostFileDeleteController.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/controller/file/PostFileDeleteController.java
@@ -20,12 +20,13 @@ public class PostFileDeleteController {
     private final PostFileDeleteUsecase postFileDeleteUsecase;
 
     /** 게시글 첨부파일 삭제 (작성자/권한 검증은 서비스에서) */
-    @Operation(summary = "게시글 첨부파일 삭제", description = "게시글에 첨부된 파일을 삭제합니다. S3 파일은 트랜잭션 커밋 이후 삭제됩니다.")
-    @DeleteMapping("/v1/user/posts/files/{fileId}")
+    @Operation(summary = "게시글 첨부파일 삭제", description = "게시글에 첨부된 파일을 삭제합니다. URL의 postId와 첨부파일이 속한 게시글이 일치해야 하며, S3 파일은 트랜잭션 커밋 이후 삭제됩니다.")
+    @DeleteMapping("/v1/user/posts/{postId}/files/{fileId}")
     public ApiResponse<Void> deletePostFile(
+            @PathVariable(name = "postId") Long postId,
             @PathVariable(name = "fileId") Long fileId) {
         Long memberId = SecurityUtils.getCurrentMemberId();
-        postFileDeleteUsecase.deletePostFile(fileId, memberId);
+        postFileDeleteUsecase.deletePostFile(postId, fileId, memberId);
         return ApiResponse.response(HttpStatus.NO_CONTENT, POST_FILE_DELETED.getMessage());
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/post/controller/file/PostFileDeleteController.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/controller/file/PostFileDeleteController.java
@@ -1,0 +1,31 @@
+package com.tavemakers.surf.domain.post.controller.file;
+
+import com.tavemakers.surf.domain.post.service.post.PostFileDeleteUsecase;
+import com.tavemakers.surf.global.common.response.ApiResponse;
+import com.tavemakers.surf.global.util.SecurityUtils;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import static com.tavemakers.surf.domain.post.controller.ResponseMessage.POST_FILE_DELETED;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping
+@Tag(name = "게시물", description = "게시물 첨부파일 삭제 API")
+public class PostFileDeleteController {
+
+    private final PostFileDeleteUsecase postFileDeleteUsecase;
+
+    /** 게시글 첨부파일 삭제 (작성자/권한 검증은 서비스에서) */
+    @Operation(summary = "게시글 첨부파일 삭제", description = "게시글에 첨부된 파일을 삭제합니다. S3 파일은 트랜잭션 커밋 이후 삭제됩니다.")
+    @DeleteMapping("/v1/user/posts/files/{fileId}")
+    public ApiResponse<Void> deletePostFile(
+            @PathVariable(name = "fileId") Long fileId) {
+        Long memberId = SecurityUtils.getCurrentMemberId();
+        postFileDeleteUsecase.deletePostFile(fileId, memberId);
+        return ApiResponse.response(HttpStatus.NO_CONTENT, POST_FILE_DELETED.getMessage());
+    }
+}

--- a/src/main/java/com/tavemakers/surf/domain/post/event/PostFilesDeletedEvent.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/event/PostFilesDeletedEvent.java
@@ -1,0 +1,9 @@
+package com.tavemakers.surf.domain.post.event;
+
+import java.util.List;
+
+/**
+ * 게시글 첨부파일 DB 삭제 완료 이벤트 - 트랜잭션 커밋 이후 S3 파일 삭제용
+ */
+public record PostFilesDeletedEvent(List<String> fileUrls) {
+}

--- a/src/main/java/com/tavemakers/surf/domain/post/event/PostFilesDeletedListener.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/event/PostFilesDeletedListener.java
@@ -1,0 +1,31 @@
+package com.tavemakers.surf.domain.post.event;
+
+import com.tavemakers.surf.global.common.s3.service.S3Service;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+/**
+ * 게시글 첨부파일 삭제 이벤트 리스너 - 트랜잭션 커밋 이후 S3 파일 삭제
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PostFilesDeletedListener {
+
+    private final S3Service s3Service;
+
+    /** DB 커밋 이후 S3 파일 삭제 (실패해도 orphan 정리로 복구 가능하므로 예외를 전파하지 않는다) */
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleFilesDeleted(PostFilesDeletedEvent event) {
+        event.fileUrls().forEach(fileUrl -> {
+            try {
+                s3Service.deleteFile(fileUrl);
+            } catch (Exception e) {
+                log.warn("[PostFileDelete] S3 파일 삭제 실패. fileUrl={}", fileUrl, e);
+            }
+        });
+    }
+}

--- a/src/main/java/com/tavemakers/surf/domain/post/event/PostFilesDeletedListener.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/event/PostFilesDeletedListener.java
@@ -3,6 +3,7 @@ package com.tavemakers.surf.domain.post.event;
 import com.tavemakers.surf.global.common.s3.service.S3Service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
@@ -18,6 +19,7 @@ public class PostFilesDeletedListener {
     private final S3Service s3Service;
 
     /** DB 커밋 이후 S3 파일 삭제 (실패해도 orphan 정리로 복구 가능하므로 예외를 전파하지 않는다) */
+    @Async("s3DeleteExecutor")
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleFilesDeleted(PostFilesDeletedEvent event) {
         event.fileUrls().forEach(fileUrl -> {

--- a/src/main/java/com/tavemakers/surf/domain/post/exception/ErrorMessage.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/exception/ErrorMessage.java
@@ -14,7 +14,8 @@ public enum ErrorMessage {
     POST_DELETED_DENIED(HttpStatus.UNAUTHORIZED, "[게시글]을 삭제할 권한이 없습니다."),
 
     POST_FILE_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 [첨부파일]입니다."),
-    POST_FILE_DELETE_DENIED(HttpStatus.UNAUTHORIZED, "[첨부파일]을 삭제할 권한이 없습니다."),
+    POST_FILE_DELETE_DENIED(HttpStatus.FORBIDDEN, "[첨부파일]을 삭제할 권한이 없습니다."),
+    POST_FILE_MISMATCH(HttpStatus.NOT_FOUND, "해당 [게시글]에 속하지 않는 [첨부파일]입니다."),
 
     BOARD_WRITE_NOT_ALLOWED(HttpStatus.FORBIDDEN, "[공지사항] 게시판은 관리자만 게시글을 작성할 수 있습니다.");
 

--- a/src/main/java/com/tavemakers/surf/domain/post/exception/ErrorMessage.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/exception/ErrorMessage.java
@@ -13,6 +13,9 @@ public enum ErrorMessage {
     POST_IMAGE_EMPTY(HttpStatus.NOT_FOUND, "[이미지 목록]이 비어있습니다."),
     POST_DELETED_DENIED(HttpStatus.UNAUTHORIZED, "[게시글]을 삭제할 권한이 없습니다."),
 
+    POST_FILE_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 [첨부파일]입니다."),
+    POST_FILE_DELETE_DENIED(HttpStatus.UNAUTHORIZED, "[첨부파일]을 삭제할 권한이 없습니다."),
+
     BOARD_WRITE_NOT_ALLOWED(HttpStatus.FORBIDDEN, "[공지사항] 게시판은 관리자만 게시글을 작성할 수 있습니다.");
 
     private final HttpStatus status;

--- a/src/main/java/com/tavemakers/surf/domain/post/exception/PostFileDeleteAccessDeniedException.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/exception/PostFileDeleteAccessDeniedException.java
@@ -1,0 +1,11 @@
+package com.tavemakers.surf.domain.post.exception;
+
+import com.tavemakers.surf.global.common.exception.BaseException;
+
+import static com.tavemakers.surf.domain.post.exception.ErrorMessage.POST_FILE_DELETE_DENIED;
+
+public class PostFileDeleteAccessDeniedException extends BaseException {
+    public PostFileDeleteAccessDeniedException() {
+        super(POST_FILE_DELETE_DENIED.getStatus(), POST_FILE_DELETE_DENIED.getMessage());
+    }
+}

--- a/src/main/java/com/tavemakers/surf/domain/post/exception/PostFileMismatchException.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/exception/PostFileMismatchException.java
@@ -1,0 +1,11 @@
+package com.tavemakers.surf.domain.post.exception;
+
+import com.tavemakers.surf.global.common.exception.BaseException;
+
+import static com.tavemakers.surf.domain.post.exception.ErrorMessage.POST_FILE_MISMATCH;
+
+public class PostFileMismatchException extends BaseException {
+    public PostFileMismatchException() {
+        super(POST_FILE_MISMATCH.getStatus(), POST_FILE_MISMATCH.getMessage());
+    }
+}

--- a/src/main/java/com/tavemakers/surf/domain/post/exception/PostFileNotFoundException.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/exception/PostFileNotFoundException.java
@@ -1,0 +1,11 @@
+package com.tavemakers.surf.domain.post.exception;
+
+import com.tavemakers.surf.global.common.exception.BaseException;
+
+import static com.tavemakers.surf.domain.post.exception.ErrorMessage.POST_FILE_NOT_FOUND;
+
+public class PostFileNotFoundException extends BaseException {
+    public PostFileNotFoundException() {
+        super(POST_FILE_NOT_FOUND.getStatus(), POST_FILE_NOT_FOUND.getMessage());
+    }
+}

--- a/src/main/java/com/tavemakers/surf/domain/post/service/file/PostFileDeleteService.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/service/file/PostFileDeleteService.java
@@ -22,4 +22,10 @@ public class PostFileDeleteService {
         }
         repository.deleteAllInBatch(beforeFiles);
     }
+
+    /** 게시글 첨부파일 단건 삭제 */
+    @Transactional
+    public void delete(PostFileUrl file) {
+        repository.delete(file);
+    }
 }

--- a/src/main/java/com/tavemakers/surf/domain/post/service/file/PostFileGetService.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/service/file/PostFileGetService.java
@@ -1,6 +1,7 @@
 package com.tavemakers.surf.domain.post.service.file;
 
 import com.tavemakers.surf.domain.post.entity.PostFileUrl;
+import com.tavemakers.surf.domain.post.exception.PostFileNotFoundException;
 import com.tavemakers.surf.domain.post.repository.PostFileUrlRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -18,5 +19,12 @@ public class PostFileGetService {
     @Transactional(readOnly = true)
     public List<PostFileUrl> getPostFileUrls(Long postId) {
         return postFileUrlRepository.findByPostId(postId);
+    }
+
+    /** 게시글 첨부파일 단건 조회 */
+    @Transactional(readOnly = true)
+    public PostFileUrl getPostFileUrl(Long fileId) {
+        return postFileUrlRepository.findById(fileId)
+                .orElseThrow(PostFileNotFoundException::new);
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/post/service/post/PostDeleteService.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/service/post/PostDeleteService.java
@@ -5,6 +5,7 @@ import com.tavemakers.surf.domain.member.service.MemberGetService;
 import com.tavemakers.surf.domain.post.entity.PostFileUrl;
 import com.tavemakers.surf.domain.post.entity.Post;
 import com.tavemakers.surf.domain.post.entity.PostImageUrl;
+import com.tavemakers.surf.domain.post.event.PostFilesDeletedEvent;
 import com.tavemakers.surf.domain.post.exception.PostDeleteAccessDeniedException;
 import com.tavemakers.surf.domain.post.repository.PostLikeRepository;
 import com.tavemakers.surf.domain.post.repository.PostRepository;
@@ -16,6 +17,7 @@ import com.tavemakers.surf.global.logging.LogEvent;
 import com.tavemakers.surf.global.logging.LogParam;
 import com.tavemakers.surf.global.util.SecurityUtils;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -36,6 +38,7 @@ public class PostDeleteService {
     private final PostFileGetService postFileGetService;
     private final PostFileDeleteService postFileDeleteService;
     private final MemberGetService memberGetService;
+    private final ApplicationEventPublisher eventPublisher;
 
     /** 게시글 삭제 - Post 도메인 내부 데이터만 삭제 (좋아요, 이미지, 게시글) */
     @Transactional
@@ -57,6 +60,7 @@ public class PostDeleteService {
         List<PostFileUrl> postFileUrls = postFileGetService.getPostFileUrls(post.getId());
         if (postFileUrls != null && !postFileUrls.isEmpty()) {
             postFileDeleteService.deleteAll(postFileUrls);
+            publishFilesDeletedEvent(postFileUrls);
         }
 
         postRepository.delete(post);
@@ -75,9 +79,18 @@ public class PostDeleteService {
         List<PostFileUrl> postFileUrls = postFileGetService.getPostFileUrls(post.getId());
         if (postFileUrls != null && !postFileUrls.isEmpty()) {
             postFileDeleteService.deleteAll(postFileUrls);
+            publishFilesDeletedEvent(postFileUrls);
         }
 
         postRepository.delete(post);
+    }
+
+    /** DB 삭제 완료 후 호출 — 트랜잭션 커밋 이후 S3 파일 삭제를 트리거하는 이벤트를 발행한다 */
+    private void publishFilesDeletedEvent(List<PostFileUrl> fileUrls) {
+        List<String> urls = fileUrls.stream()
+                .map(PostFileUrl::getFileUrl)
+                .toList();
+        eventPublisher.publishEvent(new PostFilesDeletedEvent(urls));
     }
 
     /** 게시글 소유자 또는 관리자 권한 검증 */

--- a/src/main/java/com/tavemakers/surf/domain/post/service/post/PostFileDeleteUsecase.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/service/post/PostFileDeleteUsecase.java
@@ -1,0 +1,45 @@
+package com.tavemakers.surf.domain.post.service.post;
+
+import com.tavemakers.surf.domain.member.entity.Member;
+import com.tavemakers.surf.domain.member.service.MemberGetService;
+import com.tavemakers.surf.domain.post.entity.Post;
+import com.tavemakers.surf.domain.post.entity.PostFileUrl;
+import com.tavemakers.surf.domain.post.event.PostFilesDeletedEvent;
+import com.tavemakers.surf.domain.post.exception.PostFileDeleteAccessDeniedException;
+import com.tavemakers.surf.domain.post.service.file.PostFileDeleteService;
+import com.tavemakers.surf.domain.post.service.file.PostFileGetService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/** 게시글 첨부파일 삭제 Usecase - DB 삭제 후 커밋 시점에 S3 파일 삭제 */
+@Service
+@RequiredArgsConstructor
+public class PostFileDeleteUsecase {
+
+    private final PostFileGetService postFileGetService;
+    private final PostFileDeleteService postFileDeleteService;
+    private final MemberGetService memberGetService;
+    private final ApplicationEventPublisher eventPublisher;
+
+    /** 게시글 첨부파일 단건 삭제 (작성자 또는 관리자만 허용) */
+    @Transactional
+    public void deletePostFile(Long fileId, Long requesterId) {
+        PostFileUrl file = postFileGetService.getPostFileUrl(fileId);
+        Member member = memberGetService.getMember(requesterId);
+        validateOwnerOrManager(file.getPost(), member);
+
+        postFileDeleteService.delete(file);
+        eventPublisher.publishEvent(new PostFilesDeletedEvent(List.of(file.getFileUrl())));
+    }
+
+    /** 게시글 소유자 또는 관리자 권한 검증 */
+    private void validateOwnerOrManager(Post post, Member member) {
+        if (!member.hasDeleteRole() && !post.isOwner(member.getId())) {
+            throw new PostFileDeleteAccessDeniedException();
+        }
+    }
+}

--- a/src/main/java/com/tavemakers/surf/domain/post/service/post/PostFileDeleteUsecase.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/service/post/PostFileDeleteUsecase.java
@@ -6,6 +6,7 @@ import com.tavemakers.surf.domain.post.entity.Post;
 import com.tavemakers.surf.domain.post.entity.PostFileUrl;
 import com.tavemakers.surf.domain.post.event.PostFilesDeletedEvent;
 import com.tavemakers.surf.domain.post.exception.PostFileDeleteAccessDeniedException;
+import com.tavemakers.surf.domain.post.exception.PostFileMismatchException;
 import com.tavemakers.surf.domain.post.service.file.PostFileDeleteService;
 import com.tavemakers.surf.domain.post.service.file.PostFileGetService;
 import lombok.RequiredArgsConstructor;
@@ -27,13 +28,22 @@ public class PostFileDeleteUsecase {
 
     /** 게시글 첨부파일 단건 삭제 (작성자 또는 관리자만 허용) */
     @Transactional
-    public void deletePostFile(Long fileId, Long requesterId) {
+    public void deletePostFile(Long postId, Long fileId, Long requesterId) {
         PostFileUrl file = postFileGetService.getPostFileUrl(fileId);
+        validateFileBelongsToPost(file, postId);
+
         Member member = memberGetService.getMember(requesterId);
         validateOwnerOrManager(file.getPost(), member);
 
         postFileDeleteService.delete(file);
         eventPublisher.publishEvent(new PostFilesDeletedEvent(List.of(file.getFileUrl())));
+    }
+
+    /** URL의 postId와 첨부파일이 실제 속한 게시글이 일치하는지 검증 */
+    private void validateFileBelongsToPost(PostFileUrl file, Long postId) {
+        if (!file.getPost().getId().equals(postId)) {
+            throw new PostFileMismatchException();
+        }
     }
 
     /** 게시글 소유자 또는 관리자 권한 검증 */

--- a/src/main/java/com/tavemakers/surf/domain/post/service/post/PostPatchService.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/service/post/PostPatchService.java
@@ -16,6 +16,7 @@ import com.tavemakers.surf.domain.post.dto.response.PostImageResDTO;
 import com.tavemakers.surf.domain.post.entity.Post;
 import com.tavemakers.surf.domain.post.entity.PostFileUrl;
 import com.tavemakers.surf.domain.post.entity.PostImageUrl;
+import com.tavemakers.surf.domain.post.event.PostFilesDeletedEvent;
 import com.tavemakers.surf.domain.post.exception.PostDeleteAccessDeniedException;
 import com.tavemakers.surf.domain.post.exception.PostImageListEmptyException;
 import com.tavemakers.surf.domain.post.exception.PostNotFoundException;
@@ -35,6 +36,7 @@ import com.tavemakers.surf.global.logging.LogEvent;
 import com.tavemakers.surf.global.logging.LogParam;
 import com.tavemakers.surf.global.util.SecurityUtils;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -64,6 +66,7 @@ public class PostPatchService {
     private final PostFileDeleteService fileDeleteService;
     private final MemberGetService memberGetService;
     private final ViewCountService viewCountService;
+    private final ApplicationEventPublisher eventPublisher;
 
     /** 게시글 수정 (예약 변경 처리는 Usecase에서 담당) */
     @Transactional
@@ -134,10 +137,17 @@ public class PostPatchService {
         imageDeleteService.deleteAll(beforeImages);
     }
 
-    /** 기존 첨부파일 삭제 */
+    /** 기존 첨부파일 삭제 (DB 삭제 후 커밋 시점에 S3 삭제 이벤트 발행) */
     private void deleteExistingFiles(Post post) {
         List<PostFileUrl> beforeFiles = fileGetService.getPostFileUrls(post.getId());
+        if (beforeFiles.isEmpty()) {
+            return;
+        }
+        List<String> fileUrls = beforeFiles.stream()
+                .map(PostFileUrl::getFileUrl)
+                .toList();
         fileDeleteService.deleteAll(beforeFiles);
+        eventPublisher.publishEvent(new PostFilesDeletedEvent(fileUrls));
     }
 
     /** 카테고리 유효성 검증 및 조회 */

--- a/src/main/java/com/tavemakers/surf/global/common/s3/exception/ErrorMessage.java
+++ b/src/main/java/com/tavemakers/surf/global/common/s3/exception/ErrorMessage.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus;
 public enum ErrorMessage {
 
     FILENAME_IS_EMPTY(HttpStatus.NOT_FOUND, "건네받은 [파일명]이 없습니다."),
+    FILE_URL_INVALID(HttpStatus.BAD_REQUEST, "[파일 URL] 형식이 올바르지 않습니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/tavemakers/surf/global/common/s3/exception/InvalidFileUrlException.java
+++ b/src/main/java/com/tavemakers/surf/global/common/s3/exception/InvalidFileUrlException.java
@@ -1,0 +1,11 @@
+package com.tavemakers.surf.global.common.s3.exception;
+
+import com.tavemakers.surf.global.common.exception.BaseException;
+
+import static com.tavemakers.surf.global.common.s3.exception.ErrorMessage.FILE_URL_INVALID;
+
+public class InvalidFileUrlException extends BaseException {
+    public InvalidFileUrlException() {
+        super(FILE_URL_INVALID.getStatus(), FILE_URL_INVALID.getMessage());
+    }
+}

--- a/src/main/java/com/tavemakers/surf/global/common/s3/service/S3Service.java
+++ b/src/main/java/com/tavemakers/surf/global/common/s3/service/S3Service.java
@@ -7,10 +7,12 @@ import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
 import com.tavemakers.surf.global.common.s3.dto.PreSignedUrlResDto;
 import com.tavemakers.surf.global.common.s3.exception.FileNameIsEmptyException;
+import com.tavemakers.surf.global.common.s3.exception.InvalidFileUrlException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -67,6 +69,30 @@ public class S3Service {
     private Date getExpiration() {
         Instant expirationInstant = Instant.now().plus(PRESIGNED_EXPIRATION, ChronoUnit.MINUTES);
         return Date.from(expirationInstant);
+    }
+
+    /** S3 파일 삭제 (fileUrl에서 객체 key를 추출하여 삭제) */
+    public void deleteFile(String fileUrl) {
+        s3Client.deleteObject(bucketName, extractKey(fileUrl));
+    }
+
+    /**
+     * fileUrl에서 S3 객체 key를 추출한다.
+     * full URL(https://bucket.s3.amazonaws.com/original/...) 과 key(original/...) 양쪽을 허용한다.
+     * DB에는 full URL이 저장되는 것이 원칙이나, 프론트가 PreSignedUrlResDto.key를 직접 전달하는
+     * 경우를 대비해 key 형식도 방어적으로 처리한다.
+     */
+    private String extractKey(String fileUrl) {
+        try {
+            String path = new URL(fileUrl).getPath();
+            return path.startsWith("/") ? path.substring(1) : path;
+        } catch (MalformedURLException e) {
+            // URL 파싱 실패 → key 형식으로 간주하고 그대로 사용
+            if (fileUrl.startsWith(ORIGINAL_PATH)) {
+                return fileUrl;
+            }
+            throw new InvalidFileUrlException();
+        }
     }
 
 }

--- a/src/main/java/com/tavemakers/surf/global/common/s3/service/S3Service.java
+++ b/src/main/java/com/tavemakers/surf/global/common/s3/service/S3Service.java
@@ -31,7 +31,9 @@ public class S3Service {
     @Value("${cloud.aws.bucket-name}")
     private String bucketName;
 
-    /** 다수 파일에 대한 PreSigned URL 목록 생성 */
+    /**
+     * 다수 파일에 대한 PreSigned URL 목록 생성
+     */
     public List<PreSignedUrlResDto> generatePreSignedUrlList(List<String> fileNames) {
         validateFileName(fileNames);
         return fileNames.stream()
@@ -40,12 +42,14 @@ public class S3Service {
     }
 
     private void validateFileName(List<String> fileNames) {
-        if(fileNames == null || fileNames.isEmpty()) {
+        if (fileNames == null || fileNames.isEmpty()) {
             throw new FileNameIsEmptyException();
         }
     }
 
-    /** 단일 파일 업로드용 PreSigned URL 생성 */
+    /**
+     * 단일 파일 업로드용 PreSigned URL 생성
+     */
     public PreSignedUrlResDto generateSinglePutPreSignedUrl(String filename) {
         String key = ORIGINAL_PATH + UUID.randomUUID() + "/" + filename;
         Date expiration = getExpiration();
@@ -71,7 +75,9 @@ public class S3Service {
         return Date.from(expirationInstant);
     }
 
-    /** S3 파일 삭제 (파일 본체와 마커를 모두 정리) */
+    /**
+     * S3 파일 삭제 (파일 본체와 마커를 모두 정리)
+     */
     public void deleteFile(String fileUrl) {
         String fileKey = extractKey(fileUrl); // original/{UUID}/{filename}
 
@@ -95,14 +101,18 @@ public class S3Service {
     private String extractKey(String fileUrl) {
         try {
             String path = new URL(fileUrl).getPath();
-            return path.startsWith("/") ? path.substring(1) : path;
+            String key = path.startsWith("/") ? path.substring(1) : path;
+            return validateKey(key);
         } catch (MalformedURLException e) {
-            // URL 파싱 실패 → key 형식으로 간주하고 그대로 사용
-            if (fileUrl.startsWith(ORIGINAL_PATH)) {
-                return fileUrl;
-            }
-            throw new InvalidFileUrlException();
+            return validateKey(fileUrl);
         }
+    }
+
+    private String validateKey(String key) {
+        if (key != null && key.startsWith(ORIGINAL_PATH)) {
+            return key;
+        }
+        throw new InvalidFileUrlException();
     }
 
 }

--- a/src/main/java/com/tavemakers/surf/global/common/s3/service/S3Service.java
+++ b/src/main/java/com/tavemakers/surf/global/common/s3/service/S3Service.java
@@ -71,9 +71,19 @@ public class S3Service {
         return Date.from(expirationInstant);
     }
 
-    /** S3 파일 삭제 (fileUrl에서 객체 key를 추출하여 삭제) */
+    /** S3 파일 삭제 (파일 본체와 마커를 모두 정리) */
     public void deleteFile(String fileUrl) {
-        s3Client.deleteObject(bucketName, extractKey(fileUrl));
+        String fileKey = extractKey(fileUrl); // original/{UUID}/{filename}
+
+        // 실제 파일 삭제
+        s3Client.deleteObject(bucketName, fileKey);
+
+        // 부모 폴더 마커(original/{UUID}/) 정리
+        int lastSlash = fileKey.lastIndexOf('/');
+        if (lastSlash > 0) {
+            String folderMarkerKey = fileKey.substring(0, lastSlash + 1);
+            s3Client.deleteObject(bucketName, folderMarkerKey);
+        }
     }
 
     /**

--- a/src/main/java/com/tavemakers/surf/global/config/AsyncConfig.java
+++ b/src/main/java/com/tavemakers/surf/global/config/AsyncConfig.java
@@ -40,4 +40,20 @@ public class AsyncConfig {
                     executor.getQueue().remainingCapacity());
         }
     }
+
+    // S3 제거 로직 비동기 처리
+    @Bean("s3DeleteExecutor")
+    public Executor s3DeleteExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(5);
+        executor.setMaxPoolSize(10);
+        executor.setQueueCapacity(100);
+        executor.setThreadNamePrefix("s3-del-");
+
+        // 폐기(silent drop) 대신 호출 스레드에서 실행해 backpressure 확보 → 삭제 누락 방지
+        executor.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());
+        executor.initialize();
+        return executor;
+    }
+
 }


### PR DESCRIPTION
## 📄 작업 내용 요약
기존 코드에서는 게시글 첨부파일(`PostFileUrl`)이 다음 두 흐름에서 **DB 레코드만 삭제되고 S3 객체는 그대로 남는** 문제가 있습니다.
> 현재 브렌치의 변경점으로는 PostFileUrl 중심입니다. 이미지 PostImageUrl은 DB 삭제만 처리되고 S3 삭제 이벤트가 누락 되어있습니다.

## 📎 Issue 번호
<!-- closed #번호 -->

closed #315 
분석한 Version B (서버 직접 삭제) 안을 따른다.


## 1. 설계 원칙

### 1.1 DB 커밋 이후 S3 삭제 (AFTER_COMMIT)

`@Transactional` 내부에서 S3 객체를 직접 지우면, 트랜잭션 롤백 시 이미 사라진 S3 파일을 복구할 수 없다. 따라서 다음 순서를 강제합니다.

```
@Transactional 내부:
  1. DB에서 PostFileUrl 레코드 삭제
  2. PostFilesDeletedEvent 발행 (ApplicationEventPublisher)
  3. 트랜잭션 커밋

커밋 이후 (@TransactionalEventListener AFTER_COMMIT):
  4. S3Service.deleteFile(fileUrl) 호출
     - 실패해도 예외 전파하지 않음 (warn 로그만 남김)
     - orphan은 추후 정리 작업으로 복구 가능
```

| 실패 시점 | DB 상태 | S3 상태 | 결과 |
|----------|--------|--------|------|
| DB 삭제 실패 | 롤백 (이벤트 미발행) | 변경 없음 | **안전** |
| S3 삭제 실패 | 정상 | 구 파일 orphan | orphan 정리 작업으로 복구 가능 |

### 1.2 fileUrl 형식 양방향 허용

DB에는 full URL(`https://bucket.s3.amazonaws.com/original/...`)이 저장되는 것이 원칙이나, 프론트가 `PreSignedUrlResDto.key`를 그대로 전달하는 경우를 대비해 **full URL / key 양쪽을 허용**합니다. (`S3Service#extractKey`)

### 1.3 권한 검증 — 작성자 또는 관리자

첨부파일 단건 삭제도 게시글 삭제와 동일하게 `validateOwnerOrManager`로 작성자 본인 또는 `hasDeleteRole()` 보유자만 허용합니다.

---

## 2. 변경 사항 (Commit-by-Commit)

### 82a2dce6 S3Service에 deleteFile 메서드 추가

- `global/common/s3/service/S3Service.java`
- `global/common/s3/exception/InvalidFileUrlException.java` (신규)
- `global/common/s3/exception/ErrorMessage.java` — `FILE_URL_INVALID` 추가


`URL` 파싱 실패 시 `ORIGINAL_PATH` 접두사를 가진 key 형식이면 그대로 사용하고, 그 외에는 `InvalidFileUrlException` (HTTP 400)으로 차단

---

### 46c97385 PostFilesDeletedEvent + AFTER_COMMIT 리스너 신규

- `domain/post/event/PostFilesDeletedEvent.java` (신규)
- `domain/post/event/PostFilesDeletedListener.java` (신규)

S3 삭제 실패는 예외를 전파하지 않고 `WARN` 로그만 남긴다. 게시글 삭제/수정의 본 트랜잭션은 이미 커밋된 상태이므로, S3 실패가 사용자 응답에 영향을 주면 안 되기 때문이다. (orphan은 후속 정리 작업의 책임)

---

### 6c031e1c 게시글 수정 시 교체 파일 S3 삭제 이벤트 발행

-  `domain/post/service/post/PostPatchService.java`

- DB 삭제 전에 fileUrl 목록을 추출(엔티티 삭제 후 접근 회피)
- DB 삭제 → 이벤트 발행 순서 유지
- 빈 리스트면 일찍 종료해 불필요한 이벤트를 막음

---

### 01b77f4b 게시글 삭제 시 첨부파일 S3 orphan 해결

-  `domain/post/service/post/PostDeleteService.java`

**변경:** `delete()` / `expel()` 두 경로 모두에 `publishFilesDeletedEvent`를 호출

`delete()`(작성자/관리자 일반 삭제)와 `expel()`(제명에 의한 삭제) 양쪽 모두 동일한 이벤트로 처리해, 어떤 경로로 게시글이 사라지든 S3 정합성이 유지

---

### 7d104588 첨부파일 단건 삭제 API 신규

신규 파일:
- `domain/post/controller/file/PostFileDeleteController.java`
- `domain/post/service/post/PostFileDeleteUsecase.java`
- `domain/post/exception/PostFileNotFoundException.java`
- `domain/post/exception/PostFileDeleteAccessDeniedException.java`

변경 파일:
- `domain/post/controller/ResponseMessage.java` — `POST_FILE_DELETED` 추가
- `domain/post/exception/ErrorMessage.java` — `POST_FILE_NOT_FOUND`, `POST_FILE_DELETE_DENIED` 추가
- `domain/post/service/file/PostFileGetService.java` — `getPostFileUrl(Long fileId)` 추가
- `domain/post/service/file/PostFileDeleteService.java` — `delete(PostFileUrl file)` 추가

---

## 3. 영향받는 API

### 3.1 신규 API

| Method | Path | 설명 | 인증 | 응답 |
|--------|------|------|------|------|
| `DELETE` | `/v1/user/posts/files/{fileId}` | 게시글 첨부파일 단건 삭제 | JWT (사용자) | `204 NO_CONTENT` |


### 3.2 동작이 변경된 기존 API (Behavior Change)

| Method | Path | 변경 전 | 변경 후 |
|--------|------|---------|---------|
| `PATCH` | `/v1/user/posts/{postId}` | 교체된 첨부파일 DB만 삭제 → **S3 orphan** | DB 삭제 + 커밋 후 S3 삭제 이벤트 발행 |
| `DELETE` | `/v1/user/posts/{postId}` | 첨부파일 DB만 삭제 → **S3 orphan** | DB 삭제 + 커밋 후 S3 삭제 이벤트 발행 |
| (내부) `PostDeleteService#expel` | 제명에 의한 게시글 삭제 — 첨부파일 S3 미삭제 | 첨부파일 S3 삭제 이벤트 발행 |

---

### 4.2 게시글 수정 시 교체 파일 처리

`PostPatchService.patch()` → `deleteExistingFiles()` 내부에서 DB delete + 이벤트 발행 → 커밋 후 listener가 구 파일 일괄 S3 삭제.

---

## 4. 영향 범위 및 회귀 위험

| 영역 | 영향 |
|------|------|
| `S3Service` | `deleteFile`/`extractKey` 신규 — 기존 메서드 미수정, 회귀 없음 |
| `PostPatchService` | `deleteExistingFiles` 내부 로직만 변경, 호출 경로/응답 동일 |
| `PostDeleteService` | `delete`/`expel` 양쪽에 이벤트 발행 추가, 응답 동일 |
| `PostFileGetService` / `PostFileDeleteService` | 메서드 추가만 발생, 기존 사용처 영향 없음 |
| `ResponseMessage` / `ErrorMessage` (post) | enum 항목 추가만 발생 |
| `PostFilesDeletedListener` | 신규 빈 — 동일 이벤트를 구독하는 다른 리스너 없음 |

---

## 5. 테스트 시나리오 (수동/QA 가이드)

| # | 시나리오 | 기대 결과 |
|---|---------|----------|
| 1 | 첨부파일 있는 게시글 작성 → 본인이 `DELETE /v1/user/posts/files/{fileId}` 호출 | `204`, DB 레코드 삭제, S3 객체 제거 확인 |
| 2 | 첨부파일 있는 게시글 → 타인이 단건 삭제 호출 | `401 UNAUTHORIZED` (`[첨부파일]을 삭제할 권한이 없습니다.`) |
| 3 | 존재하지 않는 `fileId`로 단건 삭제 호출 | `404 NOT_FOUND` (`존재하지 않는 [첨부파일]입니다.`) |
| 4 | 관리자(`hasDeleteRole`)가 타인 게시글 첨부파일 단건 삭제 | `204`, 정상 삭제 |
| 5 | 첨부파일 N개 있는 게시글 `PATCH` — 첨부파일 모두 교체 | 기존 N개 S3 객체 제거 + 새 N개만 유지 |
| 6 | 첨부파일 있는 게시글 `DELETE` | 게시글/첨부파일 DB 삭제 + S3 객체 모두 제거 |
| 7 | 회원 제명에 의한 `expel` 경로 게시글 삭제 | 첨부파일 S3 객체 제거 |
| 8 | S3 일시 장애를 가정해 `s3Service.deleteFile`이 throw하도록 강제 | 본 API는 `204`로 정상 응답, WARN 로그만 남음 (orphan 발생) |
| 9 | DB에 key(`original/...`) 형식만 저장된 레거시 데이터로 단건 삭제 | `extractKey`가 key 그대로 사용해 정상 삭제 |
| 10 | DB에 잘못된 fileUrl (예: `not-a-url`) 저장된 경우 | `InvalidFileUrlException` 발생 → listener에서 WARN 로그로 흡수, 응답엔 영향 없음 |

---

## 6. 후속 작업 (Follow-up)

- [x] `PostFilesDeletedListener`에 `@Async` 도입 및 dedicated `TaskExecutor` 구성 — 응답 지연 최소화
- [ ] 동일 패턴을 `PostImageUrl`에도 확장 (현재 이미지 삭제도 DB만 처리 중이라면)

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 게시글 첨부파일 단건 삭제 API 추가(요청 후 204와 성공 메시지 반환)
  * DB 삭제 후 클라우드 스토리지 파일을 트랜잭션 커밋 이후 비동기으로 추가 삭제 처리(전용 비동기 실행기 포함)
  * 삭제 시 소속·권한 검증 로직 적용(게시글 소유자 및 관리자 허용)

* **Error Handling**
  * 첨부파일 미존재·소속 불일치·삭제 권한 거부에 대한 구체적 오류 메시지 및 예외 추가
  * 잘못된 파일 URL 형식 검증 및 관련 오류 처리 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Tave-Makers/SURF-BE/pull/324?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->