### PR TITLE
[Feat] API 성능 계측(Actuator·Server-Timing) 도입 + 알림 조회 최적화

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md
 
-이 파일은 Codex가 이 프로젝트에서 작업할 때 참조하는 설정입니다.
+이 파일은 Codex 등 AI 에이전트가 이 프로젝트에서 작업할 때 참조하는 설정입니다.
 
 ## Role
 
@@ -10,64 +10,103 @@
 
 - **서비스명**: SURF (Tave Makers 커뮤니티 플랫폼)
 - **목적**: 동아리/그룹 회원들의 커뮤니티 활동 및 게이미피케이션 플랫폼
-- **Stack**: Java 17, Spring Boot 3.x, MySQL (AWS RDS), Redis
+- **Stack**: Java 17, Spring Boot 3.x, MySQL, Redis
 
 ## Architecture
 
-**도메인 중심 계층형 아키텍처**
+**계층 우선(layer-first) 클린 아키텍처** — 2026-07 전면 리팩토링 완료 (설계 근거: `docs/refactoring-plan.md`)
 
 ```
 com.tavemakers.surf
-├── domain/{domain}/
-│   ├── controller/   # API 엔드포인트
-│   ├── service/      # 비즈니스 로직 (CRUD별 분리)
-│   ├── usecase/      # 복합 비즈니스 로직 (선택)
-│   ├── repository/, entity/, dto/{request,response}/, exception/
-│   └── event/, mapper/, constants/, facade/, validator/, scheduler/ (선택)
+├── presentation/{domain}/     # controller/, dto/{request,response}/
+├── application/{domain}/      # usecase/, query/, event/, scheduler/, task/
+├── domain/{domain}/           # entity/, repository/, service/, exception/, event/
+├── infrastructure/{domain}/   # 기술 구체 (QueryDSL·Jdbc 리포지토리, 외부 API 클라이언트, FCM)
 └── global/
     ├── common/  # advice/, aop/, encoder/, entity/, exception/, loader/, response/, s3/
-    ├── config/  # Security, Redis, QueryDSL, S3, Firebase, Swagger
+    ├── config/  # Security, Redis, QueryDSL, S3, Firebase, Swagger, Scheduler, Async
     ├── jwt/     # JWT 인증 필터 및 서비스
-    ├── logging/ # 이벤트 기반 로깅
+    ├── logging/ # 이벤트 기반 로깅, Server-Timing 헤더
     └── util/    # EmailSender, SecurityUtils
 ```
 
+- `auth`는 도메인 하위를 provider로 슬라이스: `{apple, kakao, common}`
+
+### 계층 책임 (B안)
+
+| 계층 | 책임 | 금지 |
+|------|------|------|
+| **presentation** | API 엔드포인트, Req/Res DTO | repository·infrastructure 직접 의존 |
+| **application** | usecase·query — **`@Transactional` 소유**, 도메인 서비스 조합, **엔티티→DTO 매핑** | — |
+| **domain** | 엔티티, 도메인 서비스(원시값 입력·**엔티티 반환·DTO 무지**), Spring Data 리포지토리 인터페이스 | infrastructure 의존(R8), DTO 참조 |
+| **infrastructure** | 손으로 쓴 기술 구체 — QueryDSL/JdbcTemplate 리포지토리, 외부 API 클라이언트 | — |
+
+### 레포지토리 배치 절충안
+
+- **Spring Data JPA 인터페이스** (메서드 시그니처만) → `domain/{domain}/repository/` — 사실상 포트 역할
+- **손으로 쓴 구체 클래스** (QueryDSL, JdbcTemplate 등) → `infrastructure/{domain}/` — 예: `MemberSearchRepository`, `PostJdbcRepository`
+- 구현체 1개짜리 인터페이스 포트는 만들지 않는다 (불필요한 추상화 금지)
+
+### ArchUnit 의존성 규칙 (자동 검증)
+
+`src/test/java/.../architecture/CleanArchitectureRulesTest.java` — 전체 테스트에 포함되어 위반 시 빌드 실패.
+
+| 규칙 | 내용 |
+|------|------|
+| R1a~c | controller는 repository·infrastructure 직접 의존 금지, usecase/query만 호출 |
+| R2 | 타 도메인의 비(非)Get 서비스 호출 금지 |
+| R3 | 타 도메인 repository 직접 참조 금지 |
+| R4 | `@Transactional`은 application 계층(usecase/query)에만 |
+| R5 | 트랜잭션 안에서 외부 API 호출 금지 |
+| R6 | 비동기 부수효과 리스너는 `@TransactionalEventListener(AFTER_COMMIT)` 사용 |
+| R8 | domain 계층은 infrastructure 의존 금지 (freeze 없는 즉시 실패) |
+
+일부 규칙은 `FreezingArchRule`로 기존 위반을 동결(`src/test/resources/archunit-store/`). **새 위반은 실패**하며, 부채를 청산했으면 store 파일을 삭제 후 arch 테스트를 1회 돌려 재동결한다.
+
 ## Core Domains
 
-| 도메인 | 설명 | 특이 구조 |
-|--------|------|-----------|
-| `member` | 회원 가입/프로필/탈퇴 | `usecase/`, `validator/`, `util/` |
-| `post` | 게시글 CRUD/좋아요/검색 | controller·service 하위 `like/post/search/` 분리, `image/support/`, `mapper/`, `scheduler/`, `event/` |
-| `comment` | 댓글/대댓글/좋아요 | `event/` |
+| 도메인 | 설명 | 비고 |
+|--------|------|------|
+| `member` | 회원 가입/프로필/탈퇴 | 탈퇴 3종: withdraw/expel=소프트(익명화+소셜계정 삭제), dismiss=하드 |
+| `auth` | 소셜 로그인 (Kakao/Apple) + 토큰 | provider 슬라이스, RTR(refresh 회전) |
+| `post` | 게시글 CRUD/좋아요/검색 | controller·dto 하위 `like/post/search/` 분리, 조회수는 `PostJdbcRepository` 배치 반영 |
+| `comment` | 댓글/대댓글/좋아요 | 연속 중복 등록 방지(5초 윈도) |
 | `board` | 게시판/카테고리 관리 | |
 | `schedule` | 일정 관리 (캘린더) | |
 | `scrap` | 게시글 스크랩 | |
