### PR TITLE
[Fix] 점수 행 없는 회원 활동점수 부여 시 silent no-op → 명시적 실패로 수정

### DIFF
--- a/src/main/java/com/tavemakers/surf/application/score/query/PersonalScoreGetService.java
+++ b/src/main/java/com/tavemakers/surf/application/score/query/PersonalScoreGetService.java
@@ -6,6 +6,7 @@ import com.tavemakers.surf.domain.score.repository.PersonalActivityScoreReposito
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.HashSet;
 import java.util.List;
 
 @Service
@@ -38,12 +39,23 @@ public class PersonalScoreGetService {
 
     /** 여러 회원의 개인 활동 점수 목록 조회 (점수 갱신용 — 행 잠금, 호출측 트랜잭션 필수) */
     public List<PersonalActivityScore> getPersonalScoreListByIdsForUpdate(List<Long> memberIdList) {
-        return personalScoreRepository.findAllByMemberIdInForUpdate(memberIdList);
+        List<PersonalActivityScore> scoreList = personalScoreRepository.findAllByMemberIdInForUpdate(memberIdList);
+        validateAllFound(scoreList, memberIdList);
+        return scoreList;
     }
 
     /** 여러 팀의 활동 점수 목록 조회 (점수 갱신용 — 행 잠금, 호출측 트랜잭션 필수) */
     public List<PersonalActivityScore> getTeamScoreListByIdsForUpdate(List<Long> teamIdList) {
-        return personalScoreRepository.findAllByTeamIdInForUpdate(teamIdList);
+        List<PersonalActivityScore> scoreList = personalScoreRepository.findAllByTeamIdInForUpdate(teamIdList);
+        validateAllFound(scoreList, teamIdList);
+        return scoreList;
+    }
+
+    /** 점수 행이 없는 대상이 섞여 있으면 예외 — 갱신 경로에서 대상 누락이 조용히 건너뛰어지는 것(silent no-op) 방지 */
+    private void validateAllFound(List<PersonalActivityScore> scoreList, List<Long> requestedIdList) {
+        if (scoreList.size() != new HashSet<>(requestedIdList).size()) {
+            throw new PersonalScoreNotFoundException();
+        }
     }
 
 }

