### PR TITLE
[BUG] 인증 쿠키 속성 프로필명 분기 제거 — 배포 토폴로지 설정 기반 전환 (30분 자동 로그아웃 대응)

### DIFF
--- a/src/main/java/com/tavemakers/surf/application/auth/common/usecase/LoginTokenIssuer.java
+++ b/src/main/java/com/tavemakers/surf/application/auth/common/usecase/LoginTokenIssuer.java
@@ -76,13 +76,9 @@ public class LoginTokenIssuer {
             }
         }
         // WEB 첫 로그인 — UUID 생성 후 브라우저에 저장할 쿠키도 함께 반환
+        // refresh 쿠키와 동일한 토폴로지 속성 공유 — 크로스 사이트에서 deviceId가 매 로그인 재발급되는 것을 방지
         String newId = UUID.randomUUID().toString();
-        ResponseCookie newCookie = ResponseCookie.from(DEVICE_ID_COOKIE, newId)
-                .httpOnly(true)
-                .path("/")
-                .maxAge(Duration.ofDays(365))
-                .sameSite("Lax")
-                .build();
+        ResponseCookie newCookie = jwtService.buildAuthCookie(DEVICE_ID_COOKIE, newId, Duration.ofDays(365));
         return new DeviceResolution(newId, newCookie);
     }
 

--- a/src/main/java/com/tavemakers/surf/global/jwt/JwtService.java
+++ b/src/main/java/com/tavemakers/surf/global/jwt/JwtService.java
@@ -8,7 +8,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.core.env.Environment;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Service;
@@ -16,7 +15,6 @@ import org.springframework.stereotype.Service;
 import java.nio.charset.StandardCharsets;
 import java.security.Key;
 import java.time.Duration;
-import java.util.Arrays;
 import java.util.Date;
 import java.util.Optional;
 import java.util.UUID;
