### PR TITLE
FIX: RTR rotate() 원자성, 동시성 결함 해소(Lua CAS + grace key)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,6 +45,8 @@ dependencies {
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation ("org.junit.jupiter:junit-jupiter-api:5.10.1")
     testRuntimeOnly("com.h2database:h2")
+    testImplementation("org.testcontainers:testcontainers:1.20.4")
+    testImplementation("org.testcontainers:junit-jupiter:1.20.4")
 
     implementation ("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2")
 

--- a/src/main/java/com/tavemakers/surf/domain/auth/common/service/RefreshTokenService.java
+++ b/src/main/java/com/tavemakers/surf/domain/auth/common/service/RefreshTokenService.java
@@ -12,6 +12,7 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ScanOptions;
 import org.springframework.data.redis.core.script.DefaultRedisScript;
 import org.springframework.http.ResponseCookie;
+import org.springframework.security.core.parameters.P;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
@@ -31,6 +32,16 @@ public class RefreshTokenService {
 
     /** invalidateAll SCAN 배치 크기 */
     private static final int SCAN_SIZE = 100;
+
+    /**
+     * 동시 회전 패자가 멱등 응답을 받을 수 있는 유예 시간(초).
+     * 정상 더블 서밋은 수십 ms 내에 발생하므로 30초면 충분하며,
+     * 짧게 유지해 탈취 토큰의 재사용 탐지 지연을 최소화한다.
+     */
+    private static final long GRACE_TTL_SECONDS = 30;
+
+    /** 유예 키 value 구분자 — JWT(base64url)에는 등장하지 않음 */
+    private static final char GRACE_DELIMITER = '|';
 
     // 저장된 값이 ARGV[1]과 일치할 때만 DEL — RTR 단일 사용 보장 (CAS)
     // 반환: 1=CONSUMED, 0=MISMATCH, -1=NOT_FOUND
@@ -92,13 +103,23 @@ public class RefreshTokenService {
         // 검증 + 삭제 원자화 (CAS). 동시 회전 시 단 한 요청만 CONSUMED를 받음
         ConsumeResult consumeResult = compareAndDelete(key, refreshToken);
 
-        if (consumeResult == ConsumeResult.NOT_FOUND) {
-            throw new UnauthorizedException(TokenErrorMessage.REFRESH_TOKEN_NOT_FOUND.getMessage());
-        }
-
-        if (consumeResult == ConsumeResult.MISMATCH) {
+        // 회전 경쟁의 패자 / 직전 토큰 재요청 — 유예 키로 멱등 처리
+        if (consumeResult != ConsumeResult.CONSUMED) {
+            String alreadyRotated = findGraceToken(memberId, deviceId, refreshToken);
+            if (alreadyRotated != null) {
+                log.info("[RTR][ROTATE] idempotent rotation (grace hit) memberId={}", memberId);
+                return emit(response, clientType, memberId, alreadyRotated);
+            }
+            if (consumeResult == ConsumeResult.NOT_FOUND) {
+                throw new UnauthorizedException(TokenErrorMessage.REFRESH_TOKEN_NOT_FOUND.getMessage());
+            }
             log.error("[RTR][ROTATE] refresh reuse detected memberId={}", memberId);
-            invalidateAll(memberId);
+            try {
+                invalidateAll(memberId);
+            } catch (RuntimeException ex) {
+                log.error("[RTR][ROTATE] invalidateAll failed during reuse detection memberId={}",
+                        memberId, ex);
+            }
             throw new UnauthorizedException(TokenErrorMessage.REFRESH_TOKEN_REUSE_DETECTED.getMessage());
         }
 
@@ -106,20 +127,17 @@ public class RefreshTokenService {
         log.info("[RTR][ROTATE] rotation allowed, old token consumed atomically");
 
         String newRefresh = jwtService.createRefreshToken(memberId, deviceId);
+        // 새 현재 키 저장 전에 유예 키 먼저 — 패자가 MISMATCH 시 항상 grace를 발견하도록 보장
+        saveGrace(memberId, deviceId, refreshToken, newRefresh);
         save(newRefresh);
 
-        if (clientType == ClientType.APP) {
-            log.info("[RTR][ROTATE] rotation success (app body) memberId={}", memberId);
-            return new RotateResult(memberId, newRefresh);
-        }
-        jwtService.sendRefreshToken(response, newRefresh);
-        log.info("[RTR][ROTATE] rotation success (web cookie) memberId={}", memberId);
-        return new RotateResult(memberId, null);
+        return emit(response, clientType, memberId, newRefresh);
     }
 
-    /** 특정 디바이스 refresh 무효화 (로그아웃) */
+    /** 특정 디바이스 refresh 무효화 (로그아웃) — 유예 키도 함께 폐기 */
     public void invalidate(Long memberId, String deviceId) {
         redisTemplate.delete(key(memberId, deviceId));
+        redisTemplate.delete(graceKey(memberId, deviceId));
     }
 
     /** refresh 재사용 탐지 시 전체 세션 폐기 — SCAN 커서로 non-blocking 순회 */
@@ -164,7 +182,13 @@ public class RefreshTokenService {
     /** 저장된 값이 expected와 일치하면 삭제 — Lua 스크립트로 단일 명령 보장 */
     private ConsumeResult compareAndDelete(String key, String expected) {
         Long result = redisTemplate.execute(COMPARE_AND_DELETE_SCRIPT, List.of(key), expected);
-        if (result == null || result == -1L) {
+        // 정상 결과는 -1/0/1. null은 스크립트 실행 실패·연결 이상 등 인프라 신호이므로
+        // NOT_FOUND(-1)와 묶지 않고 별도 예외로 노출해 운영 알림이 가능하게 한다.
+        if (result == null) {
+            log.error("[RTR][ROTATE] compareAndDelete returned null — Redis/script issue");
+            throw new IllegalStateException("CAS script returned null result");
+        }
+        if (result == -1L) {
             return ConsumeResult.NOT_FOUND;
         }
         return result == 1L ? ConsumeResult.CONSUMED : ConsumeResult.MISMATCH;
@@ -173,6 +197,42 @@ public class RefreshTokenService {
     private long deleteBatch(List<String> keys) {
         Long deleted = redisTemplate.delete(keys);
         return deleted == null ? 0 : deleted;
+    }
+
+    /** ClientType에 따라 새 refresh 토큰을 송출하고 결과를 반환 */
+    private RotateResult emit(HttpServletResponse response, ClientType clientType, Long memberId, String newRefresh) {
+        if (clientType == ClientType.APP) {
+            log.info("[RTR][ROTATE] rotation success (app body) memberId={}", memberId);
+            return new RotateResult(memberId, newRefresh);
+        }
+        jwtService.sendRefreshToken(response, newRefresh);
+        log.info("[RTR][ROTATE] rotation success (web cookie) memberId={}", memberId);
+        return new RotateResult(memberId, null);
+    }
+
+    /**
+     * 직전 회전으로 발급된 새 토큰을 유예 키에서 조회 (없으면 null).
+     * <p>유예 value는 {@code 직전토큰|새토큰} 형식이며, 들어온 토큰이 직전토큰과
+     * 일치할 때만 새 토큰을 반환한다. 임의의 만료 토큰이 멱등 응답을 받는 것을 막는다.
+     */
+    private String findGraceToken(Long memberId, String deviceId, String oldToken) {
+        String stored = redisTemplate.opsForValue().get(graceKey(memberId, deviceId));
+        if (stored == null) {
+            return null;
+        }
+        int sep = stored.indexOf(GRACE_DELIMITER);
+        if (sep < 0 || !stored.substring(0, sep).equals(oldToken)) {
+            return null;
+        }
+        return stored.substring(sep + 1);
+    }
+
+    /** 회전 직후 유예 키 저장 — 동시 회전 패자가 GRACE_TTL 동안 멱등 응답을 받게 한다 */
+    private void saveGrace(Long memberId, String deviceId, String oldToken, String newToken) {
+        redisTemplate.opsForValue().set(
+                graceKey(memberId, deviceId),
+                oldToken + GRACE_DELIMITER + newToken,
+                GRACE_TTL_SECONDS, TimeUnit.SECONDS);
     }
 
     private void save(String refreshToken) {
@@ -194,5 +254,10 @@ public class RefreshTokenService {
 
     private String key(Long memberId, String deviceId) {
         return KEY_PREFIX + memberId + ":" + deviceId;
+    }
+
+    /** 유예 키: refresh:{memberId}:grace:{deviceId} — invalidateAll의 SCAN 패턴에 포함된다 */
+    private String graceKey(Long memberId, String deviceId) {
+        return KEY_PREFIX + memberId + ":grace:" + deviceId;
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/auth/common/service/RefreshTokenService.java
+++ b/src/main/java/com/tavemakers/surf/domain/auth/common/service/RefreshTokenService.java
@@ -7,11 +7,15 @@ import com.tavemakers.surf.global.jwt.JwtService;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.Cursor;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ScanOptions;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
 import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Service;
 
-import java.util.Set;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 @Slf4j
@@ -24,6 +28,22 @@ public class RefreshTokenService {
 
     /** Redis key: refresh:{memberId}:{deviceId} */
     private static final String KEY_PREFIX = "refresh:";
+
+    /** invalidateAll SCAN 배치 크기 */
+    private static final int SCAN_SIZE = 100;
+
+    // 저장된 값이 ARGV[1]과 일치할 때만 DEL — RTR 단일 사용 보장 (CAS)
+    // 반환: 1=CONSUMED, 0=MISMATCH, -1=NOT_FOUND
+    private static final DefaultRedisScript<Long> COMPARE_AND_DELETE_SCRIPT = new DefaultRedisScript<>(
+            "local v = redis.call('GET', KEYS[1]); " +
+                    "if not v then return -1 end; " +
+                    "if v == ARGV[1] then redis.call('DEL', KEYS[1]); return 1 end; " +
+                    "return 0",
+            Long.class
+    );
+
+    /** compareAndDelete 결과 */
+    private enum ConsumeResult { CONSUMED, MISMATCH, NOT_FOUND }
 
     /** 로그인 시 refresh 발급 + 저장 + 쿠키 반환 (WEB 흐름) */
     public ResponseCookie issue(Long memberId, String deviceId) {
@@ -69,22 +89,21 @@ public class RefreshTokenService {
         String key = key(memberId, deviceId);
         log.debug("[RTR][ROTATE] redisKey generated");
 
-        String stored = redisTemplate.opsForValue().get(key);
+        // 검증 + 삭제 원자화 (CAS). 동시 회전 시 단 한 요청만 CONSUMED를 받음
+        ConsumeResult consumeResult = compareAndDelete(key, refreshToken);
 
-        if (stored == null) {
+        if (consumeResult == ConsumeResult.NOT_FOUND) {
             throw new UnauthorizedException(TokenErrorMessage.REFRESH_TOKEN_NOT_FOUND.getMessage());
         }
 
-        // refresh reuse detection
-        if (!refreshToken.equals(stored)) {
+        if (consumeResult == ConsumeResult.MISMATCH) {
             log.error("[RTR][ROTATE] refresh reuse detected memberId={}", memberId);
             invalidateAll(memberId);
             throw new UnauthorizedException(TokenErrorMessage.REFRESH_TOKEN_REUSE_DETECTED.getMessage());
         }
 
-        // ROTATION
-        log.info("[RTR][ROTATE] rotation allowed, deleting old token");
-        redisTemplate.delete(key);
+        // ROTATION (CONSUMED)
+        log.info("[RTR][ROTATE] rotation allowed, old token consumed atomically");
 
         String newRefresh = jwtService.createRefreshToken(memberId, deviceId);
         save(newRefresh);
@@ -103,28 +122,58 @@ public class RefreshTokenService {
         redisTemplate.delete(key(memberId, deviceId));
     }
 
-    /** refresh 재사용 탐지 시 전체 세션 폐기 */
-    // TODO: redisTemplate.keys()는 O(N) 블로킹 명령으로 프로덕션 Redis에서 서비스 장애를 유발할 수 있음.
-    // TODO: SCAN 커서 기반 명령(redisTemplate.scan())으로 교체 필요.
+    /** refresh 재사용 탐지 시 전체 세션 폐기 — SCAN 커서로 non-blocking 순회 */
     public void invalidateAll(Long memberId) {
         log.warn("[RTR][INVALIDATE-ALL] start memberId={}", memberId);
 
         String pattern = KEY_PREFIX + memberId + ":*";
         log.info("[RTR][INVALIDATE-ALL] pattern={}", pattern);
 
-        Set<String> keys = redisTemplate.keys(pattern);
-        log.info("[RTR][INVALIDATE-ALL] foundKeyCount={}",
-                keys == null ? 0 : keys.size());
+        ScanOptions scanOption = ScanOptions.scanOptions()
+                .match(pattern)
+                .count(SCAN_SIZE)
+                .build();
 
-        if (keys != null && !keys.isEmpty()) {
-            redisTemplate.delete(keys);
-            log.warn("[RTR][INVALIDATE-ALL] deleted keyCount={}", keys.size());
+        List<String> keyBuffer = new ArrayList<>(SCAN_SIZE);
+        long totalDeleted = 0;
+
+        try (Cursor<String> cursor = redisTemplate.scan(scanOption)) {
+            while (cursor.hasNext()) {
+                keyBuffer.add(cursor.next());
+
+                if (keyBuffer.size() >= SCAN_SIZE) {
+                    totalDeleted += deleteBatch(keyBuffer);
+                    keyBuffer.clear();
+                }
+            }
+
+            if (!keyBuffer.isEmpty()) {
+                totalDeleted += deleteBatch(keyBuffer);
+            }
+        }
+
+        if (totalDeleted > 0) {
+            log.warn("[RTR][INVALIDATE-ALL] deleted keyCount={}", totalDeleted);
         } else {
             log.info("[RTR][INVALIDATE-ALL] no keys to delete");
         }
     }
 
     /* ================= 내부 유틸 ================= */
+
+    /** 저장된 값이 expected와 일치하면 삭제 — Lua 스크립트로 단일 명령 보장 */
+    private ConsumeResult compareAndDelete(String key, String expected) {
+        Long result = redisTemplate.execute(COMPARE_AND_DELETE_SCRIPT, List.of(key), expected);
+        if (result == null || result == -1L) {
+            return ConsumeResult.NOT_FOUND;
+        }
+        return result == 1L ? ConsumeResult.CONSUMED : ConsumeResult.MISMATCH;
+    }
+
+    private long deleteBatch(List<String> keys) {
+        Long deleted = redisTemplate.delete(keys);
+        return deleted == null ? 0 : deleted;
+    }
 
     private void save(String refreshToken) {
         Long memberId = jwtService.extractMemberId(refreshToken).orElseThrow();

--- a/src/test/java/com/tavemakers/surf/domain/auth/common/service/RefreshTokenServiceTest.java
+++ b/src/test/java/com/tavemakers/surf/domain/auth/common/service/RefreshTokenServiceTest.java
@@ -1,0 +1,151 @@
+package com.tavemakers.surf.domain.auth.common.service;
+
+import com.tavemakers.surf.domain.auth.common.dto.ClientType;
+import com.tavemakers.surf.global.common.exception.UnauthorizedException;
+import com.tavemakers.surf.global.jwt.JwtService;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.env.Environment;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisCallback;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ScanOptions;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@Testcontainers
+@DisplayName("RefreshTokenService")
+class RefreshTokenServiceTest {
+
+    @Container
+    @SuppressWarnings("resource")
+    static final GenericContainer<?> REDIS = new GenericContainer<>("redis:7-alpine")
+            .withExposedPorts(6379);
+
+    private static LettuceConnectionFactory connectionFactory;
+    private static RedisTemplate<String, String> redisTemplate;
+    private static RefreshTokenService refreshTokenService;
+
+    @BeforeAll
+    static void setUp() {
+        RedisStandaloneConfiguration config = new RedisStandaloneConfiguration(
+                REDIS.getHost(), REDIS.getMappedPort(6379)
+        );
+        connectionFactory = new LettuceConnectionFactory(config);
+        connectionFactory.afterPropertiesSet();
+        connectionFactory.start();
+
+        StringRedisSerializer serializer = new StringRedisSerializer();
+        redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(connectionFactory);
+        redisTemplate.setKeySerializer(serializer);
+        redisTemplate.setValueSerializer(serializer);
+        redisTemplate.afterPropertiesSet();
+
+        Environment env = mock(Environment.class);
+        when(env.getActiveProfiles()).thenReturn(new String[]{"test"});
+
+        JwtService jwtService = new JwtService(env);
+        ReflectionTestUtils.setField(jwtService, "jwtSecret",
+                "testsecrettestsecrettestsecrettestsecrettestsecret");
+        ReflectionTestUtils.setField(jwtService, "accessTokenExpireMs", 3600000L);
+        ReflectionTestUtils.setField(jwtService, "refreshTokenExpireMs", 604800000L);
+        jwtService.init();
+
+        refreshTokenService = new RefreshTokenService(jwtService, redisTemplate);
+    }
+
+    @AfterAll
+    static void tearDown() {
+        connectionFactory.stop();
+        connectionFactory.destroy();
+    }
+
+    @BeforeEach
+    void flushRedis() {
+        redisTemplate.execute((RedisCallback<Void>) conn -> {
+            conn.serverCommands().flushDb();
+            return null;
+        });
+    }
+
+    @Test
+    @DisplayName("동시 rotate 요청 2개 중 정확히 1개만 성공한다")
+    void concurrentRotate_onlyOneThreadSucceeds() throws InterruptedException {
+        String refreshToken = refreshTokenService.issueRaw(1L, "device-conc");
+
+        CountDownLatch ready = new CountDownLatch(2);
+        CountDownLatch start = new CountDownLatch(1);
+        AtomicInteger successCount = new AtomicInteger();
+        AtomicInteger failCount = new AtomicInteger();
+
+        Runnable task = () -> {
+            ready.countDown();
+            try {
+                start.await();
+                refreshTokenService.rotate(null, ClientType.APP, refreshToken);
+                successCount.incrementAndGet();
+            } catch (UnauthorizedException e) {
+                failCount.incrementAndGet();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        };
+
+        Thread t1 = new Thread(task);
+        Thread t2 = new Thread(task);
+        t1.start();
+        t2.start();
+
+        ready.await();
+        start.countDown();
+
+        t1.join(5000);
+        t2.join(5000);
+
+        assertThat(successCount.get()).isEqualTo(1);
+        assertThat(failCount.get()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("110개 디바이스 세션을 invalidateAll로 전부 삭제한다")
+    void invalidateAll_deletesAllDeviceSessions() {
+        Long memberId = 2L;
+        int deviceCount = 110;
+
+        for (int i = 0; i < deviceCount; i++) {
+            refreshTokenService.issueRaw(memberId, "device-" + i);
+        }
+
+        assertThat(scanKeys("refresh:" + memberId + ":*")).hasSize(deviceCount);
+
+        refreshTokenService.invalidateAll(memberId);
+
+        assertThat(scanKeys("refresh:" + memberId + ":*")).isEmpty();
+    }
+
+    private List<String> scanKeys(String pattern) {
+        List<String> keys = new ArrayList<>();
+        try (var cursor = redisTemplate.scan(
+                ScanOptions.scanOptions().match(pattern).count(200).build())) {
+            cursor.forEachRemaining(keys::add);
+        }
+        return keys;
+    }
+}

--- a/src/test/java/com/tavemakers/surf/domain/auth/common/service/RefreshTokenServiceTest.java
+++ b/src/test/java/com/tavemakers/surf/domain/auth/common/service/RefreshTokenServiceTest.java
@@ -1,6 +1,7 @@
 package com.tavemakers.surf.domain.auth.common.service;
 
 import com.tavemakers.surf.domain.auth.common.dto.ClientType;
+import com.tavemakers.surf.domain.auth.common.service.RefreshTokenService.RotateResult;
 import com.tavemakers.surf.global.common.exception.UnauthorizedException;
 import com.tavemakers.surf.global.jwt.JwtService;
 import org.junit.jupiter.api.AfterAll;
@@ -22,10 +23,12 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -40,6 +43,7 @@ class RefreshTokenServiceTest {
 
     private static LettuceConnectionFactory connectionFactory;
     private static RedisTemplate<String, String> redisTemplate;
+    private static JwtService jwtService;
     private static RefreshTokenService refreshTokenService;
 
     @BeforeAll
@@ -61,7 +65,7 @@ class RefreshTokenServiceTest {
         Environment env = mock(Environment.class);
         when(env.getActiveProfiles()).thenReturn(new String[]{"test"});
 
-        JwtService jwtService = new JwtService(env);
+        jwtService = new JwtService(env);
         ReflectionTestUtils.setField(jwtService, "jwtSecret",
                 "testsecrettestsecrettestsecrettestsecrettestsecret");
         ReflectionTestUtils.setField(jwtService, "accessTokenExpireMs", 3600000L);
@@ -86,23 +90,30 @@ class RefreshTokenServiceTest {
     }
 
     @Test
-    @DisplayName("동시 rotate 요청 2개 중 정확히 1개만 성공한다")
-    void concurrentRotate_onlyOneThreadSucceeds() throws InterruptedException {
-        String refreshToken = refreshTokenService.issueRaw(1L, "device-conc");
+    @DisplayName("동시 rotate 2건 — 재사용 탐지 없이 같은 새 토큰으로 수렴한다")
+    void concurrentRotate_convergesWithoutReuseDetection() throws InterruptedException {
+        Long memberId = 1L;
+        String refreshToken = refreshTokenService.issueRaw(memberId, "device-conc");
+        refreshTokenService.issueRaw(memberId, "device-other");
 
         CountDownLatch ready = new CountDownLatch(2);
         CountDownLatch start = new CountDownLatch(1);
-        AtomicInteger successCount = new AtomicInteger();
-        AtomicInteger failCount = new AtomicInteger();
+        List<String> successTokens = new CopyOnWriteArrayList<>();
+        AtomicInteger reuseCount = new AtomicInteger();
+        AtomicInteger notFoundCount = new AtomicInteger();
 
         Runnable task = () -> {
             ready.countDown();
             try {
                 start.await();
-                refreshTokenService.rotate(null, ClientType.APP, refreshToken);
-                successCount.incrementAndGet();
+                RotateResult result = refreshTokenService.rotate(null, ClientType.APP, refreshToken);
+                successTokens.add(result.newRefreshToken());
             } catch (UnauthorizedException e) {
-                failCount.incrementAndGet();
+                if (e.getMessage() != null && e.getMessage().contains("재사용")) {
+                    reuseCount.incrementAndGet();
+                } else {
+                    notFoundCount.incrementAndGet();
+                }
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
             }
@@ -119,14 +130,74 @@ class RefreshTokenServiceTest {
         t1.join(5000);
         t2.join(5000);
 
-        assertThat(successCount.get()).isEqualTo(1);
-        assertThat(failCount.get()).isEqualTo(1);
+        // 패자가 전 기기 로그아웃(invalidateAll)을 유발해선 안 됨
+        assertThat(reuseCount.get()).isZero();
+        // CAS 승자는 항상 성공하며, 모든 성공은 동일한 새 토큰을 받아야 함 (멱등)
+        assertThat(successTokens).isNotEmpty();
+        assertThat(successTokens.stream().distinct().count()).isEqualTo(1);
+        // 정확히 한 개의 새 토큰만 현재 키로 살아남음
+        assertThat(redisTemplate.opsForValue().get("refresh:" + memberId + ":device-conc"))
+                .isEqualTo(successTokens.get(0));
+        // 다른 디바이스 세션은 영향받지 않아야 함
+        assertThat(redisTemplate.hasKey("refresh:" + memberId + ":device-other")).isTrue();
     }
 
     @Test
-    @DisplayName("110개 디바이스 세션을 invalidateAll로 전부 삭제한다")
-    void invalidateAll_deletesAllDeviceSessions() {
+    @DisplayName("이미 회전된 토큰으로 재요청하면 직전 발급된 새 토큰을 멱등 반환한다")
+    void retryWithConsumedToken_returnsSameNewTokenIdempotently() {
         Long memberId = 2L;
+        String oldToken = refreshTokenService.issueRaw(memberId, "device-A");
+        refreshTokenService.issueRaw(memberId, "device-other");
+
+        RotateResult first = refreshTokenService.rotate(null, ClientType.APP, oldToken);
+        RotateResult retry = refreshTokenService.rotate(null, ClientType.APP, oldToken);
+
+        // 재요청은 새 토큰을 다시 발급하지 않고 직전 결과를 그대로 반환
+        assertThat(retry.newRefreshToken()).isEqualTo(first.newRefreshToken());
+        // 멱등 처리이므로 재사용 탐지(invalidateAll)가 트리거되지 않음
+        assertThat(redisTemplate.hasKey("refresh:" + memberId + ":device-other")).isTrue();
+    }
+
+    @Test
+    @DisplayName("회전 이력이 없는 미지의 유효 토큰은 재사용으로 탐지돼 전 세션을 폐기한다")
+    void rotateWithUnknownToken_triggersReuseDetection() {
+        Long memberId = 3L;
+        refreshTokenService.issueRaw(memberId, "device-A");
+        refreshTokenService.issueRaw(memberId, "device-other");
+
+        // 서명은 유효하지만 저장·회전된 적 없는 토큰 → 유예 키가 존재하지 않음
+        String unknownToken = jwtService.createRefreshToken(memberId, "device-A");
+
+        assertThatThrownBy(() -> refreshTokenService.rotate(null, ClientType.APP, unknownToken))
+                .isInstanceOf(UnauthorizedException.class)
+                .hasMessageContaining("재사용");
+
+        // 재사용 탐지 시 해당 회원의 모든 디바이스 세션이 폐기됨
+        assertThat(redisTemplate.hasKey("refresh:" + memberId + ":device-A")).isFalse();
+        assertThat(redisTemplate.hasKey("refresh:" + memberId + ":device-other")).isFalse();
+    }
+
+    @Test
+    @DisplayName("로그아웃(invalidate)은 유예 키까지 폐기해 멱등 회전을 차단한다")
+    void invalidate_clearsGraceKey() {
+        Long memberId = 4L;
+        String oldToken = refreshTokenService.issueRaw(memberId, "device-A");
+        refreshTokenService.rotate(null, ClientType.APP, oldToken);
+
+        refreshTokenService.invalidate(memberId, "device-A");
+
+        assertThat(redisTemplate.hasKey("refresh:" + memberId + ":grace:device-A")).isFalse();
+        // 유예 키가 사라졌으므로 직전 토큰 재요청은 멱등 반환 없이 실패
+        assertThatThrownBy(() -> refreshTokenService.rotate(null, ClientType.APP, oldToken))
+                .isInstanceOf(UnauthorizedException.class);
+    }
+    
+    @Test
+    @DisplayName("SCAN 배치 크기를 초과하는 세션도 invalidateAll로 누락 없이 전부 삭제한다")
+    void invalidateAll_deletesAllDeviceSessions() {
+        Long memberId = 5L;
+        // SCAN_SIZE(100)를 초과하는 키 수 → 커서가 한 바퀴 이상 돌고 버퍼가 중간에 flush되는
+        // 경계 동작을 강제한다. 110은 현실적 디바이스 수가 아니라 배치 경계(100) 검증용 값이다.
         int deviceCount = 110;
 
         for (int i = 0; i < deviceCount; i++) {

--- a/src/test/java/com/tavemakers/surf/domain/auth/common/service/RefreshTokenServiceUnitTest.java
+++ b/src/test/java/com/tavemakers/surf/domain/auth/common/service/RefreshTokenServiceUnitTest.java
@@ -1,0 +1,91 @@
+package com.tavemakers.surf.domain.auth.common.service;
+
+import com.tavemakers.surf.domain.auth.common.dto.ClientType;
+import com.tavemakers.surf.global.common.exception.UnauthorizedException;
+import com.tavemakers.surf.global.jwt.JwtService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ScanOptions;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.data.redis.core.script.RedisScript;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Testcontainers 기반 통합 테스트(`RefreshTokenServiceTest`)로는 재현이 까다로운
+ * 인프라 예외 경로(invalidateAll 실패, Lua null 반환)를 Mockito로 검증한다.
+ */
+@DisplayName("RefreshTokenService — 인프라 예외 처리 단위 테스트")
+class RefreshTokenServiceUnitTest {
+
+    private static final Long MEMBER_ID = 1L;
+    private static final String DEVICE_ID = "device-A";
+    private static final String REFRESH_TOKEN = "header.payload.signature";
+
+    private JwtService jwtService;
+    @SuppressWarnings("unchecked")
+    private final RedisTemplate<String, String> redisTemplate = mock(RedisTemplate.class);
+    @SuppressWarnings("unchecked")
+    private final ValueOperations<String, String> valueOperations = mock(ValueOperations.class);
+    private RefreshTokenService refreshTokenService;
+
+    @BeforeEach
+    void setUp() {
+        jwtService = mock(JwtService.class);
+        when(jwtService.isTokenValid(REFRESH_TOKEN)).thenReturn(true);
+        when(jwtService.extractMemberId(REFRESH_TOKEN)).thenReturn(Optional.of(MEMBER_ID));
+        when(jwtService.extractDeviceId(REFRESH_TOKEN)).thenReturn(Optional.of(DEVICE_ID));
+
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+
+        refreshTokenService = new RefreshTokenService(jwtService, redisTemplate);
+    }
+
+    @Test
+    @DisplayName("invalidateAll이 Redis 장애로 실패해도 REUSE_DETECTED 401은 반드시 던진다")
+    @SuppressWarnings("unchecked")
+    void reuseDetected_isThrownEvenWhenInvalidateAllFails() {
+        // CAS → MISMATCH (저장값과 다름) — 진짜 재사용 경로
+        when(redisTemplate.execute(any(RedisScript.class), anyList(), any()))
+                .thenReturn(0L);
+        // grace 키는 미존재 (valueOperations.get 기본 null 반환)
+        // invalidateAll 진입 — scan 호출 즉시 인프라 장애로 실패
+        when(redisTemplate.scan(any(ScanOptions.class)))
+                .thenThrow(new RuntimeException("Redis connection refused"));
+
+        assertThatThrownBy(() -> refreshTokenService.rotate(null, ClientType.APP, REFRESH_TOKEN))
+                .isInstanceOf(UnauthorizedException.class)
+                .hasMessageContaining("재사용");
+
+        // invalidateAll을 시도는 했음 — 실패가 응답을 삼키지 않았음을 보장
+        verify(redisTemplate).scan(any(ScanOptions.class));
+    }
+
+    @Test
+    @DisplayName("Lua 스크립트 null 반환은 NOT_FOUND로 위장하지 않고 IllegalStateException으로 노출한다")
+    @SuppressWarnings("unchecked")
+    void luaNullResult_isExposedAsInfrastructureError() {
+        when(redisTemplate.execute(any(RedisScript.class), anyList(), any()))
+                .thenReturn(null);
+
+        assertThatThrownBy(() -> refreshTokenService.rotate(null, ClientType.APP, REFRESH_TOKEN))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("CAS script");
+
+        // 후속 회전·세션 폐기 동작이 일절 실행되지 않아야 함
+        verify(jwtService, never()).createRefreshToken(anyLong(), anyString());
+        verify(redisTemplate, never()).scan(any(ScanOptions.class));
+    }
+}


### PR DESCRIPTION
## 📄 작업 내용 요약

`RefreshTokenService.rotate()`의 검증·삭제 비원자성으로 인한 RTR 단일 사용(single-use) 보장 결함을 Lua CAS로 해소하고, 그 과정에서 새로 드러난 `"동시 회전 패자"` 문제를 유예 키(grace key) 기반 멱등 회전으로 해결합니다. `invalidateAll()`의 `KEYS` 블로킹도 `SCAN` 커서 기반으로 교체하고, 인프라 예외 처리도 함께 보강합니다.

> Lua는 Redis 서버에 내장된 경량 스크립트 언어로, 여러 Redis 명령을 도중에 다른 명령이 끼어들 수 없는 하나의 원자 연산으로 묶어 실행하게 해줍니다.

---

## 1. 한 줄 요약

`rotate()`의 `GET → 비교 → DELETE` 3분리로 인한 race condition을 Lua CAS로 원자화하고, CAS 패자의 비결정적 처리(정상 더블 서밋에서 전 기기 로그아웃 가능)를 유예 키 멱등 응답으로 해결합니다.

---

## 2. 작업 배경

| | |
|---|---|
| **CodeRabbit Critical 지적** | `rotate()`의 `get → equals → delete`가 3개의 분리된 Redis 명령으로 수행되어 TOCTOU race condition 존재. 동시 요청이 둘 다 검증을 통과해 단일 사용 보장 붕괴 |
| **재사용 탐지 우회 위험** | "폐기된 토큰의 재등장"이 RTR 재사용 탐지의 유일한 신호. 단일 사용이 깨지면 회전 직후 timing window에서 탈취 토큰 사용 시 `invalidateAll`이 트리거되지 않음 |
| **`invalidateAll`의 `KEYS` 블로킹** | 재사용 탐지 시 호출되는 `redisTemplate.keys(pattern)`이 O(N) 블로킹 명령으로 Redis 전체 지연 유발 가능 (자체 TODO로 인지된 상태) |
| **모바일 더블 서밋 시나리오** | 1차 원자화 후, 정상 클라이언트의 동시 refresh(앱 인터셉터 동시 401 → 동시 refresh)에서 CAS 패자가 타이밍에 따라 `MISMATCH → invalidateAll`로 빠져 **사용자의 모든 기기 세션이 폐기**되는 경로 발견 |

---

## 3. 설계 결정과 의도

### 3-1. 검증·삭제 원자화 — Lua 스크립트 채택

`GET → 비교 → DEL`을 하나의 끊기지 않는 연산으로 묶기 위해 후보를 비교했다.

| 방안 | 채택 여부와 이유 |
|---|---|
| **Lua 스크립트** | ✅ Redis가 Lua 스크립트를 원자 실행. 추가 의존성 없이 조건부 삭제와 3-state 반환을 한 단위로 표현 |
| `WATCH`/`MULTI` 낙관적 트랜잭션 | ❌ 충돌 시 재시도 루프 필요 — 코드 복잡, 경합 잦으면 비효율 |
| 분산 락(Redisson 등) | ❌ 라이브러리 의존성·락 왕복 비용. 단순 CAS에 과도 |
| `GETDEL` 단일 명령 | ❌ 무조건 삭제 — 불일치 시 정상 토큰까지 지움. 비교 분기 표현 불가 |

```lua
local v = redis.call('GET', KEYS[1]);
if not v then return -1 end;                                -- NOT_FOUND
if v == ARGV[1] then redis.call('DEL', KEYS[1]); return 1 end; -- CONSUMED
return 0                                                    -- MISMATCH
```

3-state(`CONSUMED`/`MISMATCH`/`NOT_FOUND`)로 반환해 호출부가 정상 회전·재사용 탐지·미존재를 명확히 분기.

### 3-2. `KEYS` → `SCAN` 전환

`invalidateAll()`을 커서 기반 `SCAN`(배치 100건)으로 교체. 비블로킹 순회로 Redis 단일 스레드 지연 제거. 중복 키 반환 가능성은 idempotent delete라 무해.

### 3-3. 동시 회전 패자 처리 — B-light(유예 키 멱등 회전) 채택

원자화 후 새로 드러난 문제: 정상 더블 서밋에서 CAS 패자가 타이밍에 따라 `NOT_FOUND`(가벼운 401) 또는 `MISMATCH`(→ `invalidateAll`로 전 기기 로그아웃)으로 갈림. 옵션을 비교했다.

| 방안 | 채택 여부와 이유 |
|---|---|
| **A. 엄격 RTR + 클라이언트 직렬화** | ❌ 모바일 인터셉터 동작을 백엔드에서 통제 불가. 정상 사용자의 전 기기 로그아웃 리스크 존속 |
| **B-light. 유예 키 멱등 응답** | ✅ Lua 그대로 유지하면서 위험 경로만 차단. ~50줄, 1파일 |
| B-full. compare-and-swap Lua | ❌ 2키·다중 ARGV 스크립트 재작성. 잔여 NOT_FOUND 윈도우 제거 이득이 비용 대비 낮음 |

**유예 키 설계**:
- 회전 성공 시 `refresh:{m}:grace:{d}` 키에 `{직전토큰}|{새토큰}` 값을 30초 TTL로 저장
- CAS 패자는 이 키를 조회해 직전 토큰과 일치하면 승자의 새 토큰을 멱등 반환 (`invalidateAll` 호출 안 함)
- **값에 직전 토큰을 함께 저장**: 새 토큰만 두면 아무 만료 토큰이 들어와도 유효 토큰을 받게 되는 보안 구멍 — 직전 토큰 검증으로 차단
- **순서 보장**: 새 현재 키 `save()` 전에 `saveGrace()` 먼저 실행 — 패자가 `MISMATCH`를 보는 시점엔 grace가 반드시 존재해야 위험 경로(전 기기 로그아웃)가 닫힘
- **키 네이밍**: `refresh:{m}:grace:{d}` 형태로 `invalidateAll`의 SCAN 패턴 `refresh:{m}:*`에 자동 포함 — 재사용 탐지 시 grace도 함께 폐기되어 탐지 우회 방지

### 3-4. 로그아웃 시 유예 키 동반 폐기

`invalidate()`가 현재 키와 함께 grace 키도 폐기. 그렇지 않으면 로그아웃 후 30초 이내 옛 토큰으로 멱등 회전이 성사돼 로그아웃이 무력화될 수 있음.

### 3-5. 인프라 예외 격리 — 보안 신호 보존

```java
log.error("[RTR][ROTATE] refresh reuse detected memberId={}", memberId);
try {
    invalidateAll(memberId);
} catch (RuntimeException ex) {
    log.error("[RTR][ROTATE] invalidateAll failed during reuse detection memberId={}", memberId, ex);
}
throw new UnauthorizedException(...REFRESH_TOKEN_REUSE_DETECTED...);
```

재사용 탐지 중 `invalidateAll`이 Redis 장애로 실패하면 `UnauthorizedException(REUSE_DETECTED)`이 발화하지 못하고 500이 반환되어 **보안 신호가 응답에서 사라지는 문제** 차단. 실패는 ERROR 로그로 운영에 전달하되 응답은 반드시 401 REUSE.

### 3-6. Lua null 결과 분리 — NOT_FOUND 위장 방지

```java
if (result == null) {
    log.error("[RTR][ROTATE] compareAndDelete returned null — Redis/script issue");
    throw new IllegalStateException("CAS script returned null result");
}
if (result == -1L) return ConsumeResult.NOT_FOUND;
```

Lua 정상 결과는 -1/0/1. `null`은 스크립트 실행 실패·연결 이상 신호. 기존 코드는 `null || -1L`을 같이 `NOT_FOUND`로 처리해 인프라 오류를 토큰 없음 401로 위장 → `GlobalExceptionHandler.handleException`의 `any.error` 구조화 이벤트 발행이 누락. 분리해 500으로 노출.

---

## 4. 변경 파일

| 파일 | 변경 내용 |
|---|---|
| `domain/auth/common/service/RefreshTokenService.java` | Lua CAS(`COMPARE_AND_DELETE_SCRIPT`) + 3-state `ConsumeResult`, `invalidateAll()` SCAN 전환, 유예 키 helpers(`saveGrace`/`findGraceToken`/`graceKey`), `rotate()` 패자 분기 재구성, `emit()` 송출 헬퍼, `invalidate()` grace 동반 폐기, `invalidateAll` 격리, Lua null 분리 |
| `domain/auth/common/service/RefreshTokenServiceTest.java` | Testcontainers(`redis:7-alpine`) 기반 통합 테스트 5종 — 동시 회전 수렴, 멱등 재요청, 미지 토큰 재사용 탐지, 로그아웃 grace 폐기, 110개 디바이스 일괄 삭제 |
| `domain/auth/common/service/RefreshTokenServiceUnitTest.java` | Mockito 단위 테스트 2종 — `invalidateAll` 실패 시 REUSE 응답 보존, Lua null 시 `IllegalStateException` 노출 |
| `build.gradle.kts` | `testcontainers`, `testcontainers-junit-jupiter` 의존성 추가(testImplementation) |

**DB 변경 없음 · Redis 키 포맷 호환** — 기존 `refresh:{m}:{d}` 유지, 신규 `refresh:{m}:grace:{d}` 추가만. 무중단 배포 가능.

---

## 5. 운영/배포 영향

- **롤링 배포 호환**: 옛/새 인스턴스가 같은 Redis를 공유해도 현재 키 포맷 동일 → 데이터 손상 없음.
- **재사용 탐지 최대 30초 지연**: 정상 회전 직후 30초 내 탈취 토큰 재사용 시 grace에 걸려 멱등 응답을 받음. grace-window 방식의 본질적 트레이드오프이며, `GRACE_TTL_SECONDS`로 조정 가능.
- **동시 요청 시 access token 2개 발급**: 양쪽 응답 각각이 새 access를 받음. 모두 유효, 회귀 아님(원래 버그 상태와 동일한 발급 수).
- **Redis Cluster 미대응**: 멀티키 명령이 `CROSSSLOT` 가능 — 기존 동일, 회귀 아님. standalone(ElastiCache) 전제.
- **CI 테스트 스킵 유의**: 현재 `dev.yml`/`test.yml`이 `./gradlew clean build -x test`로 테스트 미실행. 신규 테스트는 자동 회귀 가드 역할을 못 함 — 로컬에서 `./gradlew test --tests "...RefreshTokenServiceUnitTest"` 실행 결과 첨부 권장.

---

## 6. 테스트 플랜

### 자동 (단위 — Docker 불필요)
- [x] `invalidateAll` 실패 시에도 `UnauthorizedException(REUSE_DETECTED)` 반환 검증
- [x] Lua null 결과 시 `IllegalStateException` 노출 검증

### 자동 (통합 — Docker 필요)
- [ ] 동시 rotate 2건 — 재사용 탐지 0건, 모든 성공이 동일 토큰으로 수렴, 다른 기기 세션 생존
- [ ] 소비된 토큰 재요청 — 직전 발급 토큰 멱등 반환, `invalidateAll` 미발동
- [ ] 회전 이력 없는 미지의 유효 토큰 — 재사용 탐지 → 전 세션 폐기
- [ ] 로그아웃 — 유예 키까지 폐기 확인
- [ ] 110개 디바이스 세션 `invalidateAll` 일괄 삭제 (SCAN 배치 경계 검증)

### 수기
- [ ] 일반 토큰 회전 시나리오 회귀 없음 (WEB/APP 모두)
- [ ] 로그아웃 후 즉시 옛 토큰 회전 시도 → 멱등 응답 받지 못함 (logout이 grace 폐기)
- [ ] 운영 환경 Redis 장애 모의 시 500 응답 + `any.error` 이벤트 발행 확인

---

## 📎 Issue 번호
closed #325


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 리프레시 토큰 회전 시 동시성 요청에 대한 멱등성을 개선하여 중복 회전 시도 시에도 안정적으로 동일한 토큰을 반환합니다.
  * 토큰 무효화 로직을 강화하여 동시성 상황에서의 세션 관리 신뢰성을 향상시켰습니다.

* **Tests**
  * 리프레시 토큰 회전, 무효화, 재시도 및 동시성 동작에 대한 통합 테스트를 추가했습니다.
  * 예외 처리 경로에 대한 단위 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->