### PR TITLE
[FEAT] 소셜 로그인 통합 Phase 2: 로그인·upsert 경로 SocialAccount 기준 전환

### DIFF
--- a/src/main/java/com/tavemakers/surf/domain/auth/apple/usecase/AppleLoginUsecase.java
+++ b/src/main/java/com/tavemakers/surf/domain/auth/apple/usecase/AppleLoginUsecase.java
@@ -50,7 +50,7 @@ public class AppleLoginUsecase {
         Member member = memberUpsertService.upsertRegisteringFromOAuth(Provider.APPLE, userInfo);
 
         if (appleToken.refreshToken() != null) {
-            member.updateAppleRefreshToken(appleToken.refreshToken());
+            updateAppleRefreshToken(member, appleToken.refreshToken());
         }
         LoginPayloadResDTO payload = loginTokenIssuer.issue(member, userInfo, ClientType.WEB, request);
 
@@ -83,7 +83,7 @@ public class AppleLoginUsecase {
         if (req.authorizationCode() != null && !req.authorizationCode().isBlank()) {
             AppleTokenResDTO appleToken = appleAuthService.exchangeAppCodeForToken(req.authorizationCode());
             if (appleToken.refreshToken() != null) {
-                member.updateAppleRefreshToken(appleToken.refreshToken());
+                updateAppleRefreshToken(member, appleToken.refreshToken());
                 log.info("[LOGIN][APPLE][APP] refresh_token 저장 완료 memberId={}", member.getId());
             } else {
                 log.warn("[LOGIN][APPLE][APP] Apple이 refresh_token 미반환 — 탈퇴 시 revoke 불가 memberId={}", member.getId());
@@ -101,5 +101,15 @@ public class AppleLoginUsecase {
         );
 
         return payload;
+    }
+
+    /**
+     * Apple refresh_token 을 SocialAccount(신규 정규 저장소)와 Member(레거시, 탈퇴 revoke 호환)에 함께 저장한다.
+     * SocialAccount 로 탈퇴 로직이 이관되면(Phase 5) Member 쪽 저장은 제거한다.
+     */
+    private void updateAppleRefreshToken(Member member, String refreshToken) {
+        member.updateAppleRefreshToken(refreshToken);
+        member.findSocialAccount(Provider.APPLE)
+                .ifPresent(sa -> sa.updateAppleRefreshToken(refreshToken));
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/auth/common/service/LoginTokenIssuer.java
+++ b/src/main/java/com/tavemakers/surf/domain/auth/common/service/LoginTokenIssuer.java
@@ -37,12 +37,18 @@ public class LoginTokenIssuer {
 
         String accessToken = jwtService.createAccessToken(member.getId(), member.getRole().name());
 
+        // 응답 프로필 출처 = Member 기준(통합 프로필, 방식 B). 온보딩 전(REGISTERING)에는 Member 프로필이 비어 있으므로 provider 데이터로 폴백한다.
+        boolean registering = member.isRegistering();
+        String nickname = registering ? info.nickname() : member.getName();
+        String email = registering ? info.email() : member.getEmail();
+        String profileImageUrl = registering ? info.profileImageUrl() : member.getProfileImageUrl();
+
         if (clientType == ClientType.APP) {
             String refreshToken = refreshTokenService.issueRaw(member.getId(), resolution.deviceId());
-            LoginResDTO loginRes = LoginResDTO.ofApp(info.nickname(), info.email(), accessToken, refreshToken, info.profileImageUrl());
+            LoginResDTO loginRes = LoginResDTO.ofApp(nickname, email, accessToken, refreshToken, profileImageUrl);
             return LoginPayloadResDTO.app(loginRes);
         }
-        LoginResDTO loginRes = LoginResDTO.of(info.nickname(), info.email(), accessToken, info.profileImageUrl());
+        LoginResDTO loginRes = LoginResDTO.of(nickname, email, accessToken, profileImageUrl);
         ResponseCookie rtCookie = refreshTokenService.issue(member.getId(), resolution.deviceId());
         return LoginPayloadResDTO.web(loginRes, rtCookie, resolution.newCookie());
     }

--- a/src/main/java/com/tavemakers/surf/domain/member/entity/Member.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/entity/Member.java
@@ -174,13 +174,11 @@ public class Member extends BaseEntity {
     /**
      * OAuth provider 정보로 REGISTERING 상태의 회원을 생성한다 (D1, D5).
      * Kakao 는 닉네임이 일반적으로 채워져 있고, Apple 은 첫 로그인 시 nickname/profileImageUrl 이 null 일 수 있다.
+     * provider 이메일 유무에 의존하지 않는다 — provider 이메일은 SocialAccount.providerEmail 에 저장되며 없을 수 있다(Apple 미제공 등).
      */
     public static Member createRegisteringFromOAuth(Provider provider, OAuthUserInfoDTO info) {
         if (provider == null) {
             throw new IllegalStateException("provider 는 필수입니다.");
-        }
-        if (info.email() == null || info.email().isBlank()) {
-            throw new IllegalStateException(provider + " 계정의 이메일 권한이 필요합니다.");
         }
         if (info.oauthId() == null || info.oauthId().isBlank()) {
             throw new IllegalStateException(provider + " 식별자(oauthId)가 비어 있습니다.");
@@ -196,12 +194,13 @@ public class Member extends BaseEntity {
             }
         }
 
+        // 통합 이메일(Member.email)은 온보딩 입력값으로만 채운다. REGISTERING 단계에서는 값 없음(null).
+        // provider 가 준 이메일은 SocialAccount.providerEmail 에만 저장된다.
         return Member.builder()
                 .provider(provider)
                 .providerId(info.oauthId())
                 .kakaoId(legacyKakaoId)
                 .name(info.nickname())
-                .email(info.email())
                 .phoneNumberPublic(false)
                 .profileImageUrl(info.profileImageUrl())
                 .status(MemberStatus.REGISTERING)

--- a/src/main/java/com/tavemakers/surf/domain/member/entity/Member.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/entity/Member.java
@@ -23,6 +23,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.function.Consumer;
 
 import lombok.extern.slf4j.Slf4j;
@@ -74,12 +75,15 @@ public class Member extends BaseEntity {
 
     private String graduateSchool;
 
-    @Column(nullable = false, unique = true) // 이메일은 고유해야 함
+    /** 온보딩에서 사용자가 입력한 통합 이메일. 소셜이 준 이메일(SocialAccount.providerEmail)과 구분된다. REGISTERING은 값 없음. */
+    @Column(unique = true)
     private String email;
 
     @Embedded
     private Password password;
 
+    /** 통합 판단 기준 전화번호. REGISTERING은 값 없음. */
+    @Column(unique = true)
     private String phoneNumber;
 
     @Column(length = 256)
@@ -93,6 +97,11 @@ public class Member extends BaseEntity {
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     @BatchSize(size = 20)
     private List<Track> tracks = new ArrayList<>();
+
+    /** 회원에 연결된 소셜 로그인 수단 목록 (provider별 최대 1개). */
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    @BatchSize(size = 20)
+    private List<SocialAccount> socialAccounts = new ArrayList<>();
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
@@ -261,6 +270,28 @@ public class Member extends BaseEntity {
 
         Track track = new Track(generation, part);
         track.setMember(this); // 여기서만 add 수행
+    }
+
+    /** 소셜 계정을 연결한다. 동일 provider 계정이 이미 있으면 거부한다 (1 provider = 1 account). */
+    public void addSocialAccount(SocialAccount socialAccount) {
+        if (hasProvider(socialAccount.getProvider())) {
+            throw new IllegalStateException(
+                    "이미 연결된 provider 입니다: " + socialAccount.getProvider());
+        }
+        socialAccount.setMember(this); // setMember 에서만 양방향 add 수행
+    }
+
+    /** 해당 provider 로그인 수단을 이미 보유하고 있는지 여부. */
+    public boolean hasProvider(Provider provider) {
+        return socialAccounts.stream()
+                .anyMatch(sa -> sa.getProvider() == provider);
+    }
+
+    /** 해당 provider 의 소셜 계정을 조회한다. */
+    public Optional<SocialAccount> findSocialAccount(Provider provider) {
+        return socialAccounts.stream()
+                .filter(sa -> sa.getProvider() == provider)
+                .findFirst();
     }
 
     /** 댓글의 멘션 기능에서 회원들의 기수별로 정렬하기 위한 메서드 */

--- a/src/main/java/com/tavemakers/surf/domain/member/entity/SocialAccount.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/entity/SocialAccount.java
@@ -1,0 +1,142 @@
+package com.tavemakers.surf.domain.member.entity;
+
+import com.tavemakers.surf.domain.auth.common.dto.OAuthUserInfoDTO;
+import com.tavemakers.surf.domain.auth.common.enums.Provider;
+import com.tavemakers.surf.domain.member.exception.InvalidMemberInfoException;
+import com.tavemakers.surf.global.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * provider별 로그인 수단 단위 엔티티 — {@code Member} 와 N : 1 관계.
+ * 한 회원이 Kakao/Apple 등 여러 소셜 계정을 연결할 수 있으며, 어느 쪽으로 로그인해도 같은 회원으로 인증된다.
+ */
+@Entity
+@Table(
+        name = "social_account",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_social_provider_provider_id",
+                        columnNames = {"provider", "provider_id"}
+                )
+        },
+        indexes = {
+                @Index(name = "idx_social_member_id", columnList = "member_id"),
+                @Index(name = "idx_social_provider", columnList = "provider")
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SocialAccount extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "social_account_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 16)
+    private Provider provider;
+
+    @Column(name = "provider_id", nullable = false, length = 64)
+    private String providerId;
+
+    /**
+     * 소셜 로그인이 전달한 이메일. 회원 식별에는 사용하지 않는다.
+     * 로그인 시점 provider 값으로만 채우며, 레거시 이관 행은 null 로 남을 수 있다(카카오 원본 이메일 백필하지 않음).
+     */
+    @Column(name = "provider_email")
+    private String providerEmail;
+
+    /** Apple 계정 탈퇴(revoke) 시 사용. 로그인 코드 교환 후 저장, 탈퇴 시 null 처리. */
+    @Column(name = "apple_refresh_token", length = 1024)
+    private String appleRefreshToken;
+
+    /** 카카오 unlink용 레거시 식별자. */
+    @Column(name = "kakao_id")
+    private Long kakaoId;
+
+    @Builder
+    private SocialAccount(Provider provider,
+                          String providerId,
+                          String providerEmail,
+                          String appleRefreshToken,
+                          Long kakaoId) {
+        this.provider = provider;
+        this.providerId = providerId;
+        this.providerEmail = providerEmail;
+        this.appleRefreshToken = appleRefreshToken;
+        this.kakaoId = kakaoId;
+    }
+
+    /**
+     * OAuth provider 정보로 SocialAccount 를 생성한다.
+     * providerEmail 은 소셜이 준 이메일을 그대로 저장하며, 회원 식별에는 사용하지 않는다.
+     */
+    public static SocialAccount createFromOAuth(Provider provider, OAuthUserInfoDTO info) {
+        if (provider == null) {
+            throw new IllegalStateException("provider 는 필수입니다.");
+        }
+        if (info.oauthId() == null || info.oauthId().isBlank()) {
+            throw new IllegalStateException(provider + " 식별자(oauthId)가 비어 있습니다.");
+        }
+
+        Long legacyKakaoId = null;
+        if (provider == Provider.KAKAO) {
+            try {
+                legacyKakaoId = Long.parseLong(info.oauthId());
+            } catch (NumberFormatException e) {
+                throw new InvalidMemberInfoException(
+                        "Provider.KAKAO oauthId가 유효한 숫자 형식이 아닙니다: " + info.oauthId());
+            }
+        }
+
+        return SocialAccount.builder()
+                .provider(provider)
+                .providerId(info.oauthId())
+                .providerEmail(info.email())
+                .kakaoId(legacyKakaoId)
+                .build();
+    }
+
+    /**
+     * 소속 회원을 설정하고 양방향 연관관계 일관성을 유지한다.
+     * 통합(연동) 시 기존 회원으로 재연결하는 용도로도 사용한다.
+     */
+    public void setMember(Member member) {
+        if (member == null) {
+            throw new IllegalArgumentException("member는 null일 수 없습니다.");
+        }
+
+        if (this.member == member) return;
+
+        // 기존 관계 끊기
+        if (this.member != null) {
+            this.member.getSocialAccounts().remove(this);
+        }
+
+        this.member = member;
+
+        // 양방향 일관성 유지
+        if (!member.getSocialAccounts().contains(this)) {
+            member.getSocialAccounts().add(this);
+        }
+    }
+
+    /** 로그인 시점에 provider 가 전달한 이메일로 갱신한다(레거시 백필 대체). */
+    public void updateProviderEmail(String providerEmail) {
+        this.providerEmail = providerEmail;
+    }
+
+    /** Apple refresh_token 갱신 — 로그인 코드 교환 시 호출. */
+    public void updateAppleRefreshToken(String refreshToken) {
+        this.appleRefreshToken = refreshToken;
+    }
+}

--- a/src/main/java/com/tavemakers/surf/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/repository/MemberRepository.java
@@ -1,6 +1,5 @@
 package com.tavemakers.surf.domain.member.repository;
 
-import com.tavemakers.surf.domain.auth.common.enums.Provider;
 import com.tavemakers.surf.domain.member.entity.Member;
 import com.tavemakers.surf.domain.member.entity.enums.MemberStatus;
 import org.springframework.data.domain.Pageable;
@@ -28,13 +27,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     List<Member> findByActivityStatusAndNameAndStatusNot(Boolean activityStatus, String name, MemberStatus status);
 
     Optional<Member> findByEmailAndStatus(String email, MemberStatus status);
-  
-    /** provider + providerId 복합 식별자로 회원 조회 (D1). */
-    Optional<Member> findByProviderAndProviderId(Provider provider, String providerId);
-
-    /** @deprecated provider/providerId 모델로 마이그레이션됨 (D1). 호출자 일소 후 후속 PR(Step 7)에서 제거. */
-    @Deprecated
-    Optional<Member> findByKakaoId(Long kakaoId);
 
     // 댓글(comment)에서 멘션할 회원을 검색할 때 사용
     @Query("""

--- a/src/main/java/com/tavemakers/surf/domain/member/repository/SocialAccountRepository.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/repository/SocialAccountRepository.java
@@ -1,0 +1,15 @@
+package com.tavemakers.surf.domain.member.repository;
+
+import com.tavemakers.surf.domain.auth.common.enums.Provider;
+import com.tavemakers.surf.domain.member.entity.SocialAccount;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface SocialAccountRepository extends JpaRepository<SocialAccount, Long> {
+
+    /** provider + providerId 복합 식별자로 소셜 계정을 조회한다 (로그인 upsert 진입점). */
+    Optional<SocialAccount> findByProviderAndProviderId(Provider provider, String providerId);
+}

--- a/src/main/java/com/tavemakers/surf/domain/member/service/MemberUpsertService.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/service/MemberUpsertService.java
@@ -2,46 +2,69 @@ package com.tavemakers.surf.domain.member.service;
 
 import com.tavemakers.surf.domain.auth.common.dto.OAuthUserInfoDTO;
 import com.tavemakers.surf.domain.auth.common.enums.Provider;
-import com.tavemakers.surf.domain.auth.common.exception.EmailConflictException;
 import com.tavemakers.surf.domain.member.entity.Member;
+import com.tavemakers.surf.domain.member.entity.SocialAccount;
 import com.tavemakers.surf.domain.member.repository.MemberRepository;
+import com.tavemakers.surf.domain.member.repository.SocialAccountRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
 public class MemberUpsertService {
 
     private final MemberRepository memberRepository;
+    private final SocialAccountRepository socialAccountRepository;
     private final MemberBlacklistGetService memberBlacklistGetService;
 
     /**
-     * OAuth provider 정보로 회원 생성 또는 기존 회원 반환 (D1).
-     * 동일 이메일이 다른 provider 로 이미 가입돼 있으면 EmailConflictException 발생 (D6).
+     * 소셜 로그인 upsert — SocialAccount 기준으로 조회하고, 없으면 REGISTERING 회원 + SocialAccount 를 생성한다.
+     * <p>로그인 단계에서는 email/phone 기반 자동 통합을 하지 않는다(명시적 연동만 허용, EmailConflictException 폐기).
+     * 반환 엔티티는 현재 트랜잭션에서 managed 상태이므로 호출자의 후속 변경(refresh_token 등)이 커밋에 함께 반영된다.
      */
     @Transactional
     public Member upsertRegisteringFromOAuth(Provider provider, OAuthUserInfoDTO info) {
-        return memberRepository.findByProviderAndProviderId(provider, info.oauthId())
-                .orElseGet(() -> createWithEmailConflictGuard(provider, info));
+        return findExistingMember(provider, info)
+                .orElseGet(() -> createNewSocialMember(provider, info));
     }
 
-    private Member createWithEmailConflictGuard(Provider provider, OAuthUserInfoDTO info) {
+    /** SocialAccount 로 기존 회원을 조회하고, 있으면 provider 가 준 이메일로 providerEmail 을 갱신한다. */
+    private Optional<Member> findExistingMember(Provider provider, OAuthUserInfoDTO info) {
+        return socialAccountRepository.findByProviderAndProviderId(provider, info.oauthId())
+                .map(socialAccount -> {
+                    refreshProviderEmail(socialAccount, info.email());
+                    return socialAccount.getMember();
+                });
+    }
+
+    /**
+     * 신규 소셜 계정 로그인 — REGISTERING 회원 + SocialAccount 를 현재 트랜잭션에서 생성/연결한다.
+     * <p>동시 첫 로그인 경합 시 한쪽은 UNIQUE 제약 위반으로 트랜잭션이 롤백되며(재시도 시 정상 진입), 오염된 세션에서 복구를 시도하지 않는다.
+     */
+    private Member createNewSocialMember(Provider provider, OAuthUserInfoDTO info) {
         Long kakaoId = provider == Provider.KAKAO ? Long.parseLong(info.oauthId()) : null;
         memberBlacklistGetService.validateNotBlacklisted(kakaoId, info.email(), null);
 
-        memberRepository.findByEmail(info.email()).ifPresent(existing -> {
-            if (existing.getProvider() != provider) {
-                throw new EmailConflictException(existing.getProvider());
-            }
-        });
-        Member toSave = Member.createRegisteringFromOAuth(provider, info);
-        try {
-            return memberRepository.saveAndFlush(toSave);
-        } catch (DataIntegrityViolationException e) {
-            return memberRepository.findByProviderAndProviderId(provider, info.oauthId())
-                    .orElseThrow(() -> e);
+        Member member = Member.createRegisteringFromOAuth(provider, info);
+        SocialAccount socialAccount = SocialAccount.createFromOAuth(provider, info);
+        member.addSocialAccount(socialAccount);
+
+        return memberRepository.save(member);
+    }
+
+    /**
+     * 재로그인 시 provider 가 준 이메일로 providerEmail 을 갱신한다(레거시 이관 행의 null 백필 대체, 설계 3.6).
+     * <p>Apple 은 최초 로그인 이후 이메일을 주지 않으므로 값이 있을 때만 갱신해 기존 값을 지우지 않는다.
+     */
+    private void refreshProviderEmail(SocialAccount socialAccount, String providerEmail) {
+        if (providerEmail == null || providerEmail.isBlank()) {
+            return;
+        }
+        if (!providerEmail.equals(socialAccount.getProviderEmail())) {
+            socialAccount.updateProviderEmail(providerEmail);
         }
     }
 }


### PR DESCRIPTION
## 재생성 안내

기존 #335 가 실수로 \`feat/#332/social-account-entity\` 브랜치에 머지되어, 해당 머지를 되돌리고(#333 브랜치를 Phase 1 상태로 복원) 이 PR 로 재생성했습니다. 내용은 #335 와 동일합니다.

## 병합 순서 (중요)

1) PR #333 (Phase 1) 병합 → social_account 테이블·엔티티 도입
2) docs/sql/phase1-social-account-migration.sql 실행 (전문: step 0~3, email NOT NULL 완화 포함)
3) 이 PR (Phase 2) 병합 → 로그인 경로를 social_account 기준으로 전환

- base 브랜치는 \`feat/#332/social-account-entity\` (Phase 1) 이라 diff 에는 Phase 2 변경만 보입니다. #333 이 dev 로 병합되면 GitHub 가 이 PR 의 base 를 자동으로 dev 로 재지정합니다.

## 변경점 (커밋 단위)

- \`0a5ff93\` 로그인 upsert 를 SocialAccount 기준으로 전환 (MemberUpsertService/MemberRepository/Member)
- \`66d823a\` 로그인 응답 프로필을 Member 통합 프로필 기준으로 전환 (LoginTokenIssuer)
- \`c7e6a27\` Apple refresh_token 을 SocialAccount 에 함께 저장 (AppleLoginUsecase)

resolves #334