--- a/src/test/java/com/tavemakers/surf/application/activity/usecase/ActivityRecordMissingScoreRegressionTest.java
+++ b/src/test/java/com/tavemakers/surf/application/activity/usecase/ActivityRecordMissingScoreRegressionTest.java
@@ -1,0 +1,173 @@
+package com.tavemakers.surf.application.activity.usecase;
+
+import com.tavemakers.surf.presentation.activity.dto.activityRecord.request.ActivityRecordReqDTO;
+import com.tavemakers.surf.presentation.activity.dto.activityRecord.request.ActivityRecordReqDTOV2;
+import com.tavemakers.surf.domain.activity.entity.enums.ActivityType;
+import com.tavemakers.surf.application.activity.mapper.ActivityRecordMapper;
+import com.tavemakers.surf.application.activity.query.ActivityRecordGetService;
+import com.tavemakers.surf.domain.activity.service.activityRecord.ActivityRecordCreateService;
+import com.tavemakers.surf.domain.activity.service.activityRecord.ActivityRecordDeleteService;
+import com.tavemakers.surf.domain.activity.service.activityRecord.ActivityRecordPatchService;
+import com.tavemakers.surf.domain.member.entity.Member;
+import com.tavemakers.surf.domain.member.entity.enums.MemberRole;
+import com.tavemakers.surf.domain.member.entity.enums.MemberStatus;
+import com.tavemakers.surf.domain.member.entity.enums.MemberType;
+import com.tavemakers.surf.domain.auth.common.enums.Provider;
+import com.tavemakers.surf.domain.score.entity.PersonalActivityScore;
+import com.tavemakers.surf.domain.score.exception.PersonalScoreNotFoundException;
+import com.tavemakers.surf.application.score.query.PersonalScoreGetService;
+import com.tavemakers.surf.domain.score.repository.PersonalActivityScoreRepository;
+import com.tavemakers.surf.domain.score.util.ScoreCalculator;
+import com.tavemakers.surf.global.logging.LogEventEmitter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+/**
+ * 점수 행(PersonalActivityScore) 미존재 회원 점수 부여 silent no-op 회귀 테스트.
+ *
+ * <p>applyActivityRecord/createActivityRecordList는 기존 점수 행만 조회해 루프를 돌기 때문에,
+ * 행이 없는 회원은 조회 결과에서 빠져 기록 생성 없이 그대로 성공(201)을 반환했다.
+ * 관리자는 점수를 부여했다고 믿지만 실제로는 아무것도 반영되지 않는 무결성 문제다.
+ *
+ * <p>수정 후에는 조회된 점수 행 수가 요청 대상 수와 다르면 PersonalScoreNotFoundException으로
+ * 명확히 실패해야 한다. (수정 전에는 예외 없이 통과 → 이 테스트 실패)
+ *
+ * <p>H2의 ActivityRecord DDL(TINYINT(1)) 파싱 한계로 @DataJpaTest 저장이 불가하여
+ * 기존 회귀 테스트와 동일하게 mock 리포지토리 + 실제 PersonalScoreGetService 조합으로 검증한다.
+ */
+@ExtendWith(MockitoExtension.class)
+class ActivityRecordMissingScoreRegressionTest {
+
+    private static final ActivityType REWARD_TYPE = ActivityType.ENGAGE_TECH_SEMINAR; // +10, REWARD
+    private static final long MEMBER_A_ID = 101L;
+    private static final long MEMBER_B_ID = 102L;
+    private static final long TEAM_ID = 201L;
+
+    @Mock
+    private ActivityRecordCreateService activityRecordCreateService;
+    @Mock
+    private ActivityRecordGetService activityRecordGetService;
+    @Mock
+    private ActivityRecordDeleteService activityRecordDeleteService;
+    @Mock
+    private ScoreCalculator scoreCalculator;
+    @Mock
+    private LogEventEmitter logEventEmitter;
+    @Mock
+    private ActivityRecordMapper activityRecordMapper;
+    @Mock
+    private PersonalActivityScoreRepository personalScoreRepository;
+
+    private ActivityRecordUsecase usecase;
+
+    @BeforeEach
+    void setUp() {
+        // 버그가 조회 계층(PersonalScoreGetService)과 usecase 사이에 걸쳐 있으므로 GetService는 실제 객체를 사용
+        usecase = new ActivityRecordUsecase(
+                activityRecordCreateService,
+                activityRecordGetService,
+                new ActivityRecordPatchService(),
+                activityRecordDeleteService,
+                activityRecordMapper,
+                new PersonalScoreGetService(personalScoreRepository),
+                scoreCalculator,
+                logEventEmitter
+        );
+    }
+
+    private PersonalActivityScore scoreOf(Member member) {
+        return PersonalActivityScore.builder()
+                .member(member)
+                .score(BigDecimal.valueOf(100))
+                .rewardPrefixSum(BigDecimal.ZERO)
+                .penaltyPrefixSum(BigDecimal.ZERO)
+                .build();
+    }
+
+    private Member approvedMember() {
+        return Member.builder()
+                .provider(Provider.KAKAO)
+                .providerId("provider-a")
+                .name("회원A")
+                .status(MemberStatus.APPROVED)
+                .role(MemberRole.MEMBER)
+                .memberType(MemberType.YB)
+                .activityStatus(true)
+                .build();
+    }
+
+    @Test
+    @DisplayName("V2 개인 부여 — 점수 행 없는 회원이면 silent no-op 대신 예외로 실패한다")
+    void V2_개인부여_점수행_없으면_예외() {
+        given(personalScoreRepository.findAllByMemberIdInForUpdate(List.of(MEMBER_A_ID)))
+                .willReturn(List.of()); // 점수 행 미존재
+
+        ActivityRecordReqDTOV2 dto = new ActivityRecordReqDTOV2(
+                List.of(MEMBER_A_ID), null, null, null, REWARD_TYPE, LocalDate.now());
+
+        assertThatThrownBy(() -> usecase.applyActivityRecord(dto))
+                .isInstanceOf(PersonalScoreNotFoundException.class);
+
+        verify(activityRecordCreateService, never()).saveActivityRecordList(any());
+    }
+
+    @Test
+    @DisplayName("V2 개인 부여 — 일부 회원만 점수 행이 없어도 부분 반영 없이 예외로 실패한다")
+    void V2_개인부여_일부_점수행_없으면_부분반영_없이_예외() {
+        // A만 점수 행 존재, B는 미존재 → 요청 2명 중 1명만 조회됨
+        given(personalScoreRepository.findAllByMemberIdInForUpdate(List.of(MEMBER_A_ID, MEMBER_B_ID)))
+                .willReturn(List.of(scoreOf(approvedMember())));
+
+        ActivityRecordReqDTOV2 dto = new ActivityRecordReqDTOV2(
+                List.of(MEMBER_A_ID, MEMBER_B_ID), null, null, null, REWARD_TYPE, LocalDate.now());
+
+        assertThatThrownBy(() -> usecase.applyActivityRecord(dto))
+                .isInstanceOf(PersonalScoreNotFoundException.class);
+
+        verify(activityRecordCreateService, never()).saveActivityRecordList(any());
+    }
+
+    @Test
+    @DisplayName("V2 팀 부여 — 점수 행 없는 팀이면 silent no-op 대신 예외로 실패한다")
+    void V2_팀부여_점수행_없으면_예외() {
+        given(personalScoreRepository.findAllByTeamIdInForUpdate(List.of(TEAM_ID)))
+                .willReturn(List.of()); // 팀 점수 행 미존재
+
+        ActivityRecordReqDTOV2 dto = new ActivityRecordReqDTOV2(
+                null, List.of(TEAM_ID), null, null, REWARD_TYPE, LocalDate.now());
+
+        assertThatThrownBy(() -> usecase.applyActivityRecord(dto))
+                .isInstanceOf(PersonalScoreNotFoundException.class);
+
+        verify(activityRecordCreateService, never()).saveActivityRecordList(any());
+    }
+
+    @Test
+    @DisplayName("V1 다수 부여 — 점수 행 없는 회원이 섞여 있으면 예외로 실패한다")
+    void V1_다수부여_점수행_없으면_예외() {
+        given(personalScoreRepository.findAllByMemberIdInForUpdate(List.of(MEMBER_A_ID, MEMBER_B_ID)))
+                .willReturn(List.of(scoreOf(approvedMember())));
+
+        ActivityRecordReqDTO dto = new ActivityRecordReqDTO(
+                List.of(MEMBER_A_ID, MEMBER_B_ID), null, REWARD_TYPE, LocalDate.now());
+
+        assertThatThrownBy(() -> usecase.createActivityRecordList(dto))
+                .isInstanceOf(PersonalScoreNotFoundException.class);
+
+        verify(activityRecordCreateService, never()).saveActivityRecordList(any());
+    }
+}