-| `letter` | 쪽지 | `facade/`, `event/` |
-| `score` | 활동 점수 (게이미피케이션) | `usecase/`, `utils/` |
-| `badge` | 배지 시스템 | `usecase/` |
-| `notification` | FCM 푸시 알림 | `event/` |
+| `letter` | 쪽지 | |
+| `score` | 활동 점수 (게이미피케이션) | |
+| `badge` | 배지 시스템 | |
+| `notification` | FCM 푸시 알림 | 목록 조회는 Slice 페이지네이션, `member_id` 인덱스 |
 | `home` | 홈 화면 배너/콘텐츠 | |
-| `login` | 카카오 OAuth2 로그인 | `auth/`, `kakao/` |
-| `activity` | 활동 기록 관리 | controller·service·dto 하위 `activeGeneration/`, `activityRecord/` 분리, `usecase/`, `mapper/`, `constants/` |
+| `activity` | 활동 기록 관리 | dto 하위 `activeGeneration/`, `activityRecord/` 분리 |
 | `feedback` | 사용자 피드백 | |
-| `reservation` | 예약 관리 | `usecase/`, `task/` |
+| `reservation` | 게시글 예약 발행 | presentation 없음 (post가 트리거, `task/`로 실행) |
 | `team` | 팀/그룹 관리 | |
 
 ## Authentication
 
-- **방식**: JWT + OAuth2 (Kakao) / Access + Refresh Token / Redis 저장
-- **관련 코드**: `global/jwt/`, `domain/login/kakao/`
+- **방식**: JWT + OAuth2 (Kakao, Apple) / Access + Refresh Token
+- **RTR**: refresh 회전 — Redis Lua CAS로 단일 사용 보장, grace key 멱등 처리, 재사용 탐지 시 전 세션 폐기
+- **로그인 식별**: `social_account(provider, provider_id)` 기준. 탈퇴 시 소셜 계정 연결도 삭제(재가입 허용), 퇴출자는 블랙리스트 차단
+- **관련 코드**: `global/jwt/`, `domain/auth/`, `application/auth/`
 
 ## External Services
 
 | 서비스 | 용도 |
 |--------|------|
 | AWS S3 | 이미지/파일 업로드 |
-| AWS RDS | MySQL DB |
-| Redis | 토큰 관리, 캐싱 |
+| MySQL (RDS) | DB |
+| Redis | refresh 토큰(RTR), 조회수 캐싱 |
 | Firebase FCM | 푸시 알림 |
-| Kakao OAuth | 소셜 로그인 |
+| Kakao / Apple OAuth | 소셜 로그인 |
 | JavaMail | 이메일 전송 |
+
+## Observability
+
+- **Actuator**: `/actuator/metrics/http.server.requests` — 엔드포인트별 응답시간 (관리자 역할 전용, `/actuator/health`만 무토큰 허용)
+- **Server-Timing**: 모든 REST 응답에 `Server-Timing: app;dur=<ms>` 헤더 (`global/logging/ServerTimingResponseAdvice`)
+- **이벤트 로깅**: `LogEventEmitter`로 요청 컨텍스트에 적재 → `WebLoggingFilter`가 flush → 분석 서버 전송(옵션)
 
 ## Tech Stack
 
@@ -80,6 +119,7 @@ com.tavemakers.surf
 
 ```bash
 ./gradlew build / bootRun / test
+./gradlew test --tests "*CleanArchitectureRulesTest"   # 아키텍처 규칙만
 ```
 
 ---
@@ -90,8 +130,9 @@ com.tavemakers.surf
 
 | 구분 | 패턴 | 예시 |
 |------|------|------|
-| Service | `{Domain}{Action}Service` | `PostCreateService` |
+| 도메인 Service | `{Domain}{Action}Service` | `PostCreateService` |
 | Usecase | `{Domain}Usecase` | `PostDeleteUsecase` |
+| Query 서비스 | `{Domain}GetService` | `MemberGetService` |
 | Controller | `{Domain}{Action}Controller` | `PostGetController` |
 | DTO (Request) | `{Action}ReqDTO` | `PostCreateReqDTO` |
 | DTO (Response) | `{Action}ResDTO` | `PostDetailResDTO` |
@@ -103,20 +144,21 @@ com.tavemakers.surf
 ### 서비스 계층 규칙
 
 ```
-Controller → Usecase → Service → Repository
-                 ↓
-            타 도메인 GetService (조회만 허용)
+Controller → Usecase/Query(@Transactional, DTO 매핑) → 도메인 Service(엔티티 반환) → Repository
+                      ↓
+              타 도메인 GetService (조회만 허용)
 ```
 
-- 타 도메인 Repository 직접 호출 ❌ → GetService 사용 ✅
-- 알림 발송: Service 직접 호출 ❌ → Event 발행 ✅
-- `@Transactional`: Usecase에서 관리
+- 타 도메인 Repository 직접 호출 ❌ → GetService 사용 ✅ (R2·R3)
+- 알림 발송: Service 직접 호출 ❌ → Event 발행 ✅ (R6: AFTER_COMMIT 리스너)
+- `@Transactional`: application 계층에서만 (R4)
+- 도메인 서비스는 DTO를 모른다 — 매핑은 usecase/query에서
 
 ### 주석 규칙
 
 ```java
 /** 한줄 설명 (한글, Javadoc 형식) */
-public void createPost(PostCreateReqDTO dto) { ... }
+public void createPost(...) { ... }
 ```
 
 ### DTO 규칙