@@ -30,7 +28,6 @@ public class JwtService {
     private static final String BEARER_PREFIX = "Bearer ";
     private static final String REFRESH_COOKIE_NAME = "refreshToken";
     private static final String ROLE_PREFIX = "ROLE_";
-    private final Environment environment;
 
     @Value("${jwt.secret}")
     private String jwtSecret;
@@ -40,6 +37,17 @@ public class JwtService {
 
     @Value("${jwt.refresh.expiration}")
     private long refreshTokenExpireMs;
+
+    // 쿠키 속성은 프로필명이 아닌 배포 토폴로지(프론트↔API 도메인 관계) 기준으로 결정한다.
+    // 크로스 사이트 배포면 SameSite=None + Secure 필수, 같은 등록 도메인 공유 시에만 domain 지정.
+    @Value("${jwt.cookie.secure:true}")
+    private boolean cookieSecure;
+
+    @Value("${jwt.cookie.same-site:None}")
+    private String cookieSameSite;
+
+    @Value("${jwt.cookie.domain:}")
+    private String cookieDomain;
 
     private Key secretKey;
 
@@ -123,31 +131,26 @@ public class JwtService {
         }
     }
 
-    private boolean isDev() {
-        return Arrays.asList(environment.getActiveProfiles()).contains("dev");
-    }
+    /** 인증용 쿠키 공통 빌더 — refresh·deviceId 쿠키가 동일한 토폴로지 속성을 공유한다 */
+    public ResponseCookie buildAuthCookie(String name, String value, Duration maxAge) {
+        ResponseCookie.ResponseCookieBuilder builder =
+                ResponseCookie.from(name, value)
+                        .httpOnly(true)
+                        .path("/")
+                        .maxAge(maxAge)
+                        .secure(cookieSecure)
+                        .sameSite(cookieSameSite);
 
-    private boolean isTest() {
-        return Arrays.asList(environment.getActiveProfiles()).contains("test");
+        if (cookieDomain != null && !cookieDomain.isBlank()) {
+            builder.domain(cookieDomain);
+        }
+
+        return builder.build();
     }
 
     /** Refresh Token 쿠키 생성 */
     public ResponseCookie buildRefreshTokenCookie(String refreshToken) {
-        ResponseCookie.ResponseCookieBuilder builder =
-                ResponseCookie.from(REFRESH_COOKIE_NAME, refreshToken)
-                        .httpOnly(true)
-                        .path("/")
-                        .maxAge(Duration.ofMillis(refreshTokenExpireMs));
-
-        if (isDev()) {
-            builder.secure(true).sameSite("None").domain(".tavesurf.site");
-        } else if (isTest()) {
-            builder.secure(false).sameSite("Lax");
-        } else {
-            builder.secure(true).sameSite("Lax");
-        }
-
-        return builder.build();
+        return buildAuthCookie(REFRESH_COOKIE_NAME, refreshToken, Duration.ofMillis(refreshTokenExpireMs));
     }
 
     /** Refresh Token 쿠키 전송 */
@@ -190,21 +193,7 @@ public class JwtService {
 
     /** Refresh Token 쿠키 삭제 */
     public void clearRefreshTokenCookie(HttpServletResponse res) {
-        ResponseCookie.ResponseCookieBuilder builder =
-                ResponseCookie.from(REFRESH_COOKIE_NAME, "")
-                        .httpOnly(true)
-                        .path("/")
-                        .maxAge(Duration.ZERO);
-
-        if (isDev()) {
-            builder.secure(true).domain(".tavesurf.site").sameSite("None");
-        } else if (isTest()) {
-            builder.secure(false).sameSite("Lax");
-        } else {
-            builder.secure(true).sameSite("Lax");
-        }
-
-        ResponseCookie refreshCookie = builder.build();
+        ResponseCookie refreshCookie = buildAuthCookie(REFRESH_COOKIE_NAME, "", Duration.ZERO);
         res.addHeader("Set-Cookie", refreshCookie.toString());
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -63,6 +63,13 @@ jwt:
   refresh:
     expiration: ${JWT_REFRESH_EXPIRATION}
     header: RefreshToken
+  # 인증 쿠키 속성 — 프로필명이 아닌 배포 토폴로지 기준으로 환경변수로 결정 (기본값 = 운영 현행)
+  # 크로스 사이트(프론트↔API 도메인 상이) 배포: same-site=None + secure=true 필수
+  # domain 은 프론트·API가 같은 등록 도메인을 공유할 때만 지정, 빈 값이면 host-only
+  cookie:
+    secure: ${JWT_COOKIE_SECURE:true}
+    same-site: ${JWT_COOKIE_SAME_SITE:None}
+    domain: ${JWT_COOKIE_DOMAIN:.tavesurf.site}
 
 feedback:
   hash:

--- a/src/test/java/com/tavemakers/surf/domain/auth/common/service/RefreshTokenServiceTest.java
+++ b/src/test/java/com/tavemakers/surf/domain/auth/common/service/RefreshTokenServiceTest.java
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.core.env.Environment;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisCallback;
@@ -29,8 +28,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 @Testcontainers
 @DisplayName("RefreshTokenService")
@@ -62,14 +59,14 @@ class RefreshTokenServiceTest {
         redisTemplate.setValueSerializer(serializer);
         redisTemplate.afterPropertiesSet();
 
-        Environment env = mock(Environment.class);
-        when(env.getActiveProfiles()).thenReturn(new String[]{"test"});
-
-        jwtService = new JwtService(env);
+        jwtService = new JwtService();
         ReflectionTestUtils.setField(jwtService, "jwtSecret",
                 "testsecrettestsecrettestsecrettestsecrettestsecret");
         ReflectionTestUtils.setField(jwtService, "accessTokenExpireMs", 3600000L);
         ReflectionTestUtils.setField(jwtService, "refreshTokenExpireMs", 604800000L);
+        ReflectionTestUtils.setField(jwtService, "cookieSecure", false);
+        ReflectionTestUtils.setField(jwtService, "cookieSameSite", "Lax");
+        ReflectionTestUtils.setField(jwtService, "cookieDomain", "");
         jwtService.init();
 
         refreshTokenService = new RefreshTokenService(jwtService, redisTemplate);

--- a/src/test/java/com/tavemakers/surf/global/jwt/JwtServiceTest.java
+++ b/src/test/java/com/tavemakers/surf/global/jwt/JwtServiceTest.java
@@ -6,8 +6,10 @@ import io.jsonwebtoken.security.Keys;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.mock.env.MockEnvironment;
+import org.springframework.http.ResponseCookie;
 import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.Duration;
 
 import java.nio.charset.StandardCharsets;
 import java.security.Key;
@@ -24,10 +26,13 @@ class JwtServiceTest {
 
     @BeforeEach
     void setUp() {
-        jwtService = new JwtService(new MockEnvironment());
+        jwtService = new JwtService();
         ReflectionTestUtils.setField(jwtService, "jwtSecret", SECRET);
         ReflectionTestUtils.setField(jwtService, "accessTokenExpireMs", 3_600_000L);
         ReflectionTestUtils.setField(jwtService, "refreshTokenExpireMs", 3_600_000L);
+        ReflectionTestUtils.setField(jwtService, "cookieSecure", true);
+        ReflectionTestUtils.setField(jwtService, "cookieSameSite", "None");
+        ReflectionTestUtils.setField(jwtService, "cookieDomain", ".tavesurf.site");
         jwtService.init();
     }
 
@@ -53,6 +58,28 @@ class JwtServiceTest {
         String validToken = jwtService.createAccessToken(42L, "MEMBER");
 
         assertThat(jwtService.extractMemberId(validToken)).contains(42L);
+    }
+
+    @Test
+    @DisplayName("refresh 쿠키는 설정된 토폴로지 속성(Secure/SameSite/Domain)으로 발급된다")
+    void buildRefreshTokenCookie_appliesConfiguredAttributes() {
+        ResponseCookie cookie = jwtService.buildRefreshTokenCookie("refresh-token-value");
+
+        assertThat(cookie.isSecure()).isTrue();
+        assertThat(cookie.getSameSite()).isEqualTo("None");
+        assertThat(cookie.getDomain()).isEqualTo(".tavesurf.site");
+        assertThat(cookie.isHttpOnly()).isTrue();
+        assertThat(cookie.getPath()).isEqualTo("/");
+    }
+
+    @Test
+    @DisplayName("domain 설정이 비어 있으면 host-only 쿠키로 발급된다 (Domain 속성 없음)")
+    void buildAuthCookie_blankDomain_hostOnly() {
+        ReflectionTestUtils.setField(jwtService, "cookieDomain", "");
+
+        ResponseCookie cookie = jwtService.buildAuthCookie("anyCookie", "v", Duration.ofDays(1));
+
+        assertThat(cookie.getDomain()).isNull();
     }
 
     private String buildToken(String secret, Date expiration) {


### PR DESCRIPTION
## 📄 작업 내용 요약

문의(로그인 후 30분 뒤 자동 로그아웃)의 원인 분석 과정에서 확인된 **인증 쿠키 속성의 프로필명 하드코딩 결합**을 해소합니다.

### 배경 (원인 분석 결과)

- 운영은 `Dockerfile-dev`의 `-Dspring.profiles.active=dev`로 기동 → 현재는 `dev` 분기(`Secure; SameSite=None; Domain=.tavesurf.site`)로 정상 발급 중
- 그러나 프로필명이 바뀌거나 `prod` 프로필을 추가하는 순간 조용히 `SameSite=Lax`로 떨어져, 크로스 사이트 환경에서 refresh 쿠키가 전송되지 않아 **AT 만료 시점(30분)마다 전면 로그아웃**되는 구조
- `__surf_device_id` 쿠키는 항상 `Lax`·`Secure` 없음으로 발급되어 크로스 사이트 오리진에서 매 로그인 deviceId가 재발급되는 문제도 존재

### 변경 사항

| 파일 | 내용 |
|---|---|
| `JwtService` | `isDev()`/`isTest()` 프로필 분기 제거, `jwt.cookie.{secure,same-site,domain}` 설정 주입. 공통 빌더 `buildAuthCookie()` 신설 — 발급/삭제 쿠키 속성 중복 코드 제거 |
| `LoginTokenIssuer` | `__surf_device_id` 쿠키도 `buildAuthCookie()` 사용 — refresh 쿠키와 동일 토폴로지 속성 공유 |
| `application.yml` | `JWT_COOKIE_SECURE` / `JWT_COOKIE_SAME_SITE` / `JWT_COOKIE_DOMAIN` 환경변수 키 추가 |
| 테스트 | `JwtServiceTest` 쿠키 속성 회귀 테스트 2건 추가, `Environment` 생성자 의존 제거 반영 |

### 배포 영향

- **기본값 = 운영 현행 동작**(`secure=true, same-site=None, domain=.tavesurf.site`) → 운영 `.env`에 새 환경변수를 추가하지 않아도 동작 변화 없음
- 로컬 개발자는 `.env`에 `JWT_COOKIE_SAME_SITE=Lax`, `JWT_COOKIE_DOMAIN=`(빈 값) 추가 필요 (기본값 도메인이 localhost에서 거부됨)
- 전체 테스트 276건 그린

### 남은 후속 (이슈 체크리스트 유지)

30분 튕김의 최종 원인 확정은 운영 접근이 필요합니다 — 운영 로그 `[RTR]` 패턴, 고객 접속 오리진(cross-site 서드파티 쿠키 차단 여부), Redis 설정, 프론트 인터셉터 점검. 이슈 #344 코멘트에 정리되어 있습니다.

## 📎 Issue 번호
<!-- closed #번호 -->
#344

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **개선 사항**
  - 인증 및 디바이스 쿠키의 보안 속성(Secure, SameSite, Domain)이 일관되게 적용됩니다.
  - 배포 환경에 따라 쿠키 보안 설정을 구성할 수 있습니다.
  - 크로스 사이트 환경에서 로그인 및 인증 쿠키가 안정적으로 동작하도록 개선되었습니다.
  - 도메인을 비워 두면 현재 호스트에서만 유효한 쿠키로 설정할 수 있습니다.
  - 로그아웃 또는 토큰 만료 시 인증 쿠키가 보다 일관되게 삭제됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->