### PR DESCRIPTION
## 배경

`POST /v1/manager/activity-records`(또는 `/v1/admin/...`)로 활동점수를 부여할 때, 대상 회원의 `PersonalActivityScore` 행이 존재하지 않으면 **아무 기록도 생성하지 않고 201 성공**을 반환하는 silent no-op 버그가 있었습니다.

- 원인: `ActivityRecordUsecase`가 `getPersonalScoreListByIdsForUpdate(memberIdList)`로 **기존 점수 행만 조회해 루프**를 돌기 때문에, 행이 없는 회원은 조회 결과에서 빠져 조용히 건너뛰어짐
- 점수 행은 회원 승인 플로우에서 생성(YB 100/OB 50)되므로 정상 플로우에서는 드물지만, 마이그레이션·수동 삽입·과거 데이터 정합성 문제가 있으면 **관리자는 점수를 줬다고 믿는데 실제로는 미반영**되는 무결성 문제
- 같은 버그가 V2 개인 경로뿐 아니라 **V2 팀 경로, V1 `createActivityRecordList`에도 동일하게 존재**

## 변경 사항

### 수정 — `PersonalScoreGetService`
갱신용 행 잠금 조회 2개(`getPersonalScoreListByIdsForUpdate`, `getTeamScoreListByIdsForUpdate`)에서 **조회 결과 수가 요청 대상 수(중복 제거 기준)와 다르면 `PersonalScoreNotFoundException`(400)** 을 던집니다.

- 이 위치 한 곳으로 V1·V2, 개인·팀 네 경로가 모두 커버됨
- 부수 효과: `findScoreByRecord`의 팀 점수 `get(0)`이 행 부재 시 `IndexOutOfBoundsException`(500)을 내던 것도 같은 예외(400)로 정리됨

### 수정 방향 선택 근거 (옵션 1: 명시적 실패)
대안이었던 자가 치유(없는 행을 `PersonalActivityScore.from(Member)`로 생성 후 진행)는 배제했습니다 — 기본 점수 부여(YB 100/OB 50)는 회원 승인 플로우의 책임이고, 점수 행 부재라는 정합성 이상 신호를 조용히 덮게 되기 때문입니다. 자가 치유가 낫다고 판단되면 리뷰에서 논의 후 전환 가능합니다.

### 재현 회귀 테스트 — `ActivityRecordMissingScoreRegressionTest` (4건)
수정 전 코드에서 4건 모두 실패(예외 없이 통과)함을 확인 후 수정했습니다.
- V2 개인 — 점수 행 없는 회원 부여 시 예외
- V2 개인 — **일부 회원만** 행이 없어도 부분 반영 없이 예외
- V2 팀 — 점수 행 없는 팀 부여 시 예외
- V1 다수 부여 — 행 없는 회원이 섞여 있으면 예외

mock 리포지토리 + 실제 `PersonalScoreGetService` 조합으로 검증 (H2의 `ActivityRecord` DDL 한계로 기존 회귀 테스트와 동일한 방식).

## 검증

- 신규 회귀 테스트 4건 통과
- 전체 테스트 통과 (ArchUnit·E2E 포함, 유일한 실패 `RefreshTokenService`는 로컬 Docker 미기동으로 인한 Testcontainers 환경 문제 — 본 변경과 무관)

🤖 Generated with [Claude Code](https://claude.com/claude-code)