### PR TITLE
[Refactor] 게시글 수정 API 부분 업데이트 개선

### DIFF
--- a/src/main/java/com/tavemakers/surf/domain/post/controller/post/PostPatchController.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/controller/post/PostPatchController.java
@@ -23,7 +23,10 @@ public class PostPatchController {
     private final PostPatchUsecase postPatchUsecase;
 
     /** 게시글 수정 (작성자 검증은 서비스에서) */
-    @Operation(summary = "게시글 수정", description = "본인이 작성한 게시글을 수정합니다.")
+    @Operation(
+            summary = "게시글 (부분) 수정",
+            description = "본인이 작성한 게시글을 수정합니다. title/content 등 일부 필드만 보내면 해당 필드만 수정되며, null이면 기존 값이 유지됩니다."
+    )
     @PatchMapping("/v1/user/posts/{postId}")
     public ApiResponse<PostDetailResDTO> updatePost(
             @PathVariable(name = "postId") Long postId,

--- a/src/main/java/com/tavemakers/surf/domain/post/dto/request/PostUpdateReqDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/dto/request/PostUpdateReqDTO.java
@@ -2,24 +2,23 @@ package com.tavemakers.surf.domain.post.dto.request;
 
 import com.tavemakers.surf.global.logging.LogPropsProvider;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 
 @Schema(description = "게시글 수정 요청 DTO")
 public record PostUpdateReqDTO(
 
-        @Schema(description = "게시글 제목", example = "만남의 장 공지사항")
-        @NotBlank String title,
+        @Schema(description = "게시글 제목 (null이면 기존 값 유지, 공백만으로는 불가)", example = "만남의 장 공지사항")
+        @Pattern(regexp = ".*\\S.*", flags = Pattern.Flag.DOTALL, message = "제목은 공백만으로 구성될 수 없습니다.")
+        String title,
 
-        @Schema(description = "게시글 본문 내용", example = "전반기 만남의 장 언제 어디에 진행합니다!")
-        @NotBlank String content,
-
-        Boolean isContentChanged,
+        @Schema(description = "게시글 본문 내용 (null이면 기존 값 유지, 공백만으로는 불가)", example = "전반기 만남의 장 언제 어디에 진행합니다!")
+        @Pattern(regexp = ".*\\S.*", flags = Pattern.Flag.DOTALL, message = "본문 내용은 공백만으로 구성될 수 없습니다.")
+        String content,
 
         @Schema(description = "세부 카테고리 ID", example = "2")
         Long categoryId,
@@ -52,15 +51,17 @@ public record PostUpdateReqDTO(
 
         @Override
         public Map<String, Object> buildProps() {
+                boolean contentChanged = content != null && !content.isBlank();
+
                 List<String> changedFields = new ArrayList<>();
                 if (title != null && !title.isBlank()) changedFields.add("title");
-                if (content != null && !content.isBlank()) changedFields.add("content");
+                if (contentChanged) changedFields.add("content");
                 if (pinned != null) changedFields.add("pinned");
                 if (isImageChanged != null) changedFields.add("has_image_changed");
 
                 return Map.of(
                         "changed_fields", changedFields,
-                        "edit_length", isContentChanged ? String.valueOf(Objects.requireNonNull(content).length()) : "notChanged"
+                        "edit_length", contentChanged ? String.valueOf(content.length()) : "notChanged"
                 );
         }
 

--- a/src/main/java/com/tavemakers/surf/domain/post/entity/Post.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/entity/Post.java
@@ -97,8 +97,12 @@ public class Post extends BaseEntity {
     }
 
     public void update(PostUpdateReqDTO req, Board board, BoardCategory category) {
-        this.title = req.title();
-        this.content = req.content();
+        if (req.title() != null && !req.title().isBlank()) {
+            this.title = req.title();
+        }
+        if (req.content() != null && !req.content().isBlank()) {
+            this.content = req.content();
+        }
         this.pinned = req.pinned() != null ? req.pinned() : this.pinned;
 
         this.board = board;


### PR DESCRIPTION
## 📄 작업 내용 요약
> 게시글 수정 API (`PATCH /v1/user/posts/{postId}`)가 `PATCH`임에도 모든 필드를 보내야만 수정이 가능했고, `isContentChanged` 플래그가 실제 로직과 불일치하는 문제가 있어 부분 업데이트가 동작하도록 개선했습니다.

- `PostUpdateReqDTO`에서 `title`, `content`의 `@NotBlank` 제거하여 선택적 필드 전달 허용
- 실제 로직과 맞지 않던 `isContentChanged` 플래그 제거 (값 전달 여부로 수정 판단하도록 일원화)
- `Post` 엔티티 `update` 메서드에 `null/blank` 체크 추가 (데이터 유실 방지)
- 단, 공백만 들어온 경우(`""`, `"   "`)는 잘못된 요청이므로 `@Pattern`으로 `400` 처리 (null은 허용, 공백은 거부)
- 로깅(`buildProps`)을 값 기준으로 정리하여 `changed_fields`/`edit_length` 정합성 확보 및 NPE 위험 제거
- Swagger 설명을 부분 수정(`PATCH`)에 맞게 수정

예를 들어, 이전에는 내용만 그대로 두고 제목만 바꾸려 해도 기존 본문까지 모두 다시 보내야 했지만
```
{
  "title": "만남의 장 공지사항",
  "content": "전반기 만남의 장 언제 어디에 진행합니다!",
  "isContentChanged": false
}
```

이제는 아래와 같이 수정하고 싶은 필드만 보내면 됩니다.
```
{
  "title": "만남의 장 공지사항(수정)"
}
```

또한 수정할 때 필드 값이 `null`이면 수정에 반영되지 않고 기존 값이 유지됩니다.
공백만으로 구성된 값(`""`, `"   "`)은 잘못된 수정 요청으로 보고 `400`을 반환합니다.

## 📎 Issue 번호
closed #307


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 게시글 수정 시, 제목이나 내용을 일부만 보내도 해당 항목만 반영되도록 개선되었습니다.
  * 값이 비어 있거나 공백만 포함된 입력은 허용되지 않도록 검증이 강화되었습니다.

* **Bug Fixes**
  * 수정 요청에서 비어 있는 값 때문에 기존 내용이 덮어써지는 문제를 방지했습니다.
  * 수정 설명이 부분 수정 동작을 더 명확하게 안내하도록 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->