### PR TITLE
[FEAT] 게시판 카테고리 전체 조회/삭제 API 추가

### DIFF
--- a/src/main/java/com/tavemakers/surf/domain/board/controller/BoardCategoryDeleteController.java
+++ b/src/main/java/com/tavemakers/surf/domain/board/controller/BoardCategoryDeleteController.java
@@ -1,0 +1,32 @@
+package com.tavemakers.surf.domain.board.controller;
+
+import com.tavemakers.surf.domain.board.usecase.BoardCategoryUsecase;
+import com.tavemakers.surf.global.common.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import static com.tavemakers.surf.domain.board.controller.ResponseMessage.BOARD_CATEGORY_DELETED;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping
+// 게시판 태그와 동일한 태그 사용
+@Tag(name = "게시판", description = "추후 MVP를 통해 디벨롭 될 예정")
+public class BoardCategoryDeleteController {
+
+    private final BoardCategoryUsecase boardCategoryUsecase;
+
+    /** 게시판 카테고리를 삭제합니다. (하위 게시글이 없는 경우에만 가능) */
+    @Operation(summary = "게시판 카테고리 삭제", description = "특정 게시판의 카테고리를 삭제합니다. 하위 게시글이 존재하면 삭제할 수 없습니다.")
+    @DeleteMapping("/v1/admin/boards/{boardId}/categories/{categoryId}")
+    public ApiResponse<Void> deleteCategory(
+            @PathVariable Long boardId,
+            @PathVariable Long categoryId) {
+        boardCategoryUsecase.deleteCategory(boardId, categoryId);
+        return ApiResponse.response(HttpStatus.NO_CONTENT, BOARD_CATEGORY_DELETED.getMessage());
+    }
+
+}

--- a/src/main/java/com/tavemakers/surf/domain/board/controller/BoardCategoryGetController.java
+++ b/src/main/java/com/tavemakers/surf/domain/board/controller/BoardCategoryGetController.java
@@ -1,0 +1,33 @@
+package com.tavemakers.surf.domain.board.controller;
+
+import com.tavemakers.surf.domain.board.dto.response.BoardCategoriesGetResDTO;
+import com.tavemakers.surf.domain.board.usecase.BoardCategoryUsecase;
+import com.tavemakers.surf.global.common.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+import static com.tavemakers.surf.domain.board.controller.ResponseMessage.BOARD_CATEGORY_READ;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping
+// 게시판 태그와 동일한 태그 사용
+@Tag(name = "게시판", description = "추후 MVP를 통해 디벨롭 될 예정")
+public class BoardCategoryGetController {
+
+    private final BoardCategoryUsecase boardCategoryUsecase;
+
+    /** 전체 카테고리를 게시판별로 묶어서 조회합니다. */
+    @Operation(summary = "카테고리 목록 게시판별 조회", description = "전체 카테고리를 게시판(Board) 단위로 묶어서 조회합니다.")
+    @GetMapping("/v1/user/boards/categories")
+    public ApiResponse<List<BoardCategoriesGetResDTO>> getCategoriesGroupedByBoard() {
+        List<BoardCategoriesGetResDTO> response = boardCategoryUsecase.getCategoriesGroupedByBoard();
+        return ApiResponse.response(HttpStatus.OK, BOARD_CATEGORY_READ.getMessage(), response);
+    }
+
+}

