### PR TITLE
[REFACTOR] 게시글 이미지(PostImageUrl) 수정/삭제 시 S3 고아 문제 해결

### DIFF
--- a/src/main/java/com/tavemakers/surf/domain/post/controller/ResponseMessage.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/controller/ResponseMessage.java
@@ -12,6 +12,7 @@ public enum ResponseMessage {
     POST_DELETED("[게시글]이 성공적으로 삭제되었습니다."),
     POST_READ("[게시글]이 성공적으로 조회되었습니다."),
     POST_FILE_DELETED("[게시글] 첨부파일이 성공적으로 삭제되었습니다."),
+    POST_IMAGE_DELETED("[게시글] 이미지가 성공적으로 삭제되었습니다."),
     MY_POSTS_READ("내가 작성한 [게시글] 목록을 성공적으로 조회했습니다."),
     POSTS_BY_BOARD_READ("[게시판]별 [게시글] 목록을 성공적으로 조회했습니다."),
     POSTS_BY_MEMBER_READ("특정 회원이 작성한 [게시글] 목록을 성공적으로 조회했습니다."),

--- a/src/main/java/com/tavemakers/surf/domain/post/controller/image/PostImageDeleteController.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/controller/image/PostImageDeleteController.java
@@ -1,0 +1,32 @@
+package com.tavemakers.surf.domain.post.controller.image;
+
+import com.tavemakers.surf.domain.post.service.post.PostImageDeleteUsecase;
+import com.tavemakers.surf.global.common.response.ApiResponse;
+import com.tavemakers.surf.global.util.SecurityUtils;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import static com.tavemakers.surf.domain.post.controller.ResponseMessage.POST_IMAGE_DELETED;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping
+@Tag(name = "게시물", description = "게시물 이미지 삭제 API")
+public class PostImageDeleteController {
+
+    private final PostImageDeleteUsecase postImageDeleteUsecase;
+
+    /** 게시글 이미지 삭제 (작성자/권한 검증은 서비스에서) */
+    @Operation(summary = "게시글 이미지 삭제", description = "게시글에 첨부된 이미지를 삭제합니다. URL의 postId와 이미지가 속한 게시글이 일치해야 하며, S3 이미지는 트랜잭션 커밋 이후 삭제됩니다.")
+    @DeleteMapping("/v1/user/posts/{postId}/images/{imageId}")
+    public ApiResponse<Void> deletePostImage(
+            @PathVariable(name = "postId") Long postId,
+            @PathVariable(name = "imageId") Long imageId) {
+        Long memberId = SecurityUtils.getCurrentMemberId();
+        postImageDeleteUsecase.deletePostImage(postId, imageId, memberId);
+        return ApiResponse.response(HttpStatus.NO_CONTENT, POST_IMAGE_DELETED.getMessage());
+    }
+}

--- a/src/main/java/com/tavemakers/surf/domain/post/exception/ErrorMessage.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/exception/ErrorMessage.java
@@ -17,6 +17,10 @@ public enum ErrorMessage {
     POST_FILE_DELETE_DENIED(HttpStatus.FORBIDDEN, "[첨부파일]을 삭제할 권한이 없습니다."),
     POST_FILE_MISMATCH(HttpStatus.NOT_FOUND, "해당 [게시글]에 속하지 않는 [첨부파일]입니다."),
 
+    POST_IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 [이미지]입니다."),
+    POST_IMAGE_DELETE_DENIED(HttpStatus.FORBIDDEN, "[이미지]를 삭제할 권한이 없습니다."),
+    POST_IMAGE_MISMATCH(HttpStatus.NOT_FOUND, "해당 [게시글]에 속하지 않는 [이미지]입니다."),
+
     BOARD_WRITE_NOT_ALLOWED(HttpStatus.FORBIDDEN, "[공지사항] 게시판은 관리자만 게시글을 작성할 수 있습니다.");
 
     private final HttpStatus status;

--- a/src/main/java/com/tavemakers/surf/domain/post/exception/PostImageDeleteAccessDeniedException.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/exception/PostImageDeleteAccessDeniedException.java
@@ -1,0 +1,11 @@
+package com.tavemakers.surf.domain.post.exception;
+
+import com.tavemakers.surf.global.common.exception.BaseException;
+
+import static com.tavemakers.surf.domain.post.exception.ErrorMessage.POST_IMAGE_DELETE_DENIED;
+
+public class PostImageDeleteAccessDeniedException extends BaseException {
+    public PostImageDeleteAccessDeniedException() {
+        super(POST_IMAGE_DELETE_DENIED.getStatus(), POST_IMAGE_DELETE_DENIED.getMessage());
+    }
+}

--- a/src/main/java/com/tavemakers/surf/domain/post/exception/PostImageMismatchException.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/exception/PostImageMismatchException.java
@@ -1,0 +1,11 @@
+package com.tavemakers.surf.domain.post.exception;
+
+import com.tavemakers.surf.global.common.exception.BaseException;
+
+import static com.tavemakers.surf.domain.post.exception.ErrorMessage.POST_IMAGE_MISMATCH;
+
+public class PostImageMismatchException extends BaseException {
+    public PostImageMismatchException() {
+        super(POST_IMAGE_MISMATCH.getStatus(), POST_IMAGE_MISMATCH.getMessage());
+    }
+}

--- a/src/main/java/com/tavemakers/surf/domain/post/exception/PostImageNotFoundException.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/exception/PostImageNotFoundException.java
@@ -1,0 +1,11 @@
+package com.tavemakers.surf.domain.post.exception;
+
+import com.tavemakers.surf.global.common.exception.BaseException;
+
+import static com.tavemakers.surf.domain.post.exception.ErrorMessage.POST_IMAGE_NOT_FOUND;
+
+public class PostImageNotFoundException extends BaseException {
+    public PostImageNotFoundException() {
+        super(POST_IMAGE_NOT_FOUND.getStatus(), POST_IMAGE_NOT_FOUND.getMessage());
+    }
+}

--- a/src/main/java/com/tavemakers/surf/domain/post/service/image/PostImageDeleteService.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/service/image/PostImageDeleteService.java
@@ -23,4 +23,10 @@ public class PostImageDeleteService {
         repository.deleteAllInBatch(beforeImages);
     }
 
+    /** 게시글 이미지 단건 삭제 */
+    @Transactional
+    public void delete(PostImageUrl image) {
+        repository.delete(image);
+    }
+
 }

--- a/src/main/java/com/tavemakers/surf/domain/post/service/image/PostImageGetService.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/service/image/PostImageGetService.java
@@ -1,6 +1,7 @@
 package com.tavemakers.surf.domain.post.service.image;
 
 import com.tavemakers.surf.domain.post.entity.PostImageUrl;
+import com.tavemakers.surf.domain.post.exception.PostImageNotFoundException;
 import com.tavemakers.surf.domain.post.repository.PostImageUrlRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -18,6 +19,13 @@ public class PostImageGetService {
     @Transactional(readOnly = true)
     public List<PostImageUrl> getPostImageUrls(Long postId) {
         return postImageUrlRepository.findByPostId(postId);
+    }
+
+    /** 게시글 이미지 단건 조회 */
+    @Transactional(readOnly = true)
+    public PostImageUrl getPostImageUrl(Long imageId) {
+        return postImageUrlRepository.findById(imageId)
+                .orElseThrow(PostImageNotFoundException::new);
     }
 
 }

--- a/src/main/java/com/tavemakers/surf/domain/post/service/post/PostDeleteService.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/service/post/PostDeleteService.java
@@ -55,6 +55,7 @@ public class PostDeleteService {
         List<PostImageUrl> postImageUrls = postImageGetService.getPostImageUrls(post.getId());
         if (postImageUrls != null && !postImageUrls.isEmpty()) {
             postImageDeleteService.deleteAll(postImageUrls);
+            publishImagesDeletedEvent(postImageUrls);
         }
 
         List<PostFileUrl> postFileUrls = postFileGetService.getPostFileUrls(post.getId());
@@ -74,6 +75,7 @@ public class PostDeleteService {
         List<PostImageUrl> postImageUrls = postImageGetService.getPostImageUrls(post.getId());
         if (postImageUrls != null && !postImageUrls.isEmpty()) {
             postImageDeleteService.deleteAll(postImageUrls);
+            publishImagesDeletedEvent(postImageUrls);
         }
 
         List<PostFileUrl> postFileUrls = postFileGetService.getPostFileUrls(post.getId());
@@ -89,6 +91,14 @@ public class PostDeleteService {
     private void publishFilesDeletedEvent(List<PostFileUrl> fileUrls) {
         List<String> urls = fileUrls.stream()
                 .map(PostFileUrl::getFileUrl)
+                .toList();
+        eventPublisher.publishEvent(new PostFilesDeletedEvent(urls));
+    }
+
+    /** DB 삭제 완료 후 호출 — 트랜잭션 커밋 이후 S3 이미지 삭제를 트리거하는 이벤트를 발행한다 */
+    private void publishImagesDeletedEvent(List<PostImageUrl> imageUrls) {
+        List<String> urls = imageUrls.stream()
+                .map(PostImageUrl::getOriginalUrl)
                 .toList();
         eventPublisher.publishEvent(new PostFilesDeletedEvent(urls));
     }

--- a/src/main/java/com/tavemakers/surf/domain/post/service/post/PostImageDeleteUsecase.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/service/post/PostImageDeleteUsecase.java
@@ -1,0 +1,55 @@
+package com.tavemakers.surf.domain.post.service.post;
+
+import com.tavemakers.surf.domain.member.entity.Member;
+import com.tavemakers.surf.domain.member.service.MemberGetService;
+import com.tavemakers.surf.domain.post.entity.Post;
+import com.tavemakers.surf.domain.post.entity.PostImageUrl;
+import com.tavemakers.surf.domain.post.event.PostFilesDeletedEvent;
+import com.tavemakers.surf.domain.post.exception.PostImageDeleteAccessDeniedException;
+import com.tavemakers.surf.domain.post.exception.PostImageMismatchException;
+import com.tavemakers.surf.domain.post.service.image.PostImageDeleteService;
+import com.tavemakers.surf.domain.post.service.image.PostImageGetService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/** 게시글 이미지 삭제 Usecase - DB 삭제 후 커밋 시점에 S3 이미지 삭제 */
+@Service
+@RequiredArgsConstructor
+public class PostImageDeleteUsecase {
+
+    private final PostImageGetService postImageGetService;
+    private final PostImageDeleteService postImageDeleteService;
+    private final MemberGetService memberGetService;
+    private final ApplicationEventPublisher eventPublisher;
+
+    /** 게시글 이미지 단건 삭제 (작성자 또는 관리자만 허용) */
+    @Transactional
+    public void deletePostImage(Long postId, Long imageId, Long requesterId) {
+        PostImageUrl image = postImageGetService.getPostImageUrl(imageId);
+        validateImageBelongsToPost(image, postId);
+
+        Member member = memberGetService.getMember(requesterId);
+        validateOwnerOrManager(image.getPost(), member);
+
+        postImageDeleteService.delete(image);
+        eventPublisher.publishEvent(new PostFilesDeletedEvent(List.of(image.getOriginalUrl())));
+    }
+
+    /** URL의 postId와 이미지가 실제 속한 게시글이 일치하는지 검증 */
+    private void validateImageBelongsToPost(PostImageUrl image, Long postId) {
+        if (!image.getPost().getId().equals(postId)) {
+            throw new PostImageMismatchException();
+        }
+    }
+
+    /** 게시글 소유자 또는 관리자 권한 검증 */
+    private void validateOwnerOrManager(Post post, Member member) {
+        if (!member.hasDeleteRole() && !post.isOwner(member.getId())) {
+            throw new PostImageDeleteAccessDeniedException();
+        }
+    }
+}

--- a/src/main/java/com/tavemakers/surf/domain/post/service/post/PostPatchService.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/service/post/PostPatchService.java
@@ -131,10 +131,17 @@ public class PostPatchService {
         return PostDetailResDTO.of(post, scrappedByMe, likedByMe, true, imageDtoList, fileDtoList, reservedAt, viewCount);
     }
 
-    /** 기존 이미지 삭제 */
+    /** 기존 이미지 삭제 (DB 삭제 후 커밋 시점에 S3 삭제 이벤트 발행) */
     private void deleteExistingImages(Post post) {
         List<PostImageUrl> beforeImages = imageGetService.getPostImageUrls(post.getId());
+        if (beforeImages.isEmpty()) {
+            return;
+        }
+        List<String> imageUrls = beforeImages.stream()
+                .map(PostImageUrl::getOriginalUrl)
+                .toList();
         imageDeleteService.deleteAll(beforeImages);
+        eventPublisher.publishEvent(new PostFilesDeletedEvent(imageUrls));
     }
 
     /** 기존 첨부파일 삭제 (DB 삭제 후 커밋 시점에 S3 삭제 이벤트 발행) */


### PR DESCRIPTION
## 📄 작업 내용 요약
게시글 이미지 S3 orphan 해결 + 이미지 단건 삭제 API 추가 — 첨부파일(#324)의 PostFilesDeletedEvent/AFTER_COMMIT 패턴 재사용, 신규 이벤트 없음·응답 스펙 무변경

## 📎 Issue 번호
<!-- closed #번호 -->
closed #328

## 1. 배경 (Background)

게시글 **첨부파일**(`PostFileUrl`)은 게시글 수정·삭제 시 S3 객체까지 함께 정리되도록
`PostFilesDeletedEvent` + `@TransactionalEventListener(AFTER_COMMIT)` 구조로 정합성을 확보했다.

하지만 게시글 **이미지**(`PostImageUrl`)는 동일한 orphan 문제가 **그대로 남아 있다.**
현재 이미지는 DB 레코드만 삭제되고 S3 객체는 영구히 남는다.

### 문제가 발생하는 흐름

| 흐름 | 현재 동작 | 문제 |
|------|-----------|------|
| `PATCH /v1/user/posts/{postId}` (이미지 교체) | `deleteExistingImages()` → `imageDeleteService.deleteAll()` (DB batch delete) | 기존 이미지 S3 객체가 orphan으로 누적 |
| `DELETE /v1/user/posts/{postId}` (게시글 삭제) | `PostDeleteService.delete()` → `imageDeleteService.deleteAll()` | 이미지 S3 객체가 orphan으로 누적 |
| (내부) `PostDeleteService.expel()` (제명에 의한 삭제) | 동일하게 DB만 삭제 | 이미지 S3 객체가 orphan으로 누적 |

게시글은 이미지를 다수 포함하는 경우가 많아 첨부파일보다 orphan 누적 속도가 더 빠르고,
S3 저장 비용·관리 부담으로 직결된다.

### 현재 코드

```java
// PostImageDeleteService — DB만 삭제, S3 삭제 없음
@Transactional
public void deleteAll(List<PostImageUrl> beforeImages) {
    if (beforeImages == null || beforeImages.isEmpty()) {
        return;
    }
    repository.deleteAllInBatch(beforeImages);   // ← S3 객체는 그대로 남음
}
```

```java
// PostPatchService — 이미지는 이벤트 발행 없이 DB만 삭제 (첨부파일과 대비)
private void deleteExistingImages(Post post) {
    List<PostImageUrl> beforeImages = imageGetService.getPostImageUrls(post.getId());
    imageDeleteService.deleteAll(beforeImages);   // ← 첨부파일과 달리 이벤트 미발행
}
```

---

## 2. 목표 (Goal)

PR #315 에서 정립한 **Version B (서버 직접 삭제) + AFTER_COMMIT** 패턴을 이미지에 동일하게 적용한다.

- [ ] 게시글 수정 시 교체된 기존 이미지의 S3 객체 제거
- [ ] 게시글 삭제(`delete`) 시 이미지 S3 객체 제거
- [ ] 게시글 제명 삭제(`expel`) 시 이미지 S3 객체 제거
- [ ] DB 커밋 이후에만 S3 삭제가 실행되도록 트랜잭션 순서 보장
- [ ] S3 삭제 실패가 사용자 응답·본 트랜잭션에 영향을 주지 않도록 격리(WARN 로그 흡수)

> **Non-Goal:** 기존에 이미 누적된 orphan을 일괄 정리하는 배치는 별도 이슈로 분리한다. (PR #315 follow-up 참고)

---

## 3. 설계 원칙 (PR #315와 동일)

### 3.1 DB 커밋 이후 S3 삭제 (AFTER_COMMIT)

`@Transactional` 내부에서 S3 객체를 직접 지우면 트랜잭션 롤백 시 이미 사라진 S3 객체를 복구할 수 없다.

```
@Transactional 내부:
  1. DB에서 PostImageUrl 레코드 삭제
  2. PostFilesDeletedEvent 발행 (이미지 URL 목록은 삭제 전에 추출)
  3. 트랜잭션 커밋

커밋 이후 (@TransactionalEventListener AFTER_COMMIT):
  4. PostFilesDeletedListener 가 S3Service.deleteFile(url) 호출
     - 실패해도 예외 전파하지 않고 WARN 로그만 남김
     - orphan은 후속 정리 배치로 복구
```

| 실패 시점 | DB 상태 | S3 상태 | 결과 |
|-----------|--------|--------|------|
| DB 삭제 실패 | 롤백 (이벤트 미발행) | 변경 없음 | **안전** |
| S3 삭제 실패 | 정상 | 구 이미지 orphan | 후속 정리로 복구 가능 |

### 3.2 기존 이벤트·리스너·S3 로직 전면 재사용

S3 제거 방식은 첨부파일 제거와 **완전히 동일**하다. 따라서 이미지 전용 신규 코드를 만들지 않고
PR #315에서 추가한 자산을 그대로 재사용한다.

- `PostFilesDeletedEvent(List<String> fileUrls)` — 이미지 URL 목록을 그대로 담아 발행
- `PostFilesDeletedListener` (AFTER_COMMIT) — 변경 없이 이미지 URL도 함께 처리
- `S3Service#deleteFile(String fileUrl)` / `extractKey` (full URL / key 양방향 허용)

> 이벤트는 "삭제된 S3 객체 URL 목록"이라는 동일한 의미를 가지므로, 첨부파일/이미지를 구분하지 않고
> 하나의 이벤트로 통합한다. **신규 이벤트·리스너 클래스를 추가하지 않는다.**

---

## 4. 구현 방향 (TODO)

> 신규 이벤트/리스너 클래스 없음. 기존 `PostFilesDeletedEvent` / `PostFilesDeletedListener` 를 재사용한다.
> 첨부파일에서 이미 검증된 "DB 삭제 → URL 추출 → 이벤트 발행" 패턴을 이미지 삭제 지점에 그대로 옮긴다.

### 4.1 PostPatchService — DB 삭제 후 이벤트 발행

```java
private void deleteExistingImages(Post post) {
    List<PostImageUrl> beforeImages = imageGetService.getPostImageUrls(post.getId());
    if (beforeImages.isEmpty()) {
        return;
    }
    List<String> imageUrls = beforeImages.stream()
            .map(PostImageUrl::getOriginalUrl)   // 삭제 전에 URL 추출
            .toList();
    imageDeleteService.deleteAll(beforeImages);
    eventPublisher.publishEvent(new PostFilesDeletedEvent(imageUrls));   // 기존 이벤트 재사용
}
```

### 4.2 PostDeleteService — delete()/expel() 양쪽에 이벤트 발행

```java
// delete() / expel() 내부 — 이미지 DB 삭제 직후
if (postImageUrls != null && !postImageUrls.isEmpty()) {
    postImageDeleteService.deleteAll(postImageUrls);
    publishImagesDeletedEvent(postImageUrls);
}

private void publishImagesDeletedEvent(List<PostImageUrl> images) {
    List<String> urls = images.stream()
            .map(PostImageUrl::getOriginalUrl)
            .toList();
    eventPublisher.publishEvent(new PostFilesDeletedEvent(urls));   // 기존 이벤트 재사용
}
```

> **참고:** `PostFilesDeletedEvent` 의 필드명이 `fileUrls` 이지만, 의미는 "삭제된 S3 객체 URL 목록"으로
> 이미지에도 그대로 적용된다. 필드명이 첨부파일에 한정돼 혼동을 준다면, 후속 리팩터링에서
> `urls` 등 중립적 이름으로 변경하는 것을 고려할 수 있다. (이번 이슈 범위에서는 변경하지 않는다.)

---

## 5. 영향 범위

| 영역 | 변경 |
|------|------|
| `PostFilesDeletedEvent` / `PostFilesDeletedListener` | 변경 없음 — **재사용** |
| `S3Service` | 변경 없음 (#315에서 추가한 `deleteFile`/`extractKey` 재사용) |
| `PostPatchService#deleteExistingImages` | 이벤트 발행 추가 (응답 스펙 동일) |
| 신규 클래스 | **없음** |
| API 응답(payload/상태코드) | **변경 없음** — 후행 S3 정리 동작만 추가 |

---

## 6. 테스트 시나리오 (QA 가이드)

| # | 시나리오 | 기대 결과 |
|---|---------|----------|
| 1 | 이미지 N개 게시글 `PATCH` — 이미지 전체 교체 | 기존 N개 S3 객체 제거 + 새 이미지만 유지 |
| 2 | 이미지 있는 게시글 `DELETE` | 게시글/이미지 DB 삭제 + S3 객체 모두 제거 |
| 3 | 제명(`expel`) 경로 게시글 삭제 | 이미지 S3 객체 제거 |
| 4 | S3 일시 장애 가정(`deleteFile` throw) | 본 API 정상 응답, WARN 로그만 남고 orphan 발생 |
| 5 | 이미지 없는 게시글 수정/삭제 | 이벤트 미발행, 정상 동작 (불필요 호출 없음) |
| 6 | DB에 key 형식만 저장된 레거시 이미지 | `extractKey`가 key 그대로 사용해 정상 삭제 |

---

## 7. 체크리스트

- [x] `PostPatchService.deleteExistingImages` 에 `PostFilesDeletedEvent` 발행 추가
- [x] `PostDeleteService.delete` 에 이벤트 발행 추가
- [x] `PostDeleteService.expel` 에 이벤트 발행 추가
- [x] 수동 QA 시나리오 1~6 검증

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 게시물 이미지 개별 삭제 기능 추가
    * 사용자가 게시물의 이미지를 하나씩 선택하여 삭제할 수 있습니다
    * 게시물 작성자만 삭제 가능하며, 권한 없음/이미지 미존재 등의 오류 메시지로 명확한 피드백을 제공합니다

<!-- end of auto-generated comment: release notes by coderabbit.ai -->