### PR TITLE
[Hotfix] 로그 분석 서버 전송 비활성화 문제 해결 #326

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -86,7 +86,7 @@ server:
 
 logging:
   forwarding:
-    enabled: false
+    enabled: ${LOG_FORWARD_ENABLED:false}
     url: ${LOG_FORWARD_URL:}
     timeout-ms: 3000
     max-retries: 1


### PR DESCRIPTION
## Summary

- `application.yml`에 `logging.forwarding.enabled: false`가 하드코딩되어 있어 `LogForwardingService` 빈이 생성되지 않고, 분석 서버로의 로그 전송이 항상 스킵되는 버그 수정
- `enabled` 값을 환경변수 `LOG_FORWARD_ENABLED`로 제어할 수 있도록 변경 (기본값 `false` 유지)
- `.env`에 `LOG_FORWARD_ENABLED=true` 추가 필요 (gitignore 대상이라 직접 추가 요망)

## Root Cause

```
LogForwardingService (@ConditionalOnProperty enabled=true)
    → enabled: false (하드코딩) → 빈 미생성

LogEventEmitterImpl.flush()
    → if (forwardingService != null)  ← 항상 null → 전송 스킵
```

## Changes

```yaml
# before
logging:
  forwarding:
    enabled: false

# after
logging:
  forwarding:
    enabled: ${LOG_FORWARD_ENABLED:false}
```

## Test Plan

- [ ] `.env`에 `LOG_FORWARD_ENABLED=true` 설정 후 서버 재시작
- [ ] 게시글 생성 API 호출
- [ ] 분석 서버(`http://52.65.89.250:8000/api/events`)에 로그 수신 확인
- [ ] `LOG_FORWARD_ENABLED` 미설정 시 기존과 동일하게 전송 비활성화 확인

closes #326

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **설정 개선**
  * 로깅 전달(Logging Forwarding) 기능을 환경 변수로 제어할 수 있도록 변경했습니다. 기본값은 비활성화 상태이며, `LOG_FORWARD_ENABLED` 환경 변수를 통해 동적으로 설정할 수 있습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Tave-Makers/SURF-BE/pull/327?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->