--- a/src/main/java/com/tavemakers/surf/domain/board/controller/ResponseMessage.java
+++ b/src/main/java/com/tavemakers/surf/domain/board/controller/ResponseMessage.java
@@ -12,7 +12,8 @@ public enum ResponseMessage {
     BOARD_DELETED("[게시판]이 성공적으로 삭제되었습니다."),
     BOARD_READ("[게시판]이 성공적으로 조회되었습니다."),
 
-    BOARD_CATEGORY_CREATED("[게시판-카테고리]가 성공적으로 생성되었습니다.");
+    BOARD_CATEGORY_CREATED("[게시판-카테고리]가 성공적으로 생성되었습니다."),
+    BOARD_CATEGORY_READ("[게시판-카테고리]가 성공적으로 조회되었습니다.");
 
     private final String message;
 

--- a/src/main/java/com/tavemakers/surf/domain/board/controller/ResponseMessage.java
+++ b/src/main/java/com/tavemakers/surf/domain/board/controller/ResponseMessage.java
@@ -13,7 +13,8 @@ public enum ResponseMessage {
     BOARD_READ("[게시판]이 성공적으로 조회되었습니다."),
 
     BOARD_CATEGORY_CREATED("[게시판-카테고리]가 성공적으로 생성되었습니다."),
-    BOARD_CATEGORY_READ("[게시판-카테고리]가 성공적으로 조회되었습니다.");
+    BOARD_CATEGORY_READ("[게시판-카테고리]가 성공적으로 조회되었습니다."),
+    BOARD_CATEGORY_DELETED("[게시판-카테고리]가 성공적으로 삭제되었습니다.");
 
     private final String message;
 

--- a/src/main/java/com/tavemakers/surf/domain/board/dto/response/BoardCategoriesGetResDTO.java
+++ b/src/main/java/com/tavemakers/surf/domain/board/dto/response/BoardCategoriesGetResDTO.java
@@ -1,0 +1,35 @@
+package com.tavemakers.surf.domain.board.dto.response;
+
+import com.tavemakers.surf.domain.board.entity.Board;
+import com.tavemakers.surf.domain.board.entity.BoardCategory;
+import com.tavemakers.surf.domain.board.entity.BoardType;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "게시판별 카테고리 목록 응답 DTO")
+public record BoardCategoriesGetResDTO(
+
+        @Schema(description = "게시판 ID", example = "1")
+        Long boardId,
+
+        @Schema(description = "게시판 이름", example = "공지사항")
+        String boardName,
+
+        @Schema(description = "게시판 타입", example = "NOTICE")
+        BoardType boardType,
+
+        @Schema(description = "게시판에 속한 카테고리 목록")
+        List<BoardCategoryResDTO> categories
+) {
+    public static BoardCategoriesGetResDTO of(Board board, List<BoardCategory> categories) {
+        return new BoardCategoriesGetResDTO(
+                board.getId(),
+                board.getName(),
+                board.getType(),
+                categories.stream()
+                        .map(BoardCategoryResDTO::from)
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/com/tavemakers/surf/domain/board/exception/CategoryHasPostsException.java
+++ b/src/main/java/com/tavemakers/surf/domain/board/exception/CategoryHasPostsException.java
@@ -1,0 +1,11 @@
+package com.tavemakers.surf.domain.board.exception;
+
+import com.tavemakers.surf.global.common.exception.BaseException;
+
+import static com.tavemakers.surf.domain.board.exception.ErrorMessage.CATEGORY_HAS_POSTS;
+
+public class CategoryHasPostsException extends BaseException {
+    public CategoryHasPostsException() {
+        super(CATEGORY_HAS_POSTS.getStatus(), CATEGORY_HAS_POSTS.getMessage());
+    }
+}

--- a/src/main/java/com/tavemakers/surf/domain/board/exception/ErrorMessage.java
+++ b/src/main/java/com/tavemakers/surf/domain/board/exception/ErrorMessage.java
@@ -15,7 +15,9 @@ public enum ErrorMessage {
 
     BOARD_CATEGORY_ALREADY_EXISTS(HttpStatus.CONFLICT, "해당 [게시판]에 이미 존재하는 [슬러그]입니다."),
 
-    INVALID_CATEGORY_MAPPING(HttpStatus.BAD_REQUEST, "유효하지 않은 [게시판]과 [카테고리] 조합입니다.");
+    INVALID_CATEGORY_MAPPING(HttpStatus.BAD_REQUEST, "유효하지 않은 [게시판]과 [카테고리] 조합입니다."),
+
+    CATEGORY_HAS_POSTS(HttpStatus.CONFLICT, "하위 [게시글]이 존재하여 [카테고리]를 삭제할 수 없습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/tavemakers/surf/domain/board/repository/BoardCategoryRepository.java
+++ b/src/main/java/com/tavemakers/surf/domain/board/repository/BoardCategoryRepository.java
@@ -3,6 +3,7 @@ package com.tavemakers.surf.domain.board.repository;
 import com.tavemakers.surf.domain.board.entity.Board;
 import com.tavemakers.surf.domain.board.entity.BoardCategory;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 import java.util.Optional;
@@ -11,6 +12,10 @@ public interface BoardCategoryRepository extends JpaRepository<BoardCategory, Lo
 
     // 보드 내 모든 카테고리 조회
     List<BoardCategory> findAllByBoardId(Long boardId);
+
+    // 전체 카테고리를 게시판과 함께 조회 (N+1 방지, 게시판/카테고리 ID 순 정렬)
+    @Query("select bc from BoardCategory bc join fetch bc.board order by bc.board.id asc, bc.id asc")
+    List<BoardCategory> findAllWithBoard();
 
     // 보드 내 슬러그로 조회 (URL 접근용)
     Optional<BoardCategory> findByBoardIdAndSlug(Long boardId, String slug);

--- a/src/main/java/com/tavemakers/surf/domain/board/service/BoardCategoryGetService.java
+++ b/src/main/java/com/tavemakers/surf/domain/board/service/BoardCategoryGetService.java
@@ -1,11 +1,18 @@
 package com.tavemakers.surf.domain.board.service;
 
+import com.tavemakers.surf.domain.board.dto.response.BoardCategoriesGetResDTO;
+import com.tavemakers.surf.domain.board.entity.Board;
 import com.tavemakers.surf.domain.board.entity.BoardCategory;
 import com.tavemakers.surf.domain.board.exception.CategoryNotFoundException;
 import com.tavemakers.surf.domain.board.repository.BoardCategoryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -17,6 +24,18 @@ public class BoardCategoryGetService {
     public BoardCategory getCategory(Long id) {
         return boardCategoryRepository.findById(id)
                 .orElseThrow(CategoryNotFoundException::new);
+    }
+
+    /** 전체 카테고리를 게시판(Board)별로 묶어서 조회 */
+    public List<BoardCategoriesGetResDTO> getCategoriesGroupedByBoard() {
+        Map<Board, List<BoardCategory>> grouped = new LinkedHashMap<>();
+        for (BoardCategory category : boardCategoryRepository.findAllWithBoard()) {
+            grouped.computeIfAbsent(category.getBoard(), b -> new ArrayList<>())
+                    .add(category);
+        }
+        return grouped.entrySet().stream()
+                .map(entry -> BoardCategoriesGetResDTO.of(entry.getKey(), entry.getValue()))
+                .toList();
     }
 
     /** Board ID와 slug로 BoardCategory 엔티티 조회, 없으면 CategoryNotFoundException */

--- a/src/main/java/com/tavemakers/surf/domain/board/service/BoardCategoryService.java
+++ b/src/main/java/com/tavemakers/surf/domain/board/service/BoardCategoryService.java
@@ -35,4 +35,11 @@ public class BoardCategoryService {
             throw new BoardCategoryAlreadyExistsException();
         }
     }
+
+    /** 게시판 카테고리 삭제 */
+    @Transactional
+    @LogEvent(value = "board.category.delete", message = "게시판 카테고리 삭제 성공")
+    public void deleteBoardCategory(BoardCategory category) {
+        boardCategoryRepository.delete(category);
+    }
 }

--- a/src/main/java/com/tavemakers/surf/domain/board/usecase/BoardCategoryUsecase.java
+++ b/src/main/java/com/tavemakers/surf/domain/board/usecase/BoardCategoryUsecase.java
@@ -1,24 +1,35 @@
 package com.tavemakers.surf.domain.board.usecase;
 
 import com.tavemakers.surf.domain.board.dto.request.BoardCategoryCreateReqDTO;
+import com.tavemakers.surf.domain.board.dto.response.BoardCategoriesGetResDTO;
 import com.tavemakers.surf.domain.board.dto.response.BoardCategoryResDTO;
 import com.tavemakers.surf.domain.board.entity.Board;
-import com.tavemakers.surf.domain.board.service.BoardGetService;
+import com.tavemakers.surf.domain.board.service.BoardCategoryGetService;
 import com.tavemakers.surf.domain.board.service.BoardCategoryService;
+import com.tavemakers.surf.domain.board.service.BoardGetService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class BoardCategoryUsecase {
     private final BoardGetService boardGetService;
     private final BoardCategoryService boardCategoryService;
+    private final BoardCategoryGetService boardCategoryGetService;
 
     /** 게시판 카테고리를 생성합니다. */
     @Transactional
     public BoardCategoryResDTO createCategory(Long boardId, BoardCategoryCreateReqDTO req) {
         Board board = boardGetService.getBoard(boardId);
         return boardCategoryService.createBoardCategory(board, req);
+    }
+
+    /** 전체 카테고리를 게시판(Board)별로 묶어서 조회합니다. */
+    @Transactional(readOnly = true)
+    public List<BoardCategoriesGetResDTO> getCategoriesGroupedByBoard() {
+        return boardCategoryGetService.getCategoriesGroupedByBoard();
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/board/usecase/BoardCategoryUsecase.java
+++ b/src/main/java/com/tavemakers/surf/domain/board/usecase/BoardCategoryUsecase.java
@@ -4,9 +4,13 @@ import com.tavemakers.surf.domain.board.dto.request.BoardCategoryCreateReqDTO;
 import com.tavemakers.surf.domain.board.dto.response.BoardCategoriesGetResDTO;
 import com.tavemakers.surf.domain.board.dto.response.BoardCategoryResDTO;
 import com.tavemakers.surf.domain.board.entity.Board;
+import com.tavemakers.surf.domain.board.entity.BoardCategory;
+import com.tavemakers.surf.domain.board.exception.CategoryHasPostsException;
+import com.tavemakers.surf.domain.board.exception.InvalidCategoryMappingException;
 import com.tavemakers.surf.domain.board.service.BoardCategoryGetService;
 import com.tavemakers.surf.domain.board.service.BoardCategoryService;
 import com.tavemakers.surf.domain.board.service.BoardGetService;
+import com.tavemakers.surf.domain.post.service.post.PostGetService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,6 +23,7 @@ public class BoardCategoryUsecase {
     private final BoardGetService boardGetService;
     private final BoardCategoryService boardCategoryService;
     private final BoardCategoryGetService boardCategoryGetService;
+    private final PostGetService postGetService;
 
     /** 게시판 카테고리를 생성합니다. */
     @Transactional
@@ -31,5 +36,20 @@ public class BoardCategoryUsecase {
     @Transactional(readOnly = true)
     public List<BoardCategoriesGetResDTO> getCategoriesGroupedByBoard() {
         return boardCategoryGetService.getCategoriesGroupedByBoard();
+    }
+
+    /** 게시판 카테고리를 삭제합니다. (하위 게시글이 없는 경우에만 가능) */
+    @Transactional
+    public void deleteCategory(Long boardId, Long categoryId) {
+        BoardCategory category = boardCategoryGetService.getCategory(categoryId);
+
+        if (!category.getBoard().getId().equals(boardId)) {
+            throw new InvalidCategoryMappingException();
+        }
+        if (postGetService.existsByCategory(categoryId)) {
+            throw new CategoryHasPostsException();
+        }
+
+        boardCategoryService.deleteBoardCategory(category);
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/repository/PostRepository.java
@@ -20,6 +20,8 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     Slice<Post> findByBoardIdAndCategoryIdAndIsReservedFalse(Long boardId, Long categoryId, Pageable pageable);
 
+    boolean existsByCategoryId(Long categoryId);
+
     Slice<Post> findByMemberId(Long memberId, Pageable pageable);
 
     @Query("select p.version from Post p where p.id = :id")

--- a/src/main/java/com/tavemakers/surf/domain/post/service/post/PostGetService.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/service/post/PostGetService.java
@@ -63,6 +63,12 @@ public class PostGetService {
                 .orElseThrow(PostNotFoundException::new);
     }
 
+    /** 특정 카테고리에 속한 게시글 존재 여부 */
+    @Transactional(readOnly = true)
+    public boolean existsByCategory(Long categoryId) {
+        return postRepository.existsByCategoryId(categoryId);
+    }
+
     /** 게시글 상세 조회 (DTO 반환) */
     @Transactional
     public PostDetailResDTO getPostDetail(Long postId, Long memberId) {


### PR DESCRIPTION
## 📄 작업 내용 요약

프론트 요청으로 게시판 카테고리 관련 API 2건을 추가했습니다.

### 1. 전체 카테고리 게시판별 조회 (USER)
- `GET /v1/user/boards/categories`
- 전체 카테고리를 게시판(Board) 단위로 묶어서 반환합니다.
- `join fetch`로 N+1을 방지하고, 게시판/카테고리 ID 오름차순으로 정렬합니다.
- 응답 DTO: `BoardCategoriesGetResDTO` (게시판 정보 + 카테고리 목록)

### 2. 게시판 카테고리 삭제 (ADMIN)
- `DELETE /v1/admin/boards/{boardId}/categories/{categoryId}`
- 검증 순서: ① 카테고리 존재(`404`) → ② 게시판 매핑 일치(`400`) → ③ 하위 게시글 존재 여부
- **하위 게시글이 존재하면 삭제를 차단하고 `409 Conflict`로 응답합니다.**
- 타 도메인 조회는 컨벤션에 따라 `PostGetService.existsByCategory`를 통해서만 접근합니다.

### 응답 메시지 / 예외 추가
- `ResponseMessage`: `BOARD_CATEGORY_READ`, `BOARD_CATEGORY_DELETED`
- `ErrorMessage` + `CategoryHasPostsException`: `CATEGORY_HAS_POSTS` (409)

### 참고
- 카테고리가 하나도 없는 게시판은 조회 결과에 포함되지 않습니다.

## 📎 Issue 번호
<!-- closed #번호 -->
closed #336


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 게시판별 카테고리 목록을 한 번에 조회할 수 있게 되었습니다.
  * 관리자용 카테고리 삭제 기능이 추가되었습니다.
* **Bug Fixes**
  * 카테고리에 게시글이 있으면 삭제되지 않도록 제한이 적용되었습니다.
  * 게시판과 카테고리의 연결이 올바르지 않을 때 삭제가 차단됩니다.
* **Documentation**
  * 카테고리 조회/삭제 API 안내와 응답 메시지가 보강되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->