### PR TITLE
[FEAT] 소셜 로그인 통합 Phase 2: 로그인·upsert 경로 SocialAccount 기준 전환

### DIFF
--- a/src/main/java/com/tavemakers/surf/domain/auth/apple/usecase/AppleLoginUsecase.java
+++ b/src/main/java/com/tavemakers/surf/domain/auth/apple/usecase/AppleLoginUsecase.java
@@ -50,7 +50,7 @@ public class AppleLoginUsecase {
         Member member = memberUpsertService.upsertRegisteringFromOAuth(Provider.APPLE, userInfo);
 
         if (appleToken.refreshToken() != null) {
-            member.updateAppleRefreshToken(appleToken.refreshToken());
+            updateAppleRefreshToken(member, appleToken.refreshToken());
         }
         LoginPayloadResDTO payload = loginTokenIssuer.issue(member, userInfo, ClientType.WEB, request);
 
@@ -83,7 +83,7 @@ public class AppleLoginUsecase {
         if (req.authorizationCode() != null && !req.authorizationCode().isBlank()) {
             AppleTokenResDTO appleToken = appleAuthService.exchangeAppCodeForToken(req.authorizationCode());
             if (appleToken.refreshToken() != null) {
-                member.updateAppleRefreshToken(appleToken.refreshToken());
+                updateAppleRefreshToken(member, appleToken.refreshToken());
                 log.info("[LOGIN][APPLE][APP] refresh_token 저장 완료 memberId={}", member.getId());
             } else {
                 log.warn("[LOGIN][APPLE][APP] Apple이 refresh_token 미반환 — 탈퇴 시 revoke 불가 memberId={}", member.getId());
@@ -101,5 +101,15 @@ public class AppleLoginUsecase {
         );
 
         return payload;
+    }
+
+    /**
+     * Apple refresh_token 을 SocialAccount(신규 정규 저장소)와 Member(레거시, 탈퇴 revoke 호환)에 함께 저장한다.
+     * SocialAccount 로 탈퇴 로직이 이관되면(Phase 5) Member 쪽 저장은 제거한다.
+     */
+    private void updateAppleRefreshToken(Member member, String refreshToken) {
+        member.updateAppleRefreshToken(refreshToken);
+        member.findSocialAccount(Provider.APPLE)
+                .ifPresent(sa -> sa.updateAppleRefreshToken(refreshToken));
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/auth/common/service/LoginTokenIssuer.java
+++ b/src/main/java/com/tavemakers/surf/domain/auth/common/service/LoginTokenIssuer.java
@@ -37,12 +37,18 @@ public class LoginTokenIssuer {
 
         String accessToken = jwtService.createAccessToken(member.getId(), member.getRole().name());
 
+        // 응답 프로필 출처 = Member 기준(통합 프로필, 방식 B). 온보딩 전(REGISTERING)에는 Member 프로필이 비어 있으므로 provider 데이터로 폴백한다.
+        boolean registering = member.isRegistering();
+        String nickname = registering ? info.nickname() : member.getName();
+        String email = registering ? info.email() : member.getEmail();
+        String profileImageUrl = registering ? info.profileImageUrl() : member.getProfileImageUrl();
+
         if (clientType == ClientType.APP) {
             String refreshToken = refreshTokenService.issueRaw(member.getId(), resolution.deviceId());
-            LoginResDTO loginRes = LoginResDTO.ofApp(info.nickname(), info.email(), accessToken, refreshToken, info.profileImageUrl());
+            LoginResDTO loginRes = LoginResDTO.ofApp(nickname, email, accessToken, refreshToken, profileImageUrl);
             return LoginPayloadResDTO.app(loginRes);
         }
-        LoginResDTO loginRes = LoginResDTO.of(info.nickname(), info.email(), accessToken, info.profileImageUrl());
+        LoginResDTO loginRes = LoginResDTO.of(nickname, email, accessToken, profileImageUrl);
         ResponseCookie rtCookie = refreshTokenService.issue(member.getId(), resolution.deviceId());
         return LoginPayloadResDTO.web(loginRes, rtCookie, resolution.newCookie());
     }

--- a/src/main/java/com/tavemakers/surf/domain/member/entity/Member.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/entity/Member.java
@@ -174,13 +174,11 @@ public class Member extends BaseEntity {
     /**
      * OAuth provider 정보로 REGISTERING 상태의 회원을 생성한다 (D1, D5).
      * Kakao 는 닉네임이 일반적으로 채워져 있고, Apple 은 첫 로그인 시 nickname/profileImageUrl 이 null 일 수 있다.
+     * provider 이메일 유무에 의존하지 않는다 — provider 이메일은 SocialAccount.providerEmail 에 저장되며 없을 수 있다(Apple 미제공 등).
      */
     public static Member createRegisteringFromOAuth(Provider provider, OAuthUserInfoDTO info) {
         if (provider == null) {
             throw new IllegalStateException("provider 는 필수입니다.");
-        }
-        if (info.email() == null || info.email().isBlank()) {
-            throw new IllegalStateException(provider + " 계정의 이메일 권한이 필요합니다.");
         }
         if (info.oauthId() == null || info.oauthId().isBlank()) {
             throw new IllegalStateException(provider + " 식별자(oauthId)가 비어 있습니다.");
@@ -196,12 +194,13 @@ public class Member extends BaseEntity {
             }
         }
 
+        // 통합 이메일(Member.email)은 온보딩 입력값으로만 채운다. REGISTERING 단계에서는 값 없음(null).
+        // provider 가 준 이메일은 SocialAccount.providerEmail 에만 저장된다.
         return Member.builder()
                 .provider(provider)
                 .providerId(info.oauthId())
                 .kakaoId(legacyKakaoId)
                 .name(info.nickname())
-                .email(info.email())
                 .phoneNumberPublic(false)
                 .profileImageUrl(info.profileImageUrl())
                 .status(MemberStatus.REGISTERING)

--- a/src/main/java/com/tavemakers/surf/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/repository/MemberRepository.java
@@ -1,6 +1,5 @@
 package com.tavemakers.surf.domain.member.repository;
 
-import com.tavemakers.surf.domain.auth.common.enums.Provider;
 import com.tavemakers.surf.domain.member.entity.Member;
 import com.tavemakers.surf.domain.member.entity.enums.MemberStatus;
 import org.springframework.data.domain.Pageable;
@@ -28,13 +27,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     List<Member> findByActivityStatusAndNameAndStatusNot(Boolean activityStatus, String name, MemberStatus status);
 
     Optional<Member> findByEmailAndStatus(String email, MemberStatus status);
-  
-    /** provider + providerId 복합 식별자로 회원 조회 (D1). */
-    Optional<Member> findByProviderAndProviderId(Provider provider, String providerId);
-
-    /** @deprecated provider/providerId 모델로 마이그레이션됨 (D1). 호출자 일소 후 후속 PR(Step 7)에서 제거. */
-    @Deprecated
-    Optional<Member> findByKakaoId(Long kakaoId);
 
     // 댓글(comment)에서 멘션할 회원을 검색할 때 사용
     @Query("""

--- a/src/main/java/com/tavemakers/surf/domain/member/service/MemberUpsertService.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/service/MemberUpsertService.java
@@ -2,46 +2,69 @@ package com.tavemakers.surf.domain.member.service;
 
 import com.tavemakers.surf.domain.auth.common.dto.OAuthUserInfoDTO;
 import com.tavemakers.surf.domain.auth.common.enums.Provider;
-import com.tavemakers.surf.domain.auth.common.exception.EmailConflictException;
 import com.tavemakers.surf.domain.member.entity.Member;
+import com.tavemakers.surf.domain.member.entity.SocialAccount;
 import com.tavemakers.surf.domain.member.repository.MemberRepository;
+import com.tavemakers.surf.domain.member.repository.SocialAccountRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
 public class MemberUpsertService {
 
     private final MemberRepository memberRepository;
+    private final SocialAccountRepository socialAccountRepository;
     private final MemberBlacklistGetService memberBlacklistGetService;
 
     /**
-     * OAuth provider 정보로 회원 생성 또는 기존 회원 반환 (D1).
-     * 동일 이메일이 다른 provider 로 이미 가입돼 있으면 EmailConflictException 발생 (D6).
+     * 소셜 로그인 upsert — SocialAccount 기준으로 조회하고, 없으면 REGISTERING 회원 + SocialAccount 를 생성한다.
+     * <p>로그인 단계에서는 email/phone 기반 자동 통합을 하지 않는다(명시적 연동만 허용, EmailConflictException 폐기).
+     * 반환 엔티티는 현재 트랜잭션에서 managed 상태이므로 호출자의 후속 변경(refresh_token 등)이 커밋에 함께 반영된다.
      */
     @Transactional
     public Member upsertRegisteringFromOAuth(Provider provider, OAuthUserInfoDTO info) {
-        return memberRepository.findByProviderAndProviderId(provider, info.oauthId())
-                .orElseGet(() -> createWithEmailConflictGuard(provider, info));
+        return findExistingMember(provider, info)
+                .orElseGet(() -> createNewSocialMember(provider, info));
     }
 
-    private Member createWithEmailConflictGuard(Provider provider, OAuthUserInfoDTO info) {
+    /** SocialAccount 로 기존 회원을 조회하고, 있으면 provider 가 준 이메일로 providerEmail 을 갱신한다. */
+    private Optional<Member> findExistingMember(Provider provider, OAuthUserInfoDTO info) {
+        return socialAccountRepository.findByProviderAndProviderId(provider, info.oauthId())
+                .map(socialAccount -> {
+                    refreshProviderEmail(socialAccount, info.email());
+                    return socialAccount.getMember();
+                });
+    }
+
+    /**
+     * 신규 소셜 계정 로그인 — REGISTERING 회원 + SocialAccount 를 현재 트랜잭션에서 생성/연결한다.
+     * <p>동시 첫 로그인 경합 시 한쪽은 UNIQUE 제약 위반으로 트랜잭션이 롤백되며(재시도 시 정상 진입), 오염된 세션에서 복구를 시도하지 않는다.
+     */
+    private Member createNewSocialMember(Provider provider, OAuthUserInfoDTO info) {
         Long kakaoId = provider == Provider.KAKAO ? Long.parseLong(info.oauthId()) : null;
         memberBlacklistGetService.validateNotBlacklisted(kakaoId, info.email(), null);
 
-        memberRepository.findByEmail(info.email()).ifPresent(existing -> {
-            if (existing.getProvider() != provider) {
-                throw new EmailConflictException(existing.getProvider());
-            }
-        });
-        Member toSave = Member.createRegisteringFromOAuth(provider, info);
-        try {
-            return memberRepository.saveAndFlush(toSave);
-        } catch (DataIntegrityViolationException e) {
-            return memberRepository.findByProviderAndProviderId(provider, info.oauthId())
-                    .orElseThrow(() -> e);
+        Member member = Member.createRegisteringFromOAuth(provider, info);
+        SocialAccount socialAccount = SocialAccount.createFromOAuth(provider, info);
+        member.addSocialAccount(socialAccount);
+
+        return memberRepository.save(member);
+    }
+
+    /**
+     * 재로그인 시 provider 가 준 이메일로 providerEmail 을 갱신한다(레거시 이관 행의 null 백필 대체, 설계 3.6).
+     * <p>Apple 은 최초 로그인 이후 이메일을 주지 않으므로 값이 있을 때만 갱신해 기존 값을 지우지 않는다.
+     */
+    private void refreshProviderEmail(SocialAccount socialAccount, String providerEmail) {
+        if (providerEmail == null || providerEmail.isBlank()) {
+            return;
+        }
+        if (!providerEmail.equals(socialAccount.getProviderEmail())) {
+            socialAccount.updateProviderEmail(providerEmail);
         }
     }
 }


### PR DESCRIPTION
## 📄 작업 내용 요약

소셜 로그인 통합 **Phase 2** — 로그인/회원 upsert 경로를 `Member.provider/providerId` 직접 조회에서 **`SocialAccount` 기준 조회**로 전환합니다.
로그인 단계에서는 email/phone 기반 자동 통합을 하지 않고(명시적 연동만 허용), 로그인 응답 프로필은 로그인 수단(Kakao/Apple)과 무관하게 **회원(Member) 기준 통합 프로필**로 내려갑니다.

> 설계 문서: `docs/social-login-integration-plan.md` §3.3 / 3.4 / 3.7 (Phase 2)

---

## 🔀 이 PR을 #333과 분리한 이유 · 병합 순서 (중요)

이 PR은 스키마/데이터가 준비된 뒤에야 안전하게 동작하므로 **Phase 1(#333)과 물리적으로 분리**했습니다. 아래 순서를 반드시 지켜주세요.

```
1) PR #333 (Phase 1) 병합           ← social_account 테이블·엔티티 도입
2) docs/sql/phase1-social-account-migration.sql 실행   ← 백필 + 제약 완화 (아래 ⚠️ 참고)
3) 이 PR (Phase 2) 병합             ← 로그인 경로를 social_account 기준으로 전환
```

- **base 브랜치**: `feat/#332/social-account-entity` (Phase 1). 그래서 이 PR의 diff에는 **Phase 2 변경만** 보입니다. #333이 `dev`로 병합되면 GitHub가 이 PR의 base를 자동으로 `dev`로 재지정합니다.
- 순서를 어기고 이 코드가 SQL보다 먼저 트래픽을 받으면 그 사이 로그인이 실패합니다(원인은 아래 ⚠️). SQL 적용 시 self-heal 되며 스크립트는 재실행 안전(idempotent)입니다.

---

## 🔁 무엇이 바뀌나 (모델 전/후)

| | Before (Phase 1까지) | After (이 PR) |
|---|---|---|
| 로그인 계정 조회 | `Member.provider + providerId` | `SocialAccount.provider + providerId` |
| 신규 소셜 로그인 | `Member`만 생성 | `Member(REGISTERING)` + `SocialAccount` 동시 생성 |
| provider 이메일 | `Member.email`에 저장 | `SocialAccount.providerEmail`에 저장 (회원 식별에 미사용) |
| 같은 이메일·다른 provider | `EmailConflictException`으로 차단 | 차단 폐기 (자동 통합 없음, 명시적 연동은 Phase 4) |
| 로그인 응답 프로필 | provider가 준 값 | **Member 통합 프로필** (REGISTERING만 provider 폴백) |
| Apple refresh_token | `Member`에만 저장 | `SocialAccount` + `Member`(레거시 호환) 이중 저장 |

---

## 📂 변경점 상세 (커밋 = 리뷰 단위)

### 1️⃣ 로그인 upsert를 SocialAccount 기준으로 전환 — `0a5ff93`
`MemberUpsertService.java`, `MemberRepository.java`, `Member.java`

- **조회 진입점 변경**: `socialAccountRepository.findByProviderAndProviderId(...)`로 기존 소셜 계정을 찾고, 있으면 연결된 `Member`를 반환.
- **신규 소셜 계정**: `Member(status=REGISTERING)` + `SocialAccount`를 **같은 트랜잭션에서** 생성/연결(`member.addSocialAccount(...)` → cascade 저장). 같은 트랜잭션이라 반환 엔티티가 managed 상태로 유지되어, 호출자의 후속 변경(refresh_token 등)이 커밋에 함께 반영됩니다.
- **자동 통합/`EmailConflictException` 폐기**: provider 이메일은 더 이상 회원 식별에 쓰이지 않으므로 로그인 단계 충돌 차단을 제거. (계정 통합은 Phase 4에서 명시적 API로만)
- **`providerEmail` 재로그인 백필**: 마이그레이션에서 `providerEmail`을 null로 남긴 레거시 행을, 재로그인 시 provider가 준 이메일로 갱신. **Apple은 최초 로그인 이후 이메일을 주지 않으므로(null) 값이 있을 때만 갱신**해 기존 값을 지우지 않습니다.
- **동시 첫 로그인 경합 정책**: 같은 신규 계정으로 거의 동시에 두 번 첫 로그인하면 한쪽이 UNIQUE 제약 위반으로 트랜잭션 롤백되고(클라이언트 재시도 시 정상 진입), **오염된 영속성 컨텍스트에서 억지로 복구를 시도하지 않습니다.** (별도 트랜잭션 격리 방식은 detached 엔티티/`REPEATABLE READ` 가시성 문제를 유발해 채택하지 않음 — 아래 트레이드오프 참고)
- **repository 정리**: `MemberRepository.findByProviderAndProviderId` / `findByKakaoId`(@Deprecated) 제거(호출부 없음 확인).
- **`Member.createRegisteringFromOAuth`**: `email`을 채우지 않음. 통합 이메일은 온보딩 입력값으로만 채워지고 REGISTERING 단계에서는 null입니다.

### 2️⃣ 로그인 응답 프로필을 Member 기준으로 전환 — `66d823a` (`LoginTokenIssuer.java`)
- 응답 `nickname/email/profileImageUrl`을 로그인 수단과 무관하게 **`Member` 기준**으로 반환(설계 방식 B).
- 단 **REGISTERING(온보딩 전)** 은 Member 프로필이 비어 있으므로 provider 데이터로 폴백(온보딩 프리필 용도).

### 3️⃣ Apple refresh_token을 SocialAccount에 함께 저장 — `c7e6a27` (`AppleLoginUsecase.java`)
- refresh_token을 `SocialAccount`(정규 저장소)와 `Member`(레거시, 탈퇴 revoke 호환)에 **이중 저장**.
- Phase 5에서 탈퇴 로직이 `SocialAccount` 순회로 이관되면 Member 측 저장은 제거 예정.

---

## ⚠️ 배포 의존성 — 마이그레이션 SQL (필수)

운영은 `ddl-auto=update`라 **코드만으로는 로그인이 깨집니다.** `docs/sql/phase1-social-account-migration.sql`을 위 병합 순서 2)에서 실행해야 합니다.

| 단계 | 내용 | 안 하면 |
|---|---|---|
| 1) 백필 | 기존 `Member` provider 정보 → `social_account` 행 이관 | 기존 회원 재로그인 시 `social_account` 미조회 → 새 Member insert → `uk_member_provider_provider_id` 위반 → **로그인 실패** |
| 3) `member.email` NOT NULL 완화 | 신규 소셜 로그인은 `email=null`로 REGISTERING 생성 | 신규 소셜 로그인 저장 실패 |
| 2) `phone_number` UNIQUE | 온보딩 부분 일치 차단(Phase 3) 선행 | Phase 3 검증 불가 (이 PR 로그인 자체엔 영향 없음) |

> `member.provider/provider_id` 등 컬럼 DROP(contraction)은 **이 PR에 포함하지 않습니다.** 전환 안정화 확인 후 별도 스크립트로 진행합니다.

---

## 🧪 테스트 / 검증

- [x] 변경 4개 파일 컴파일 확인 (로컬 toolchain 이슈로 단일 파일 단위 컴파일 검증)
- [ ] **회귀(스테이징 권장)**: Kakao/Apple × Web/App **4조합 로그인**
- [ ] **회귀**: 기존(백필된) 회원 재로그인 정상 — 특히 신규 Apple 로그인 후 `apple_refresh_token`이 `social_account`/`member` 양쪽에 저장되는지
- [ ] **회귀**: 신규 소셜 로그인 시 `Member(email=null, REGISTERING)` + `SocialAccount(providerEmail=제공값)` 생성 확인

---

## 🧩 설계 결정 & 트레이드오프

- **자동 통합 없음**: 로그인 단계에서 email/phone로 계정을 병합하지 않습니다. 완전 일치 시 명시적 연동(Phase 4)에서만 통합합니다.
- **경합 복구를 별도 트랜잭션으로 격리하지 않음**: `REQUIRES_NEW`로 insert를 격리하면 ①커밋 후 반환 엔티티가 outer 트랜잭션에서 **detached**가 되어 Apple refresh_token 저장이 유실되고, ②MySQL 기본 `REPEATABLE READ`에서 outer 트랜잭션이 inner 커밋을 **못 봐서** 재조회가 실패할 수 있습니다. 그래서 같은 트랜잭션 생성 + 경합 시 실패-재시도(정상 경로 100% 정확, 초희귀 경합만 재시도)를 택했습니다.
- **로그인 응답 = Member 기준**: 어느 소셜로 로그인해도 일관된 프로필을 반환합니다.

---

## 📌 후속 과제 (이 PR 범위 밖)

- **Phase 3**: 온보딩 email/phone 부분 일치 차단 검증 (`findByPhoneNumber` 등)
- **Phase 4**: 계정 통합(연동) API — `PendingSocialIntegration`, `POST /v1/user/social-accounts/integrate`
- **Phase 5**: 탈퇴 로직을 `Member.provider` 분기 → `socialAccounts` 순회로 이관, 블랙리스트 kakaoId 의존 정리
- **contraction**: `member.provider/provider_id/kakao_id/apple_refresh_token` 및 `uk_member_provider_provider_id` DROP

---

## 📎 Issue 번호
<!-- closed #번호 -->
resolves #334


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Apple 로그인에서 가입 진행 중인 사용자의 계정 생성 흐름이 더 유연해졌습니다.
  * 로그인 응답에 표시되는 닉네임, 이메일, 프로필 이미지가 회원 상태에 따라 더 적절한 값으로 제공됩니다.

* **Bug Fixes**
  * Apple에서 이메일 제공이 없는 경우에도 가입 진행을 계속할 수 있도록 개선했습니다.
  * Apple 로그인 정보 저장 시 관련 계정 정보가 함께 더 안정적으로 반영되도록 수정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->