@@ -140,15 +182,16 @@ public record PostDetailResDTO(Long id, String title) {
 | `/v1/manager/` | 매니저 |
 | `/login/` | 인증 |
 | `/auth/` | 토큰 재발급 |
+| `/actuator/` | 메트릭·헬스체크 (health 외 관리자 전용) |
 
 ---
 
 ## Design Patterns
 
-| 패턴 | 설명 | 사용 도메인 |
-|------|------|-------------|
-| **Usecase** | 복합 비즈니스 로직 조합, `@Transactional` 관리 | member, post, score, badge, activity, reservation |
-| **Event** | 도메인 간 느슨한 결합 (`@Async @EventListener`) | comment, letter, notification, post |
-| **Facade** | 복합 도메인 로직 단순화 (`Controller → Facade → Service`) | letter |
+| 패턴 | 설명 | 위치 |
+|------|------|------|
+| **Usecase** | 도메인 서비스 조합, `@Transactional` 소유, DTO 매핑 | `application/{domain}/usecase/` |
+| **Query** | 읽기 전용 조회(read-model 조립 포함) | `application/{domain}/query/` |
+| **Event** | 도메인 간 느슨한 결합 (`@Async` + `@TransactionalEventListener(AFTER_COMMIT)`) | 발행: domain, 리스너: `application/{domain}/event/` |
 | **Mapper** | Entity ↔ DTO 변환 분리 | post, activity |
-| **Scheduler/Task** | 주기적 작업 처리 | post, reservation |
+| **Scheduler/Task** | 주기적 작업 (조회수 배치 반영, 예약 발행) | `application/post/scheduler/`, `application/reservation/task/` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,64 +10,103 @@
 
 - **서비스명**: SURF (Tave Makers 커뮤니티 플랫폼)
 - **목적**: 동아리/그룹 회원들의 커뮤니티 활동 및 게이미피케이션 플랫폼
-- **Stack**: Java 17, Spring Boot 3.x, MySQL (AWS RDS), Redis
+- **Stack**: Java 17, Spring Boot 3.x, MySQL, Redis
 
 ## Architecture
 
-**도메인 중심 계층형 아키텍처**
+**계층 우선(layer-first) 클린 아키텍처** — 2026-07 전면 리팩토링 완료 (설계 근거: `docs/refactoring-plan.md`)
 
 ```
 com.tavemakers.surf
-├── domain/{domain}/
-│   ├── controller/   # API 엔드포인트
-│   ├── service/      # 비즈니스 로직 (CRUD별 분리)
-│   ├── usecase/      # 복합 비즈니스 로직 (선택)
-│   ├── repository/, entity/, dto/{request,response}/, exception/
-│   └── event/, mapper/, constants/, facade/, validator/, scheduler/ (선택)
+├── presentation/{domain}/     # controller/, dto/{request,response}/
+├── application/{domain}/      # usecase/, query/, event/, scheduler/, task/
+├── domain/{domain}/           # entity/, repository/, service/, exception/, event/
+├── infrastructure/{domain}/   # 기술 구체 (QueryDSL·Jdbc 리포지토리, 외부 API 클라이언트, FCM)
 └── global/
     ├── common/  # advice/, aop/, encoder/, entity/, exception/, loader/, response/, s3/
-    ├── config/  # Security, Redis, QueryDSL, S3, Firebase, Swagger
+    ├── config/  # Security, Redis, QueryDSL, S3, Firebase, Swagger, Scheduler, Async
     ├── jwt/     # JWT 인증 필터 및 서비스
-    ├── logging/ # 이벤트 기반 로깅
+    ├── logging/ # 이벤트 기반 로깅, Server-Timing 헤더
     └── util/    # EmailSender, SecurityUtils
 ```
 
+- `auth`는 도메인 하위를 provider로 슬라이스: `{apple, kakao, common}`
+
+### 계층 책임 (B안)
+
+| 계층 | 책임 | 금지 |
+|------|------|------|
+| **presentation** | API 엔드포인트, Req/Res DTO | repository·infrastructure 직접 의존 |
+| **application** | usecase·query — **`@Transactional` 소유**, 도메인 서비스 조합, **엔티티→DTO 매핑** | — |
+| **domain** | 엔티티, 도메인 서비스(원시값 입력·**엔티티 반환·DTO 무지**), Spring Data 리포지토리 인터페이스 | infrastructure 의존(R8), DTO 참조 |
+| **infrastructure** | 손으로 쓴 기술 구체 — QueryDSL/JdbcTemplate 리포지토리, 외부 API 클라이언트 | — |
+
+### 레포지토리 배치 절충안
+
+- **Spring Data JPA 인터페이스** (메서드 시그니처만) → `domain/{domain}/repository/` — 사실상 포트 역할
+- **손으로 쓴 구체 클래스** (QueryDSL, JdbcTemplate 등) → `infrastructure/{domain}/` — 예: `MemberSearchRepository`, `PostJdbcRepository`
+- 구현체 1개짜리 인터페이스 포트는 만들지 않는다 (불필요한 추상화 금지)
+
+### ArchUnit 의존성 규칙 (자동 검증)
+
+`src/test/java/.../architecture/CleanArchitectureRulesTest.java` — 전체 테스트에 포함되어 위반 시 빌드 실패.
+
+| 규칙 | 내용 |
+|------|------|
+| R1a~c | controller는 repository·infrastructure 직접 의존 금지, usecase/query만 호출 |
+| R2 | 타 도메인의 비(非)Get 서비스 호출 금지 |
+| R3 | 타 도메인 repository 직접 참조 금지 |
+| R4 | `@Transactional`은 application 계층(usecase/query)에만 |
+| R5 | 트랜잭션 안에서 외부 API 호출 금지 |
+| R6 | 비동기 부수효과 리스너는 `@TransactionalEventListener(AFTER_COMMIT)` 사용 |
+| R8 | domain 계층은 infrastructure 의존 금지 (freeze 없는 즉시 실패) |
+
+일부 규칙은 `FreezingArchRule`로 기존 위반을 동결(`src/test/resources/archunit-store/`). **새 위반은 실패**하며, 부채를 청산했으면 store 파일을 삭제 후 arch 테스트를 1회 돌려 재동결한다.
+
 ## Core Domains
 
-| 도메인 | 설명 | 특이 구조 |
-|--------|------|-----------|
-| `member` | 회원 가입/프로필/탈퇴 | `usecase/`, `validator/`, `util/` |
-| `post` | 게시글 CRUD/좋아요/검색 | controller·service 하위 `like/post/search/` 분리, `image/support/`, `mapper/`, `scheduler/`, `event/` |
-| `comment` | 댓글/대댓글/좋아요 | `event/` |
+| 도메인 | 설명 | 비고 |
+|--------|------|------|
+| `member` | 회원 가입/프로필/탈퇴 | 탈퇴 3종: withdraw/expel=소프트(익명화+소셜계정 삭제), dismiss=하드 |
+| `auth` | 소셜 로그인 (Kakao/Apple) + 토큰 | provider 슬라이스, RTR(refresh 회전) |
+| `post` | 게시글 CRUD/좋아요/검색 | controller·dto 하위 `like/post/search/` 분리, 조회수는 `PostJdbcRepository` 배치 반영 |
+| `comment` | 댓글/대댓글/좋아요 | 연속 중복 등록 방지(5초 윈도) |
 | `board` | 게시판/카테고리 관리 | |
 | `schedule` | 일정 관리 (캘린더) | |
 | `scrap` | 게시글 스크랩 | |
-| `letter` | 쪽지 | `facade/`, `event/` |
-| `score` | 활동 점수 (게이미피케이션) | `usecase/`, `utils/` |
-| `badge` | 배지 시스템 | `usecase/` |
-| `notification` | FCM 푸시 알림 | `event/` |
+| `letter` | 쪽지 | |
+| `score` | 활동 점수 (게이미피케이션) | |
+| `badge` | 배지 시스템 | |
+| `notification` | FCM 푸시 알림 | 목록 조회는 Slice 페이지네이션, `member_id` 인덱스 |
 | `home` | 홈 화면 배너/콘텐츠 | |
-| `login` | 카카오 OAuth2 로그인 | `auth/`, `kakao/` |
-| `activity` | 활동 기록 관리 | controller·service·dto 하위 `activeGeneration/`, `activityRecord/` 분리, `usecase/`, `mapper/`, `constants/` |
+| `activity` | 활동 기록 관리 | dto 하위 `activeGeneration/`, `activityRecord/` 분리 |
 | `feedback` | 사용자 피드백 | |
-| `reservation` | 예약 관리 | `usecase/`, `task/` |
+| `reservation` | 게시글 예약 발행 | presentation 없음 (post가 트리거, `task/`로 실행) |
 | `team` | 팀/그룹 관리 | |
 
 ## Authentication
 
-- **방식**: JWT + OAuth2 (Kakao) / Access + Refresh Token / Redis 저장
-- **관련 코드**: `global/jwt/`, `domain/login/kakao/`
+- **방식**: JWT + OAuth2 (Kakao, Apple) / Access + Refresh Token
+- **RTR**: refresh 회전 — Redis Lua CAS로 단일 사용 보장, grace key 멱등 처리, 재사용 탐지 시 전 세션 폐기
+- **로그인 식별**: `social_account(provider, provider_id)` 기준. 탈퇴 시 소셜 계정 연결도 삭제(재가입 허용), 퇴출자는 블랙리스트 차단
+- **관련 코드**: `global/jwt/`, `domain/auth/`, `application/auth/`
 
 ## External Services
 
 | 서비스 | 용도 |
 |--------|------|
 | AWS S3 | 이미지/파일 업로드 |
-| AWS RDS | MySQL DB |
-| Redis | 토큰 관리, 캐싱 |
+| MySQL (RDS) | DB |
+| Redis | refresh 토큰(RTR), 조회수 캐싱 |
 | Firebase FCM | 푸시 알림 |
-| Kakao OAuth | 소셜 로그인 |
+| Kakao / Apple OAuth | 소셜 로그인 |
 | JavaMail | 이메일 전송 |
+
+## Observability
+
+- **Actuator**: `/actuator/metrics/http.server.requests` — 엔드포인트별 응답시간 (관리자 역할 전용, `/actuator/health`만 무토큰 허용)
+- **Server-Timing**: 모든 REST 응답에 `Server-Timing: app;dur=<ms>` 헤더 (`global/logging/ServerTimingResponseAdvice`)
+- **이벤트 로깅**: `LogEventEmitter`로 요청 컨텍스트에 적재 → `WebLoggingFilter`가 flush → 분석 서버 전송(옵션)
 
 ## Tech Stack
 
@@ -80,6 +119,7 @@ com.tavemakers.surf
 
 ```bash
 ./gradlew build / bootRun / test
+./gradlew test --tests "*CleanArchitectureRulesTest"   # 아키텍처 규칙만
 ```
 
 ---
@@ -90,8 +130,9 @@ com.tavemakers.surf
 
 | 구분 | 패턴 | 예시 |
 |------|------|------|
-| Service | `{Domain}{Action}Service` | `PostCreateService` |
+| 도메인 Service | `{Domain}{Action}Service` | `PostCreateService` |
 | Usecase | `{Domain}Usecase` | `PostDeleteUsecase` |
+| Query 서비스 | `{Domain}GetService` | `MemberGetService` |
 | Controller | `{Domain}{Action}Controller` | `PostGetController` |
 | DTO (Request) | `{Action}ReqDTO` | `PostCreateReqDTO` |
 | DTO (Response) | `{Action}ResDTO` | `PostDetailResDTO` |
@@ -103,20 +144,21 @@ com.tavemakers.surf
 ### 서비스 계층 규칙
 
 ```
-Controller → Usecase → Service → Repository
-                 ↓
-            타 도메인 GetService (조회만 허용)
+Controller → Usecase/Query(@Transactional, DTO 매핑) → 도메인 Service(엔티티 반환) → Repository
+                      ↓
+              타 도메인 GetService (조회만 허용)
 ```
 
-- 타 도메인 Repository 직접 호출 ❌ → GetService 사용 ✅
-- 알림 발송: Service 직접 호출 ❌ → Event 발행 ✅
-- `@Transactional`: Usecase에서 관리
+- 타 도메인 Repository 직접 호출 ❌ → GetService 사용 ✅ (R2·R3)
+- 알림 발송: Service 직접 호출 ❌ → Event 발행 ✅ (R6: AFTER_COMMIT 리스너)
+- `@Transactional`: application 계층에서만 (R4)
+- 도메인 서비스는 DTO를 모른다 — 매핑은 usecase/query에서
 
 ### 주석 규칙
 
 ```java
 /** 한줄 설명 (한글, Javadoc 형식) */
-public void createPost(PostCreateReqDTO dto) { ... }
+public void createPost(...) { ... }
 ```
 
 ### DTO 규칙
@@ -140,15 +182,16 @@ public record PostDetailResDTO(Long id, String title) {
 | `/v1/manager/` | 매니저 |
 | `/login/` | 인증 |
 | `/auth/` | 토큰 재발급 |
+| `/actuator/` | 메트릭·헬스체크 (health 외 관리자 전용) |
 
 ---
 
 ## Design Patterns
 
-| 패턴 | 설명 | 사용 도메인 |
-|------|------|-------------|
-| **Usecase** | 복합 비즈니스 로직 조합, `@Transactional` 관리 | member, post, score, badge, activity, reservation |
-| **Event** | 도메인 간 느슨한 결합 (`@Async @EventListener`) | comment, letter, notification, post |
-| **Facade** | 복합 도메인 로직 단순화 (`Controller → Facade → Service`) | letter |
+| 패턴 | 설명 | 위치 |
+|------|------|------|
+| **Usecase** | 도메인 서비스 조합, `@Transactional` 소유, DTO 매핑 | `application/{domain}/usecase/` |
+| **Query** | 읽기 전용 조회(read-model 조립 포함) | `application/{domain}/query/` |
+| **Event** | 도메인 간 느슨한 결합 (`@Async` + `@TransactionalEventListener(AFTER_COMMIT)`) | 발행: domain, 리스너: `application/{domain}/event/` |
 | **Mapper** | Entity ↔ DTO 변환 분리 | post, activity |
-| **Scheduler/Task** | 주기적 작업 처리 | post, reservation |
+| **Scheduler/Task** | 주기적 작업 (조회수 배치 반영, 예약 발행) | `application/post/scheduler/`, `application/reservation/task/` |

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,6 +17,7 @@ repositories {
 
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")      // MVC (Controller)
+    implementation("org.springframework.boot:spring-boot-starter-actuator") // 엔드포인트별 메트릭 (http.server.requests)
     // implementation("org.springframework.boot:spring-boot-starter-webflux")  // WebClient
     implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
     implementation("org.springframework.boot:spring-boot-starter-security")

--- a/src/main/java/com/tavemakers/surf/application/notification/query/NotificationGetService.java
+++ b/src/main/java/com/tavemakers/surf/application/notification/query/NotificationGetService.java
@@ -9,6 +9,9 @@ import com.tavemakers.surf.domain.notification.entity.NotificationType;
 import com.tavemakers.surf.domain.notification.repository.NotificationRepository;
 import com.tavemakers.surf.domain.notification.service.NotificationRenderService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Service;
 
 import java.util.Arrays;
@@ -30,24 +33,25 @@ public class NotificationGetService {
     private final NotificationRenderService renderer;
     private final MemberGetService memberGetService;
 
-    /** 회원의 알림 목록 조회 (카테고리별 필터링 가능) */
-    public List<NotificationResDTO> getNotifications(Long memberId, NotificationCategory category) {
+    /** 회원의 알림 목록 조회 (카테고리별 필터링 가능, 무한스크롤) */
+    public Slice<NotificationResDTO> getNotifications(Long memberId, NotificationCategory category, Pageable pageable) {
 
-        List<Notification> notifications;
+        Slice<Notification> notifications;
 
         if (category == null) {
             // 전체 알림
-            notifications = notificationRepository.findByMemberIdOrderByIdDesc(memberId);
+            notifications = notificationRepository.findByMemberIdOrderByIdDesc(memberId, pageable);
         } else {
             // 해당 카테고리의 타입 목록 추출
             List<NotificationType> types = Arrays.stream(NotificationType.values())
                     .filter(t -> t.getCategory() == category)
                     .toList();
 
-            notifications = notificationRepository.findByMemberIdAndTypeInOrderByIdDesc(memberId, types);
+            notifications = notificationRepository.findByMemberIdAndTypeInOrderByIdDesc(memberId, types, pageable);
         }
 
-        return toDtoList(notifications);
+        List<NotificationResDTO> content = toDtoList(notifications.getContent());
+        return new SliceImpl<>(content, pageable, notifications.hasNext());
     }
 
     /**

--- a/src/main/java/com/tavemakers/surf/application/notification/usecase/NotificationUsecase.java
+++ b/src/main/java/com/tavemakers/surf/application/notification/usecase/NotificationUsecase.java
@@ -10,12 +10,13 @@ import com.tavemakers.surf.domain.notification.event.NotificationCreatedEvent;
 import com.tavemakers.surf.domain.notification.service.NotificationCreateService;
 import com.tavemakers.surf.domain.notification.service.NotificationService;
 import com.tavemakers.surf.domain.post.entity.Post;
-import com.tavemakers.surf.presentation.notification.dto.response.NotificationResDTO;
+import com.tavemakers.surf.presentation.notification.dto.response.NotificationSliceResDTO;
 import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -34,10 +35,11 @@ public class NotificationUsecase {
     private final NotificationCreateService notificationCreateService;
     private final ApplicationEventPublisher eventPublisher;
 
-    /** 회원의 알림 목록 조회 (카테고리별 필터링 가능) */
+    /** 회원의 알림 목록 조회 (카테고리별 필터링 가능, 무한스크롤) */
     @Transactional(readOnly = true)
-    public List<NotificationResDTO> getNotifications(Long memberId, NotificationCategory category) {
-        return notificationGetService.getNotifications(memberId, category);
+    public NotificationSliceResDTO getNotifications(Long memberId, NotificationCategory category, Pageable pageable) {
+        return NotificationSliceResDTO.from(
+                notificationGetService.getNotifications(memberId, category, pageable));
     }
 
     /** 알림 읽음 처리 */

--- a/src/main/java/com/tavemakers/surf/domain/notification/entity/Notification.java
+++ b/src/main/java/com/tavemakers/surf/domain/notification/entity/Notification.java
@@ -8,6 +8,8 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -16,6 +18,10 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+// 회원별 알림 조회(where member_id = ? order by id desc)가 풀 스캔을 타지 않도록 보조 인덱스 선언
+// (InnoDB 보조 인덱스는 PK를 암묵 포함하므로 정렬까지 커버)
+@Table(name = "notification",
+        indexes = @Index(name = "idx_notification_member_id", columnList = "member_id"))
 public class Notification extends BaseEntity {
 
     @Id

--- a/src/main/java/com/tavemakers/surf/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/tavemakers/surf/domain/notification/repository/NotificationRepository.java
@@ -2,6 +2,8 @@ package com.tavemakers.surf.domain.notification.repository;
 
 import com.tavemakers.surf.domain.notification.entity.Notification;
 import com.tavemakers.surf.domain.notification.entity.NotificationType;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -15,9 +17,9 @@ import java.util.Optional;
 @Repository
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
 
-    List<Notification> findByMemberIdOrderByIdDesc(Long memberId);
+    Slice<Notification> findByMemberIdOrderByIdDesc(Long memberId, Pageable pageable);
 
-    List<Notification> findByMemberIdAndTypeInOrderByIdDesc(Long memberId, Collection<NotificationType> types);
+    Slice<Notification> findByMemberIdAndTypeInOrderByIdDesc(Long memberId, Collection<NotificationType> types, Pageable pageable);
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("""

--- a/src/main/java/com/tavemakers/surf/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/tavemakers/surf/domain/notification/repository/NotificationRepository.java
@@ -17,8 +17,10 @@ import java.util.Optional;
 @Repository
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
 
+    /** 회원의 전체 알림을 최신순으로 페이지 조회 */
     Slice<Notification> findByMemberIdOrderByIdDesc(Long memberId, Pageable pageable);
 
+    /** 회원의 알림을 타입 목록(카테고리)으로 필터링해 최신순으로 페이지 조회 */
     Slice<Notification> findByMemberIdAndTypeInOrderByIdDesc(Long memberId, Collection<NotificationType> types, Pageable pageable);
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)

--- a/src/main/java/com/tavemakers/surf/global/config/SecurityConfig.java
+++ b/src/main/java/com/tavemakers/surf/global/config/SecurityConfig.java
@@ -50,6 +50,7 @@ public class SecurityConfig {
                         .requestMatchers(permitUrlConfig.getPublicUrl()).permitAll()
                         .requestMatchers(permitUrlConfig.getMemberUrl()).hasAnyRole("MEMBER", "ADMIN", "PRESIDENT", "MANAGER")
                         .requestMatchers(permitUrlConfig.getAdminUrl()).hasAnyRole("ADMIN", "PRESIDENT", "MANAGER")
+                        .requestMatchers("/actuator/**").hasAnyRole("ADMIN", "PRESIDENT", "MANAGER")
                         .anyRequest().authenticated()
                 )
                 .formLogin(form -> form.disable()) // 우리는 소셜 로그인 + JWT 사용 → formLogin 비활성화

--- a/src/main/java/com/tavemakers/surf/global/config/SecurityConfig.java
+++ b/src/main/java/com/tavemakers/surf/global/config/SecurityConfig.java
@@ -50,6 +50,8 @@ public class SecurityConfig {
                         .requestMatchers(permitUrlConfig.getPublicUrl()).permitAll()
                         .requestMatchers(permitUrlConfig.getMemberUrl()).hasAnyRole("MEMBER", "ADMIN", "PRESIDENT", "MANAGER")
                         .requestMatchers(permitUrlConfig.getAdminUrl()).hasAnyRole("ADMIN", "PRESIDENT", "MANAGER")
+                        // 헬스체크는 LB/오케스트레이터가 무토큰으로 호출 (기본 설정이라 UP/DOWN만 노출됨)
+                        .requestMatchers("/actuator/health").permitAll()
                         .requestMatchers("/actuator/**").hasAnyRole("ADMIN", "PRESIDENT", "MANAGER")
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/com/tavemakers/surf/global/logging/ServerTimingResponseAdvice.java
+++ b/src/main/java/com/tavemakers/surf/global/logging/ServerTimingResponseAdvice.java
@@ -1,0 +1,40 @@
+package com.tavemakers.surf.global.logging;
+
+import java.time.Duration;
+import java.time.Instant;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
+
+/**
+ * 모든 REST 응답에 Server-Timing 헤더를 붙여 프론트가 DevTools에서 서버 처리시간을 바로 확인하게 한다.
+ * 시작 시각은 WebLoggingFilter가 기록한 RequestLogContext.startAt을 재사용한다.
+ * <p>ResponseBodyAdvice 시점은 응답 커밋 전이라 헤더 추가가 항상 유효하다.
+ * 본문 없는 응답(204 등)은 이 지점을 지나지 않으므로 헤더가 붙지 않는다 — 계측 용도로 허용.
+ */
+@RestControllerAdvice
+public class ServerTimingResponseAdvice implements ResponseBodyAdvice<Object> {
+
+    @Override
+    public boolean supports(MethodParameter returnType, Class<? extends HttpMessageConverter<?>> converterType) {
+        return true;
+    }
+
+    @Override
+    public Object beforeBodyWrite(Object body, MethodParameter returnType, MediaType selectedContentType,
+                                  Class<? extends HttpMessageConverter<?>> selectedConverterType,
+                                  ServerHttpRequest request, ServerHttpResponse response) {
+        Instant startAt = RequestLogContext.get().startAt;
+        if (startAt != null) {
+            long durMs = Duration.between(startAt, Instant.now()).toMillis();
+            response.getHeaders().add("Server-Timing", "app;dur=" + durMs);
+            // 프론트가 다른 오리진이라 Timing-Allow-Origin 없이는 브라우저가 Server-Timing을 숨긴다
+            response.getHeaders().add("Timing-Allow-Origin", "*");
+        }
+        return body;
+    }
+}

--- a/src/main/java/com/tavemakers/surf/presentation/notification/controller/NotificationGetController.java
+++ b/src/main/java/com/tavemakers/surf/presentation/notification/controller/NotificationGetController.java
@@ -26,6 +26,7 @@ public class NotificationGetController {
     private final NotificationUsecase notificationUsecase;
     private final LogEventEmitter logEventEmitter;
 
+    /** 회원의 알림 목록 조회 (카테고리 필터 + 무한스크롤) */
     @Operation(summary = "알람 조회", description = "category 파라미터로 카테고리별 필터링 조회합니다. null일 경우 전체 알람 조회. page/size로 무한스크롤 조회합니다.")
     @GetMapping("/v1/user/notifications")
     public ApiResponse<NotificationSliceResDTO> getNotifications(

--- a/src/main/java/com/tavemakers/surf/presentation/notification/controller/NotificationGetController.java
+++ b/src/main/java/com/tavemakers/surf/presentation/notification/controller/NotificationGetController.java
@@ -1,6 +1,6 @@
 package com.tavemakers.surf.presentation.notification.controller;
 
-import com.tavemakers.surf.presentation.notification.dto.response.NotificationResDTO;
+import com.tavemakers.surf.presentation.notification.dto.response.NotificationSliceResDTO;
 import com.tavemakers.surf.domain.notification.entity.NotificationCategory;
 import com.tavemakers.surf.application.notification.usecase.NotificationUsecase;
 import com.tavemakers.surf.global.common.response.ApiResponse;
@@ -9,10 +9,10 @@ import com.tavemakers.surf.global.util.SecurityUtils;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
 import java.util.Map;
 
 import static com.tavemakers.surf.presentation.notification.controller.ResponseMessage.*;
@@ -26,17 +26,20 @@ public class NotificationGetController {
     private final NotificationUsecase notificationUsecase;
     private final LogEventEmitter logEventEmitter;
 
-    @Operation(summary = "알람 조회", description = "category 파라미터로 카테고리별 필터링 조회합니다. null일 경우 전체 알람 조회")
+    @Operation(summary = "알람 조회", description = "category 파라미터로 카테고리별 필터링 조회합니다. null일 경우 전체 알람 조회. page/size로 무한스크롤 조회합니다.")
     @GetMapping("/v1/user/notifications")
-    public ApiResponse<List<NotificationResDTO>> getNotifications(
-            @RequestParam(required = false) NotificationCategory category
+    public ApiResponse<NotificationSliceResDTO> getNotifications(
+            @RequestParam(required = false) NotificationCategory category,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size
     ) {
         Long memberId = SecurityUtils.getCurrentMemberId();
         logEventEmitter.emit("notification.list_view", Map.of(
                 "member_id", memberId,
                 "category", category != null ? category.name().toLowerCase() : "all"
         ));
-        List<NotificationResDTO> response = notificationUsecase.getNotifications(memberId, category);
+        NotificationSliceResDTO response =
+                notificationUsecase.getNotifications(memberId, category, PageRequest.of(page, size));
         return ApiResponse.response(HttpStatus.OK, NOTIFICATION_READ.getMessage(), response);
     }
 }

--- a/src/main/java/com/tavemakers/surf/presentation/notification/dto/response/NotificationSliceResDTO.java
+++ b/src/main/java/com/tavemakers/surf/presentation/notification/dto/response/NotificationSliceResDTO.java
@@ -1,0 +1,22 @@
+package com.tavemakers.surf.presentation.notification.dto.response;
+
+import org.springframework.data.domain.Slice;
+
+import java.util.List;
+
+public record NotificationSliceResDTO(
+        List<NotificationResDTO> content,
+        int pageNumber,
+        int pageSize,
+        boolean hasNext
+) {
+
+    public static NotificationSliceResDTO from(Slice<NotificationResDTO> slice) {
+        return new NotificationSliceResDTO(
+                slice.getContent(),
+                slice.getNumber(),
+                slice.getSize(),
+                slice.hasNext()
+        );
+    }
+}

--- a/src/main/java/com/tavemakers/surf/presentation/notification/dto/response/NotificationSliceResDTO.java
+++ b/src/main/java/com/tavemakers/surf/presentation/notification/dto/response/NotificationSliceResDTO.java
@@ -11,6 +11,7 @@ public record NotificationSliceResDTO(
         boolean hasNext
 ) {
 
+    /** Slice 조회 결과를 무한스크롤 응답 형태로 변환 */
     public static NotificationSliceResDTO from(Slice<NotificationResDTO> slice) {
         return new NotificationSliceResDTO(
                 slice.getContent(),

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -84,6 +84,13 @@ springdoc:
 server:
   forward-headers-strategy: framework
 
+# 엔드포인트별 응답시간 메트릭 노출 (접근은 SecurityConfig에서 관리자 역할로 제한)
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, metrics
+
 logging:
   forwarding:
     enabled: ${LOG_FORWARD_ENABLED:false}

--- a/src/test/java/com/tavemakers/surf/application/notification/query/NotificationGetServicePagingTest.java
+++ b/src/test/java/com/tavemakers/surf/application/notification/query/NotificationGetServicePagingTest.java
@@ -1,0 +1,116 @@
+package com.tavemakers.surf.application.notification.query;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tavemakers.surf.application.member.query.MemberGetService;
+import com.tavemakers.surf.domain.notification.entity.Notification;
+import com.tavemakers.surf.domain.notification.entity.NotificationCategory;
+import com.tavemakers.surf.domain.notification.entity.NotificationType;
+import com.tavemakers.surf.domain.notification.repository.NotificationRepository;
+import com.tavemakers.surf.domain.notification.service.NotificationRenderService;
+import com.tavemakers.surf.presentation.notification.dto.response.NotificationResDTO;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+/**
+ * 알림 목록 조회 페이지네이션 회귀 테스트.
+ * 무제한 전체 조회(List)에서 Slice 기반 무한스크롤로 전환한 동작을 검증한다.
+ */
+@DataJpaTest
+@Import({NotificationGetService.class, NotificationRenderService.class,
+        NotificationGetServicePagingTest.ObjectMapperConfig.class})
+class NotificationGetServicePagingTest {
+
+    private static final Long MEMBER_ID = 1L;
+    private static final Long OTHER_MEMBER_ID = 2L;
+
+    @TestConfiguration
+    static class ObjectMapperConfig {
+        @Bean
+        ObjectMapper objectMapper() {
+            return new ObjectMapper();
+        }
+    }
+
+    @Autowired
+    private NotificationGetService notificationGetService;
+
+    @Autowired
+    private NotificationRepository notificationRepository;
+
+    @MockBean
+    private MemberGetService memberGetService;
+
+    @BeforeEach
+    void setUp() {
+        given(memberGetService.getMembers(any())).willReturn(List.of());
+
+        // 대상 회원: ACTIVITY 25건 + SCHEDULE(NOTICE) 3건
+        for (int i = 0; i < 25; i++) {
+            notificationRepository.save(Notification.of(
+                    MEMBER_ID, NotificationType.POST_LIKE,
+                    "{\"actorId\": 9, \"actorName\": \"서퍼\", \"boardId\": 1, \"postId\": " + i + "}"));
+        }
+        for (int i = 0; i < 3; i++) {
+            notificationRepository.save(Notification.of(
+                    MEMBER_ID, NotificationType.NOTICE,
+                    "{\"boardName\": \"공지\", \"boardId\": 2, \"postId\": " + i + "}"));
+        }
+        // 타 회원 알림은 조회에 섞이면 안 된다
+        notificationRepository.save(Notification.of(
+                OTHER_MEMBER_ID, NotificationType.POST_LIKE,
+                "{\"actorId\": 9, \"actorName\": \"서퍼\", \"boardId\": 1, \"postId\": 99}"));
+    }
+
+    @Test
+    @DisplayName("전체 조회: page 0/size 20 → 20건 + hasNext, page 1 → 8건 + hasNext 없음")
+    void 전체_알림이_페이지_단위로_조회된다() {
+        Slice<NotificationResDTO> first =
+                notificationGetService.getNotifications(MEMBER_ID, null, PageRequest.of(0, 20));
+
+        assertThat(first.getContent()).hasSize(20);
+        assertThat(first.hasNext()).isTrue();
+
+        Slice<NotificationResDTO> second =
+                notificationGetService.getNotifications(MEMBER_ID, null, PageRequest.of(1, 20));
+
+        assertThat(second.getContent()).hasSize(8);
+        assertThat(second.hasNext()).isFalse();
+    }
+
+    @Test
+    @DisplayName("최신(id 내림차순) 순서가 페이지에 걸쳐 유지된다")
+    void 최신순_정렬이_유지된다() {
+        Slice<NotificationResDTO> first =
+                notificationGetService.getNotifications(MEMBER_ID, null, PageRequest.of(0, 20));
+
+        List<Long> ids = first.getContent().stream().map(NotificationResDTO::id).toList();
+        assertThat(ids).isSortedAccordingTo((a, b) -> Long.compare(b, a));
+    }
+
+    @Test
+    @DisplayName("카테고리 필터: SCHEDULE 조회 시 NOTICE 3건만 반환된다")
+    void 카테고리_필터가_페이지네이션과_함께_동작한다() {
+        Slice<NotificationResDTO> result = notificationGetService.getNotifications(
+                MEMBER_ID, NotificationCategory.SCHEDULE, PageRequest.of(0, 20));
+
+        assertThat(result.getContent()).hasSize(3);
+        assertThat(result.hasNext()).isFalse();
+        assertThat(result.getContent())
+                .allSatisfy(dto -> assertThat(dto.category()).isEqualTo("SCHEDULE"));
+    }
+}


### PR DESCRIPTION
## 배경

프론트에서 `/badges` 803ms, `/notifications` 862ms(응답 0.3kB인데 서버 대기 801ms) 성능 이슈 보고와 함께 두 가지 요청이 있었습니다:
1. Actuator 메트릭으로 엔드포인트별 응답시간 확인
2. Server-Timing 헤더로 DevTools에서 서버 처리시간 즉시 확인

코드 조사 결과 `/notifications`는 원인이 특정되어 함께 수정했습니다.

## 변경 사항

### 1. Actuator 메트릭 (관리자 전용) — `2ba8289e`
- `spring-boot-starter-actuator` 추가, `health`/`metrics` 노출
- `/actuator/**` 접근은 **ADMIN/PRESIDENT/MANAGER 역할로 제한** (무토큰 403 확인)
- 사용법: `GET /actuator/metrics/http.server.requests?tag=uri:/v1/user/notifications` + 관리자 Authorization 헤더

### 2. Server-Timing 헤더 — `a69bbc9d`
- 모든 REST 응답에 `Server-Timing: app;dur=<ms>` + `Timing-Allow-Origin: *` 부착
- WebLoggingFilter가 이미 기록하던 요청 시작 시각을 재사용 (신규 측정 코드 없음)
- ResponseBodyAdvice 시점(응답 커밋 전)에 부착 → 대용량 응답에서도 유실 없음
- 한계: 본문 없는 응답(204 등)에는 헤더가 붙지 않음 (계측 용도로 허용)

### 3. 알림 조회 최적화 — `94b7949b`
- **인덱스**: `notification.member_id` 보조 인덱스 추가 — 기존엔 회원별 알림 조회가 **풀 테이블 스캔**이었음 (공지 발행 시 전 회원 bulk insert로 테이블이 빠르게 커지는 구조라 862ms의 유력 원인)
- **페이지네이션**: 무제한 전체 조회 → Slice 기반 무한스크롤 전환

## ⚠️ 프론트 Breaking Change

`GET /v1/user/notifications` 응답 형태가 바뀝니다 (배포 타이밍 협의 필요):

```
// before: data가 배열
"data": [ {...}, {...} ]

// after: data가 Slice 객체, page/size 쿼리 파라미터 추가 (기본 0/20)
"data": { "content": [ {...} ], "pageNumber": 0, "pageSize": 20, "hasNext": false }
```

- Server-Timing은 배포 즉시 DevTools Network 탭 → Timing에서 확인 가능
- `/badges` 800ms는 코드상 원인 불충분(쿼리 3개 전부 경량) → 배포 후 Actuator 실측으로 인프라 지연(앱↔RDS 왕복 등) 규명 예정

## 검증

- [x] 전체 테스트 그린 (`./gradlew test`)
- [x] 페이지네이션·최신순 정렬·카테고리 필터 회귀 테스트 신규 3건
- [x] 로컬 부팅 E2E: Server-Timing 헤더 확인 / actuator 무토큰 403·관리자 AT 200 / 알림 API Slice 응답 확인
- [x] 로컬 MySQL `SHOW INDEX FROM notification` → `idx_notification_member_id` 생성 확인 (ddl-auto: update가 부팅 시 생성)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 알림 목록에 페이지네이션과 무한 스크롤 지원을 추가했습니다.
  * 알림 조회 응답에 페이지 정보와 다음 페이지 존재 여부를 제공합니다.
  * 서버 응답 시간 정보를 확인할 수 있는 성능 헤더를 추가했습니다.
  * 상태 및 메트릭 모니터링 엔드포인트를 제공합니다.

* **개선 사항**
  * 알림 목록을 최신순으로 안정적으로 조회합니다.
  * 알림 유형별 필터링과 페이지 단위 조회를 함께 지원합니다.
  * 모니터링 엔드포인트 접근 권한을 관리자 역할로 제한했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->