### PR TITLE
[FEAT] 소셜 로그인 통합 Phase 1: SocialAccount 엔티티 및 스키마 기반 구축

### DIFF
--- a/src/main/java/com/tavemakers/surf/domain/member/entity/Member.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/entity/Member.java
@@ -23,6 +23,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.function.Consumer;
 
 import lombok.extern.slf4j.Slf4j;
@@ -74,12 +75,15 @@ public class Member extends BaseEntity {
 
     private String graduateSchool;
 
-    @Column(nullable = false, unique = true) // 이메일은 고유해야 함
+    /** 온보딩에서 사용자가 입력한 통합 이메일. 소셜이 준 이메일(SocialAccount.providerEmail)과 구분된다. REGISTERING은 값 없음. */
+    @Column(unique = true)
     private String email;
 
     @Embedded
     private Password password;
 
+    /** 통합 판단 기준 전화번호. REGISTERING은 값 없음. */
+    @Column(unique = true)
     private String phoneNumber;
 
     @Column(length = 256)
@@ -93,6 +97,11 @@ public class Member extends BaseEntity {
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     @BatchSize(size = 20)
     private List<Track> tracks = new ArrayList<>();
+
+    /** 회원에 연결된 소셜 로그인 수단 목록 (provider별 최대 1개). */
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    @BatchSize(size = 20)
+    private List<SocialAccount> socialAccounts = new ArrayList<>();
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
@@ -261,6 +270,28 @@ public class Member extends BaseEntity {
 
         Track track = new Track(generation, part);
         track.setMember(this); // 여기서만 add 수행
+    }
+
+    /** 소셜 계정을 연결한다. 동일 provider 계정이 이미 있으면 거부한다 (1 provider = 1 account). */
+    public void addSocialAccount(SocialAccount socialAccount) {
+        if (hasProvider(socialAccount.getProvider())) {
+            throw new IllegalStateException(
+                    "이미 연결된 provider 입니다: " + socialAccount.getProvider());
+        }
+        socialAccount.setMember(this); // setMember 에서만 양방향 add 수행
+    }
+
+    /** 해당 provider 로그인 수단을 이미 보유하고 있는지 여부. */
+    public boolean hasProvider(Provider provider) {
+        return socialAccounts.stream()
+                .anyMatch(sa -> sa.getProvider() == provider);
+    }
+
+    /** 해당 provider 의 소셜 계정을 조회한다. */
+    public Optional<SocialAccount> findSocialAccount(Provider provider) {
+        return socialAccounts.stream()
+                .filter(sa -> sa.getProvider() == provider)
+                .findFirst();
     }
 
     /** 댓글의 멘션 기능에서 회원들의 기수별로 정렬하기 위한 메서드 */

--- a/src/main/java/com/tavemakers/surf/domain/member/entity/SocialAccount.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/entity/SocialAccount.java
@@ -1,0 +1,142 @@
+package com.tavemakers.surf.domain.member.entity;
+
+import com.tavemakers.surf.domain.auth.common.dto.OAuthUserInfoDTO;
+import com.tavemakers.surf.domain.auth.common.enums.Provider;
+import com.tavemakers.surf.domain.member.exception.InvalidMemberInfoException;
+import com.tavemakers.surf.global.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * provider별 로그인 수단 단위 엔티티 — {@code Member} 와 N : 1 관계.
+ * 한 회원이 Kakao/Apple 등 여러 소셜 계정을 연결할 수 있으며, 어느 쪽으로 로그인해도 같은 회원으로 인증된다.
+ */
+@Entity
+@Table(
+        name = "social_account",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_social_provider_provider_id",
+                        columnNames = {"provider", "provider_id"}
+                )
+        },
+        indexes = {
+                @Index(name = "idx_social_member_id", columnList = "member_id"),
+                @Index(name = "idx_social_provider", columnList = "provider")
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SocialAccount extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "social_account_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 16)
+    private Provider provider;
+
+    @Column(name = "provider_id", nullable = false, length = 64)
+    private String providerId;
+
+    /**
+     * 소셜 로그인이 전달한 이메일. 회원 식별에는 사용하지 않는다.
+     * 로그인 시점 provider 값으로만 채우며, 레거시 이관 행은 null 로 남을 수 있다(카카오 원본 이메일 백필하지 않음).
+     */
+    @Column(name = "provider_email")
+    private String providerEmail;
+
+    /** Apple 계정 탈퇴(revoke) 시 사용. 로그인 코드 교환 후 저장, 탈퇴 시 null 처리. */
+    @Column(name = "apple_refresh_token", length = 1024)
+    private String appleRefreshToken;
+
+    /** 카카오 unlink용 레거시 식별자. */
+    @Column(name = "kakao_id")
+    private Long kakaoId;
+
+    @Builder
+    private SocialAccount(Provider provider,
+                          String providerId,
+                          String providerEmail,
+                          String appleRefreshToken,
+                          Long kakaoId) {
+        this.provider = provider;
+        this.providerId = providerId;
+        this.providerEmail = providerEmail;
+        this.appleRefreshToken = appleRefreshToken;
+        this.kakaoId = kakaoId;
+    }
+
+    /**
+     * OAuth provider 정보로 SocialAccount 를 생성한다.
+     * providerEmail 은 소셜이 준 이메일을 그대로 저장하며, 회원 식별에는 사용하지 않는다.
+     */
+    public static SocialAccount createFromOAuth(Provider provider, OAuthUserInfoDTO info) {
+        if (provider == null) {
+            throw new IllegalStateException("provider 는 필수입니다.");
+        }
+        if (info.oauthId() == null || info.oauthId().isBlank()) {
+            throw new IllegalStateException(provider + " 식별자(oauthId)가 비어 있습니다.");
+        }
+
+        Long legacyKakaoId = null;
+        if (provider == Provider.KAKAO) {
+            try {
+                legacyKakaoId = Long.parseLong(info.oauthId());
+            } catch (NumberFormatException e) {
+                throw new InvalidMemberInfoException(
+                        "Provider.KAKAO oauthId가 유효한 숫자 형식이 아닙니다: " + info.oauthId());
+            }
+        }
+
+        return SocialAccount.builder()
+                .provider(provider)
+                .providerId(info.oauthId())
+                .providerEmail(info.email())
+                .kakaoId(legacyKakaoId)
+                .build();
+    }
+
+    /**
+     * 소속 회원을 설정하고 양방향 연관관계 일관성을 유지한다.
+     * 통합(연동) 시 기존 회원으로 재연결하는 용도로도 사용한다.
+     */
+    public void setMember(Member member) {
+        if (member == null) {
+            throw new IllegalArgumentException("member는 null일 수 없습니다.");
+        }
+
+        if (this.member == member) return;
+
+        // 기존 관계 끊기
+        if (this.member != null) {
+            this.member.getSocialAccounts().remove(this);
+        }
+
+        this.member = member;
+
+        // 양방향 일관성 유지
+        if (!member.getSocialAccounts().contains(this)) {
+            member.getSocialAccounts().add(this);
+        }
+    }
+
+    /** 로그인 시점에 provider 가 전달한 이메일로 갱신한다(레거시 백필 대체). */
+    public void updateProviderEmail(String providerEmail) {
+        this.providerEmail = providerEmail;
+    }
+
+    /** Apple refresh_token 갱신 — 로그인 코드 교환 시 호출. */
+    public void updateAppleRefreshToken(String refreshToken) {
+        this.appleRefreshToken = refreshToken;
+    }
+}

--- a/src/main/java/com/tavemakers/surf/domain/member/repository/SocialAccountRepository.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/repository/SocialAccountRepository.java
@@ -1,0 +1,15 @@
+package com.tavemakers.surf.domain.member.repository;
+
+import com.tavemakers.surf.domain.auth.common.enums.Provider;
+import com.tavemakers.surf.domain.member.entity.SocialAccount;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface SocialAccountRepository extends JpaRepository<SocialAccount, Long> {
+
+    /** provider + providerId 복합 식별자로 소셜 계정을 조회한다 (로그인 upsert 진입점). */
+    Optional<SocialAccount> findByProviderAndProviderId(Provider provider, String providerId);
+}


### PR DESCRIPTION
## 📄 작업 내용 요약

소셜 로그인 통합(Unified Login)의 **Phase 1 — SocialAccount 엔티티/스키마 기반**을 도입합니다.
설계 문서: `docs/social-login-integration-plan.md` (§3.1 / 3.2 / 3.3 / 3.9, Phase 1)

> ⚠️ **expand 단계만 포함합니다.** 로그인/upsert 경로(`MemberUpsertService`, `LoginTokenIssuer`, `MemberWithdrawService` 등)는 **전혀 건드리지 않았고**, `Member`의 provider 계열 컬럼도 그대로 유지합니다. 따라서 **이 PR만 배포해도 기존 카카오/애플 × 웹/앱 로그인은 정상 동작**합니다. provider 컬럼 제거(contraction)와 로그인 전환은 Phase 2에서 진행합니다.

### 변경 사항

**신규 엔티티/레포지토리**
- `SocialAccount` 엔티티 — `Member` N:1 자식 (Track 패턴 준수, back-reference `setMember`)
  - 필드: `provider`, `providerId`, `providerEmail`, `appleRefreshToken`, `kakaoId`
  - 제약: `uk_social_provider_provider_id (provider, provider_id)`, 인덱스 `member_id`·`provider`
  - `createFromOAuth(provider, info)` 정적 팩토리 (providerEmail = 소셜이 준 이메일 저장, 회원 식별엔 미사용)
- `SocialAccountRepository.findByProviderAndProviderId` — Phase 2 upsert 진입점

**`Member` 엔티티**
- `@OneToMany List<SocialAccount> socialAccounts` 추가
- 편의 메서드 `addSocialAccount`(1 provider = 1 account 강제)/`hasProvider`/`findSocialAccount`
- `email`·`phoneNumber` → `@Column(unique = true)` (nullable) 로 완화

### 배포 시 유의
- 운영은 `ddl-auto=update` 라 부팅 시 `social_account` 테이블과 `phone_number` unique index 가 자동 생성될 수 있습니다. 사전 데이터 점검(총 113명, phone 중복 1쌍 정리 완료, 빈 문자열 0건)으로 unique 부여는 안전합니다.
- 데이터 이관 + phone unique 명시 부여는 아래 마이그레이션 스크립트로 **1회 수동 실행**합니다. (`docs/` 는 `.gitignore` 대상이라 diff 에 포함되지 않으므로 전문을 아래에 첨부합니다.)

---

## 🗄️ 마이그레이션 스크립트 (`docs/sql/phase1-social-account-migration.sql`)

### 쿼리별 역할

| # | 쿼리 | 역할 | 재실행 안전 |
|---|------|------|:---:|
| 0 | `CREATE TABLE IF NOT EXISTS social_account` | `ddl-auto=off` 환경 대비 테이블 명시 생성. (`update` 환경에선 Hibernate 가 자동 생성) | ✅ `IF NOT EXISTS` |
| 1 | `INSERT INTO social_account SELECT ... FROM member` | 기존 Member 의 provider 정보를 social_account 행으로 이관. `provider_email` 은 백필하지 않고 NULL(카카오 원본 이메일 복구 불가). 탈퇴/삭제 회원 제외. | ✅ `NOT EXISTS` 가드 |
| 2-a | `SELECT phone_number, COUNT(*) ... HAVING COUNT(*) > 1` | **필수 사전 검증.** phone_number 중복이 하나라도 있으면 2-b 가 실패하므로, 실행 전 반드시 0건임을 확인. | ✅ 읽기 전용 |
| 2-b | `information_schema.statistics` 확인 후 조건부 `ALTER ... ADD UNIQUE` | `phone_number` UNIQUE 부여. `@Column(unique=true)` 로 ddl-auto 가 먼저 index 를 만들었을 수 있어, **존재하지 않을 때만** 동적 실행(`PREPARE/EXECUTE`)하여 중복 index·실패 방지. | ✅ 존재 확인 가드 |

> **contraction 미포함**: `member.provider`/`provider_id`/`kakao_id`/`apple_refresh_token` 컬럼 DROP, `uk_member_provider_provider_id` 제거, `email NOT NULL` 완화는 로그인 경로가 SocialAccount 로 전환된(Phase 2) 뒤 별도 스크립트로 수행합니다. 전환 전 제거 시 앱이 동작 불가합니다.

### 스크립트 전문

```sql
-- =====================================================================
-- 소셜 로그인 통합 Phase 1 — SocialAccount 도입 마이그레이션 (expand 단계)
-- 전제: ddl-auto=update 라 테이블/인덱스는 자동 생성되나,
--   (1) provider 데이터 이관, (2) phone_number UNIQUE 부여는 본 스크립트로 1회 실행.
-- 실행 순서: 애플리케이션 배포(테이블 자동 생성) → 본 스크립트 실행.
-- =====================================================================

-- 0) (ddl-auto=off 환경 대비) social_account 테이블 명시적 생성
CREATE TABLE IF NOT EXISTS social_account (
    social_account_id   BIGINT        NOT NULL AUTO_INCREMENT,
    member_id           BIGINT        NOT NULL,
    provider            VARCHAR(16)   NOT NULL,
    provider_id         VARCHAR(64)   NOT NULL,
    provider_email      VARCHAR(255)  NULL,
    apple_refresh_token VARCHAR(1024) NULL,
    kakao_id            BIGINT        NULL,
    created_at          DATETIME(6)   NULL,
    updated_at          DATETIME(6)   NULL,
    PRIMARY KEY (social_account_id),
    CONSTRAINT uk_social_provider_provider_id UNIQUE (provider, provider_id),
    CONSTRAINT fk_social_account_member FOREIGN KEY (member_id) REFERENCES member (member_id),
    INDEX idx_social_member_id (member_id),
    INDEX idx_social_provider (provider)
) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4;

-- 1) 기존 Member provider 정보 → social_account 이관 (provider_email 백필 안 함, 탈퇴 제외, 재실행 안전)
INSERT INTO social_account
    (member_id, provider, provider_id, provider_email, apple_refresh_token, kakao_id, created_at, updated_at)
SELECT
    m.member_id, m.provider, m.provider_id, NULL, m.apple_refresh_token, m.kakao_id, NOW(6), NOW(6)
FROM member m
WHERE m.provider IS NOT NULL
  AND m.provider_id IS NOT NULL
  AND m.is_deleted = FALSE
  AND NOT EXISTS (
      SELECT 1 FROM social_account s
      WHERE s.provider = m.provider AND s.provider_id = m.provider_id
  );

-- 2-a) [필수 사전 검증] 반드시 0건 확인 후 2-b 진행
SELECT phone_number, COUNT(*) AS cnt
FROM member
WHERE phone_number IS NOT NULL
GROUP BY phone_number
HAVING COUNT(*) > 1;

-- 2-b) phone_number UNIQUE 부여 (존재하지 않을 때만 — 재실행/ddl-auto 선행 생성 안전)
SET @unique_exists := (
    SELECT COUNT(*)
    FROM information_schema.statistics
    WHERE table_schema = DATABASE()
      AND table_name = 'member'
      AND column_name = 'phone_number'
      AND non_unique = 0
);
SET @ddl := IF(@unique_exists = 0,
    'ALTER TABLE member ADD CONSTRAINT uk_member_phone_number UNIQUE (phone_number)',
    'DO 0 /* phone_number unique index 이미 존재 — skip */');
PREPARE stmt FROM @ddl;
EXECUTE stmt;
DEALLOCATE PREPARE stmt;
```

## 📎 Issue 번호
closed #332


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 소셜 로그인 계정을 회원 정보와 더 안정적으로 연결해, Apple·카카오 로그인 흐름이 개선되었습니다.
  * 로그인 상태에 따라 표시되는 이름, 이메일, 프로필 이미지가 더 일관되게 반영됩니다.

* **Bug Fixes**
  * Apple 로그인 후 갱신 정보가 함께 유지되도록 개선되어 재로그인 및 연동 안정성이 높아졌습니다.
  * 소셜 계정 정보가 변경된 경우 최신 이메일 정보가 더 정확하게 반영됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->