### PR TITLE
[REFACTOR] Phase 6 — Member 소셜 레거시 컬럼 정리 #348

### DIFF
--- a/src/main/java/com/tavemakers/surf/application/auth/apple/usecase/AppleLoginUsecase.java
+++ b/src/main/java/com/tavemakers/surf/application/auth/apple/usecase/AppleLoginUsecase.java
@@ -103,12 +103,8 @@ public class AppleLoginUsecase {
         return payload;
     }
 
-    /**
-     * Apple refresh_token 을 SocialAccount(신규 정규 저장소)와 Member(레거시, 탈퇴 revoke 호환)에 함께 저장한다.
-     * SocialAccount 로 탈퇴 로직이 이관되면(Phase 5) Member 쪽 저장은 제거한다.
-     */
+    /** Apple refresh_token 을 SocialAccount(정규 저장소)에 저장한다 — 탈퇴 시 revoke 에 사용. */
     private void updateAppleRefreshToken(Member member, String refreshToken) {
-        member.updateAppleRefreshToken(refreshToken);
         member.findSocialAccount(Provider.APPLE)
                 .ifPresent(sa -> sa.updateAppleRefreshToken(refreshToken));
     }

--- a/src/main/java/com/tavemakers/surf/domain/member/entity/Member.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/entity/Member.java
@@ -2,7 +2,6 @@ package com.tavemakers.surf.domain.member.entity;
 
 import com.tavemakers.surf.domain.auth.common.dto.OAuthUserInfoDTO;
 import com.tavemakers.surf.domain.auth.common.enums.Provider;
-import com.tavemakers.surf.domain.member.exception.InvalidMemberInfoException;
 import com.tavemakers.surf.domain.member.exception.MisMatchPasswordException;
 import com.tavemakers.surf.domain.member.exception.PasswordNotSettingException;
 import com.tavemakers.surf.global.common.entity.BaseEntity;
@@ -29,14 +28,6 @@ import org.hibernate.annotations.BatchSize;
 
 
 @Entity
-@Table(
-        uniqueConstraints = {
-                @UniqueConstraint(
-                        name = "uk_member_provider_provider_id",
-                        columnNames = {"provider", "provider_id"}
-                )
-        }
-)
 @Getter
 @Slf4j
 @NoArgsConstructor(access = AccessLevel.PROTECTED) // 기본 생성자 protected 설정
@@ -47,25 +38,9 @@ public class Member extends BaseEntity {
     @Column(name = "member_id")
     private Long id;
 
-    /** @deprecated provider/providerId 모델 도입 (D1) — 호출자 일소 후 후속 PR(Step 7)에서 제거. */
-    @Deprecated
-    @Column
-    private Long kakaoId;
-
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false, length = 16)
-    private Provider provider;
-
-    @Column(nullable = false, length = 64)
-    private String providerId;
-
     /** Apple 첫 로그인 시 닉네임 미제공 (D5) → nullable 허용. 가입 폼(applySignup)에서 채워진다. */
     @Column
     private String name;
-
-    /** Apple 계정 탈퇴(revoke) 시 사용. 로그인 시 코드 교환 후 저장, 탈퇴 시 null 처리. */
-    @Column(name = "apple_refresh_token", length = 1024)
-    private String appleRefreshToken;
 
     private String profileImageUrl;
 
@@ -138,10 +113,7 @@ public class Member extends BaseEntity {
     }
 
     @Builder
-    public Member(Provider provider,
-                  String providerId,
-                  Long kakaoId,
-                  String name,
+    public Member(String name,
                   String profileImageUrl,
                   String university,
                   String graduateSchool,
@@ -152,9 +124,6 @@ public class Member extends BaseEntity {
                   MemberRole role,
                   MemberType memberType,
                   boolean activityStatus) {
-        this.provider = provider;
-        this.providerId = providerId;
-        this.kakaoId = kakaoId;
         this.name = name;
         this.profileImageUrl = profileImageUrl;
         this.university = university;
@@ -170,34 +139,13 @@ public class Member extends BaseEntity {
     }
 
     /**
-     * OAuth provider 정보로 REGISTERING 상태의 회원을 생성한다 (D1, D5).
+     * OAuth provider 정보로 REGISTERING 상태의 회원을 생성한다 (D5).
      * Kakao 는 닉네임이 일반적으로 채워져 있고, Apple 은 첫 로그인 시 nickname/profileImageUrl 이 null 일 수 있다.
-     * provider 이메일 유무에 의존하지 않는다 — provider 이메일은 SocialAccount.providerEmail 에 저장되며 없을 수 있다(Apple 미제공 등).
+     * provider 식별 정보는 회원이 아니라 {@link SocialAccount}(정규 저장소)가 보유한다 —
+     * 통합 이메일(Member.email)은 온보딩 입력값으로만 채우며 REGISTERING 단계에서는 값이 없다(null).
      */
-    public static Member createRegisteringFromOAuth(Provider provider, OAuthUserInfoDTO info) {
-        if (provider == null) {
-            throw new IllegalStateException("provider 는 필수입니다.");
-        }
-        if (info.oauthId() == null || info.oauthId().isBlank()) {
-            throw new IllegalStateException(provider + " 식별자(oauthId)가 비어 있습니다.");
-        }
-
-        Long legacyKakaoId = null;
-        if (provider == Provider.KAKAO) {
-            try {
-                legacyKakaoId = Long.parseLong(info.oauthId());
-            } catch (NumberFormatException e) {
-                throw new InvalidMemberInfoException(
-                        "Provider.KAKAO oauthId가 유효한 숫자 형식이 아닙니다: " + info.oauthId());
-            }
-        }
-
-        // 통합 이메일(Member.email)은 온보딩 입력값으로만 채운다. REGISTERING 단계에서는 값 없음(null).
-        // provider 가 준 이메일은 SocialAccount.providerEmail 에만 저장된다.
+    public static Member createRegisteringFromOAuth(OAuthUserInfoDTO info) {
         return Member.builder()
-                .provider(provider)
-                .providerId(info.oauthId())
-                .kakaoId(legacyKakaoId)
                 .name(info.nickname())
                 .phoneNumberPublic(false)
                 .profileImageUrl(info.profileImageUrl())
@@ -402,14 +350,7 @@ public class Member extends BaseEntity {
 
         long ts = System.currentTimeMillis();
         this.email = "withdrawn_" + this.id + "_" + ts + "@deleted.local";
-        this.providerId = "withdrawn_" + this.id + "_" + ts;
-        this.kakaoId = null;
-        this.appleRefreshToken = null;
-    }
-
-    /** Apple refresh_token 갱신 — 로그인 코드 교환 시 호출 */
-    public void updateAppleRefreshToken(String refreshToken) {
-        this.appleRefreshToken = refreshToken;
+        // provider 식별자/unlink·revoke 데이터 정리는 SocialAccount 삭제(withdraw의 clear())가 담당한다.
     }
 
     public void updatePassword(String password) {

--- a/src/main/java/com/tavemakers/surf/domain/member/service/MemberUpsertService.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/service/MemberUpsertService.java
@@ -64,7 +64,7 @@ public class MemberUpsertService {
      * <p>동시 첫 로그인 경합 시 한쪽은 UNIQUE 제약 위반으로 트랜잭션이 롤백되며(재시도 시 정상 진입), 오염된 세션에서 복구를 시도하지 않는다.
      */
     private Member createNewSocialMember(Provider provider, OAuthUserInfoDTO info) {
-        Member member = Member.createRegisteringFromOAuth(provider, info);
+        Member member = Member.createRegisteringFromOAuth(info);
         SocialAccount socialAccount = SocialAccount.createFromOAuth(provider, info);
         member.addSocialAccount(socialAccount);
 

--- a/src/main/java/com/tavemakers/surf/global/util/SecurityUtils.java
+++ b/src/main/java/com/tavemakers/surf/global/util/SecurityUtils.java
@@ -34,7 +34,6 @@ public final class SecurityUtils {
         return getCurrentMember().getId();
     }
 
-    public static Long getCurrentKakaoId(){return getCurrentMember().getKakaoId();}
 
     public static String getCurrentMemberRole(){return getCurrentMember().getRole().toString();}
 }

--- a/src/test/java/com/tavemakers/surf/application/comment/usecase/CommentUsecaseTest.java
+++ b/src/test/java/com/tavemakers/surf/application/comment/usecase/CommentUsecaseTest.java
@@ -2,7 +2,6 @@ package com.tavemakers.surf.application.comment.usecase;
 
 import com.tavemakers.surf.application.comment.query.CommentGetService;
 import com.tavemakers.surf.application.comment.query.CommentMentionGetService;
-import com.tavemakers.surf.domain.auth.common.enums.Provider;
 import com.tavemakers.surf.domain.board.entity.Board;
 import com.tavemakers.surf.domain.board.entity.BoardCategory;
 import com.tavemakers.surf.domain.board.entity.BoardType;
@@ -58,8 +57,6 @@ class CommentUsecaseTest {
 
     private Member member(long id, String name) {
         Member member = Member.builder()
-                .provider(Provider.KAKAO)
-                .providerId("provider-" + id)
                 .name(name)
                 .status(MemberStatus.APPROVED)
                 .role(MemberRole.MEMBER)

--- a/src/test/java/com/tavemakers/surf/application/letter/usecase/LetterUsecaseCreateLetterTest.java
+++ b/src/test/java/com/tavemakers/surf/application/letter/usecase/LetterUsecaseCreateLetterTest.java
@@ -1,6 +1,5 @@
 package com.tavemakers.surf.application.letter.usecase;
 
-import com.tavemakers.surf.domain.auth.common.enums.Provider;
 import com.tavemakers.surf.presentation.letter.dto.request.LetterCreateReqDTO;
 import com.tavemakers.surf.presentation.letter.dto.response.LetterResDTO;
 import com.tavemakers.surf.domain.letter.event.LetterSentEvent;
@@ -150,9 +149,6 @@ class LetterUsecaseCreateLetterTest {
 
     private Member persistMember(String prefix) {
         Member member = Member.builder()
-                .provider(Provider.KAKAO)
-                .providerId(String.valueOf(System.nanoTime()))
-                .kakaoId(System.nanoTime())
                 .name("회원")
                 .email(prefix + System.nanoTime() + "@test.com")
                 .phoneNumber(String.valueOf(System.nanoTime()))

--- a/src/test/java/com/tavemakers/surf/application/member/usecase/MemberDismissCompletenessTest.java
+++ b/src/test/java/com/tavemakers/surf/application/member/usecase/MemberDismissCompletenessTest.java
@@ -1,6 +1,5 @@
 package com.tavemakers.surf.application.member.usecase;
 
-import com.tavemakers.surf.domain.auth.common.enums.Provider;
 import com.tavemakers.surf.domain.badge.event.BadgeMemberDismissListener;
 import com.tavemakers.surf.domain.badge.entity.Badge;
 import com.tavemakers.surf.domain.badge.entity.MemberBadge;
@@ -263,9 +262,6 @@ class MemberDismissCompletenessTest {
 
     private Member persistMember(String prefix) {
         Member member = Member.builder()
-                .provider(Provider.KAKAO)
-                .providerId(String.valueOf(System.nanoTime()))
-                .kakaoId(System.nanoTime())
                 .name("회원")
                 .email(prefix + System.nanoTime() + "@test.com")
                 .phoneNumber(String.valueOf(System.nanoTime()))

--- a/src/test/java/com/tavemakers/surf/application/member/usecase/MemberDismissRollbackTest.java
+++ b/src/test/java/com/tavemakers/surf/application/member/usecase/MemberDismissRollbackTest.java
@@ -1,6 +1,5 @@
 package com.tavemakers.surf.application.member.usecase;
 
-import com.tavemakers.surf.domain.auth.common.enums.Provider;
 import com.tavemakers.surf.domain.badge.event.BadgeMemberDismissListener;
 import com.tavemakers.surf.domain.badge.entity.Badge;
 import com.tavemakers.surf.domain.badge.entity.MemberBadge;
@@ -219,9 +218,6 @@ class MemberDismissRollbackTest {
 
     private Member persistMember(String prefix) {
         Member member = Member.builder()
-                .provider(Provider.KAKAO)
-                .providerId(String.valueOf(System.nanoTime()))
-                .kakaoId(System.nanoTime())
                 .name("회원")
                 .email(prefix + System.nanoTime() + "@test.com")
                 .phoneNumber(String.valueOf(System.nanoTime()))

--- a/src/test/java/com/tavemakers/surf/application/member/usecase/MemberDismissTeamCleanupTest.java
+++ b/src/test/java/com/tavemakers/surf/application/member/usecase/MemberDismissTeamCleanupTest.java
@@ -1,6 +1,5 @@
 package com.tavemakers.surf.application.member.usecase;
 
-import com.tavemakers.surf.domain.auth.common.enums.Provider;
 import com.tavemakers.surf.domain.comment.service.CommentDeleteService;
 import com.tavemakers.surf.domain.comment.service.CommentLikeService;
 import com.tavemakers.surf.domain.member.entity.Member;
@@ -189,9 +188,6 @@ class MemberDismissTeamCleanupTest {
 
     private Member persistMember(String prefix) {
         Member member = Member.builder()
-                .provider(Provider.KAKAO)
-                .providerId(String.valueOf(System.nanoTime()))
-                .kakaoId(System.nanoTime())
                 .name("회원")
                 .email(prefix + System.nanoTime() + "@test.com")
                 .phoneNumber(String.valueOf(System.nanoTime()))

--- a/src/test/java/com/tavemakers/surf/application/reservation/task/PostPublishRunnerRaceTest.java
+++ b/src/test/java/com/tavemakers/surf/application/reservation/task/PostPublishRunnerRaceTest.java
@@ -1,6 +1,5 @@
 package com.tavemakers.surf.application.reservation.task;
 
-import com.tavemakers.surf.domain.auth.common.enums.Provider;
 import com.tavemakers.surf.domain.board.entity.Board;
 import com.tavemakers.surf.domain.board.entity.BoardCategory;
 import com.tavemakers.surf.domain.board.entity.BoardType;
@@ -132,9 +131,6 @@ class PostPublishRunnerRaceTest {
 
     private Member persistMember(String email) {
         Member member = Member.builder()
-                .provider(Provider.KAKAO)
-                .providerId(String.valueOf(System.nanoTime()))
-                .kakaoId(System.nanoTime())
                 .name("회원")
                 .email(email)
                 .status(MemberStatus.APPROVED)

--- a/src/test/java/com/tavemakers/surf/application/reservation/usecase/ReservationUpdateConcurrencyTest.java
+++ b/src/test/java/com/tavemakers/surf/application/reservation/usecase/ReservationUpdateConcurrencyTest.java
@@ -1,6 +1,5 @@
 package com.tavemakers.surf.application.reservation.usecase;
 
-import com.tavemakers.surf.domain.auth.common.enums.Provider;
 import com.tavemakers.surf.domain.board.entity.Board;
 import com.tavemakers.surf.domain.board.entity.BoardCategory;
 import com.tavemakers.surf.domain.board.entity.BoardType;
@@ -130,9 +129,6 @@ class ReservationUpdateConcurrencyTest {
 
     private Member persistMember(String email) {
         Member member = Member.builder()
-                .provider(Provider.KAKAO)
-                .providerId(String.valueOf(System.nanoTime()))
-                .kakaoId(System.nanoTime())
                 .name("회원")
                 .email(email)
                 .status(MemberStatus.APPROVED)

--- a/src/test/java/com/tavemakers/surf/application/score/query/PersonalScoreConcurrencyTest.java
+++ b/src/test/java/com/tavemakers/surf/application/score/query/PersonalScoreConcurrencyTest.java
@@ -1,7 +1,6 @@
 package com.tavemakers.surf.application.score.query;
 
 import com.tavemakers.surf.domain.activity.entity.enums.ScoreType;
-import com.tavemakers.surf.domain.auth.common.enums.Provider;
 import com.tavemakers.surf.domain.member.entity.Member;
 import com.tavemakers.surf.domain.member.entity.enums.MemberRole;
 import com.tavemakers.surf.domain.member.entity.enums.MemberStatus;
@@ -77,9 +76,6 @@ class PersonalScoreConcurrencyTest {
 
     private Member persistMember(String email) {
         Member member = Member.builder()
-                .provider(Provider.KAKAO)
-                .providerId(String.valueOf(System.nanoTime()))
-                .kakaoId(System.nanoTime())
                 .name("회원")
                 .email(email)
                 .status(MemberStatus.APPROVED)

--- a/src/test/java/com/tavemakers/surf/domain/badge/service/MemberBadgeAssignConcurrencyTest.java
+++ b/src/test/java/com/tavemakers/surf/domain/badge/service/MemberBadgeAssignConcurrencyTest.java
@@ -1,6 +1,5 @@
 package com.tavemakers.surf.domain.badge.service;
 
-import com.tavemakers.surf.domain.auth.common.enums.Provider;
 import com.tavemakers.surf.domain.badge.entity.Badge;
 import com.tavemakers.surf.domain.badge.exception.MemberBadgeAlreadyExistsException;
 import com.tavemakers.surf.domain.badge.repository.MemberBadgeRepository;
@@ -104,9 +103,6 @@ class MemberBadgeAssignConcurrencyTest {
 
     private Member persistMember(String email) {
         Member member = Member.builder()
-                .provider(Provider.KAKAO)
-                .providerId(String.valueOf(System.nanoTime()))
-                .kakaoId(System.nanoTime())
                 .name("회원")
                 .email(email)
                 .status(MemberStatus.APPROVED)

--- a/src/test/java/com/tavemakers/surf/domain/comment/repository/CommentDuplicateQueryTest.java
+++ b/src/test/java/com/tavemakers/surf/domain/comment/repository/CommentDuplicateQueryTest.java
@@ -1,6 +1,5 @@
 package com.tavemakers.surf.domain.comment.repository;
 
-import com.tavemakers.surf.domain.auth.common.enums.Provider;
 import com.tavemakers.surf.domain.board.entity.Board;
 import com.tavemakers.surf.domain.board.entity.BoardCategory;
 import com.tavemakers.surf.domain.board.entity.BoardType;
@@ -109,9 +108,6 @@ class CommentDuplicateQueryTest {
     private Member persistMember(String prefix) {
         long seed = System.nanoTime();
         Member member = Member.builder()
-                .provider(Provider.KAKAO)
-                .providerId(prefix + seed)
-                .kakaoId(seed)
                 .name("회원")
                 .email(prefix + seed + "@test.com")
                 .phoneNumber(String.valueOf(seed))

--- a/src/test/java/com/tavemakers/surf/domain/comment/service/CommentDeleteServiceTest.java
+++ b/src/test/java/com/tavemakers/surf/domain/comment/service/CommentDeleteServiceTest.java
@@ -1,6 +1,5 @@
 package com.tavemakers.surf.domain.comment.service;
 
-import com.tavemakers.surf.domain.auth.common.enums.Provider;
 import com.tavemakers.surf.domain.board.entity.Board;
 import com.tavemakers.surf.domain.board.entity.BoardCategory;
 import com.tavemakers.surf.domain.board.entity.BoardType;
@@ -57,8 +56,6 @@ class CommentDeleteServiceTest {
 
     private Member member(long id) {
         Member member = Member.builder()
-                .provider(Provider.KAKAO)
-                .providerId("provider-" + id)
                 .name("회원" + id)
                 .status(MemberStatus.APPROVED)
                 .role(MemberRole.MEMBER)

--- a/src/test/java/com/tavemakers/surf/domain/comment/service/CommentLikeConcurrencyTest.java
+++ b/src/test/java/com/tavemakers/surf/domain/comment/service/CommentLikeConcurrencyTest.java
@@ -3,7 +3,6 @@ package com.tavemakers.surf.domain.comment.service;
 import com.tavemakers.surf.domain.board.entity.Board;
 import com.tavemakers.surf.domain.board.entity.BoardCategory;
 import com.tavemakers.surf.domain.board.entity.BoardType;
-import com.tavemakers.surf.domain.auth.common.enums.Provider;
 import com.tavemakers.surf.domain.comment.entity.Comment;
 import com.tavemakers.surf.domain.comment.exception.CommentLikeAlreadyExistsException;
 import com.tavemakers.surf.domain.member.entity.Member;
@@ -135,9 +134,6 @@ class CommentLikeConcurrencyTest {
 
     private Member persistMember(String email) {
         Member member = Member.builder()
-                .provider(Provider.KAKAO)
-                .providerId(String.valueOf(System.nanoTime()))
-                .kakaoId(System.nanoTime())
                 .name("회원")
                 .email(email)
                 .status(MemberStatus.APPROVED)

--- a/src/test/java/com/tavemakers/surf/domain/comment/service/CommentLikeServiceTest.java
+++ b/src/test/java/com/tavemakers/surf/domain/comment/service/CommentLikeServiceTest.java
@@ -1,6 +1,5 @@
 package com.tavemakers.surf.domain.comment.service;
 
-import com.tavemakers.surf.domain.auth.common.enums.Provider;
 import com.tavemakers.surf.domain.board.entity.Board;
 import com.tavemakers.surf.domain.board.entity.BoardCategory;
 import com.tavemakers.surf.domain.board.entity.BoardType;
@@ -71,8 +70,6 @@ class CommentLikeServiceTest {
 
     private Member member(long id) {
         Member member = Member.builder()
-                .provider(Provider.KAKAO)
-                .providerId("provider-" + id)
                 .name("회원" + id)
                 .status(MemberStatus.APPROVED)
                 .role(MemberRole.MEMBER)

--- a/src/test/java/com/tavemakers/surf/domain/comment/service/CommentMentionServiceTest.java
+++ b/src/test/java/com/tavemakers/surf/domain/comment/service/CommentMentionServiceTest.java
@@ -1,6 +1,5 @@
 package com.tavemakers.surf.domain.comment.service;
 
-import com.tavemakers.surf.domain.auth.common.enums.Provider;
 import com.tavemakers.surf.domain.board.entity.Board;
 import com.tavemakers.surf.domain.board.entity.BoardCategory;
 import com.tavemakers.surf.domain.board.entity.BoardType;
@@ -51,8 +50,6 @@ class CommentMentionServiceTest {
 
     private Member member(long id) {
         Member member = Member.builder()
-                .provider(Provider.KAKAO)
-                .providerId("provider-" + id)
                 .name("회원" + id)
                 .status(MemberStatus.APPROVED)
                 .role(MemberRole.MEMBER)

--- a/src/test/java/com/tavemakers/surf/domain/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/tavemakers/surf/domain/comment/service/CommentServiceTest.java
@@ -1,6 +1,5 @@
 package com.tavemakers.surf.domain.comment.service;
 
-import com.tavemakers.surf.domain.auth.common.enums.Provider;
 import com.tavemakers.surf.domain.board.entity.Board;
 import com.tavemakers.surf.domain.board.entity.BoardCategory;
 import com.tavemakers.surf.domain.board.entity.BoardType;
@@ -96,8 +95,6 @@ class CommentServiceTest {
 
     private Member member(long id, String name) {
         Member member = Member.builder()
-                .provider(Provider.KAKAO)
-                .providerId("provider-" + id)
                 .name(name)
                 .status(MemberStatus.APPROVED)
                 .role(MemberRole.MEMBER)

--- a/src/test/java/com/tavemakers/surf/domain/member/entity/MemberGenerationStatusSyncTest.java
+++ b/src/test/java/com/tavemakers/surf/domain/member/entity/MemberGenerationStatusSyncTest.java
@@ -12,7 +12,6 @@ class MemberGenerationStatusSyncTest {
 
     private Member createMember(MemberType memberType, boolean activityStatus) {
         return Member.builder()
-                .kakaoId(987654321L)
                 .name("기수동기화테스트")
                 .email("generation@test.com")
                 .status(MemberStatus.APPROVED)

--- a/src/test/java/com/tavemakers/surf/domain/member/entity/MemberTermsAgreementTest.java
+++ b/src/test/java/com/tavemakers/surf/domain/member/entity/MemberTermsAgreementTest.java
@@ -12,7 +12,6 @@ class MemberTermsAgreementTest {
 
     private Member createMember() {
         return Member.builder()
-                .kakaoId(123456789L)
                 .name("테스트유저")
                 .email("test@test.com")
                 .status(MemberStatus.APPROVED)

--- a/src/test/java/com/tavemakers/surf/domain/member/service/MemberBlacklistCreateServiceTest.java
+++ b/src/test/java/com/tavemakers/surf/domain/member/service/MemberBlacklistCreateServiceTest.java
@@ -1,6 +1,5 @@
 package com.tavemakers.surf.domain.member.service;
 
-import com.tavemakers.surf.domain.auth.common.enums.Provider;
 import com.tavemakers.surf.domain.member.entity.Member;
 import com.tavemakers.surf.domain.member.entity.MemberBlacklist;
 import com.tavemakers.surf.domain.member.entity.enums.MemberBlacklistActionType;
@@ -36,8 +35,6 @@ class MemberBlacklistCreateServiceTest {
 
     private Member member(String email, String phone) {
         Member member = Member.builder()
-                .provider(Provider.KAKAO)
-                .providerId("legacy-1")
                 .name("회원")
                 .email(email)
                 .phoneNumber(phone)

--- a/src/test/java/com/tavemakers/surf/domain/member/service/MemberDisconnectedEventCommitTest.java
+++ b/src/test/java/com/tavemakers/surf/domain/member/service/MemberDisconnectedEventCommitTest.java
@@ -75,8 +75,6 @@ class MemberDisconnectedEventCommitTest {
         TransactionTemplate tx = new TransactionTemplate(transactionManager);
         return tx.execute(status -> {
             Member member = Member.builder()
-                    .provider(Provider.KAKAO)
-                    .providerId("legacy-" + System.nanoTime())
                     .name("회원")
                     .email("commit" + System.nanoTime() + "@test.com")
                     .status(MemberStatus.APPROVED)

--- a/src/test/java/com/tavemakers/surf/domain/member/service/MemberGenerationSyncServiceTest.java
+++ b/src/test/java/com/tavemakers/surf/domain/member/service/MemberGenerationSyncServiceTest.java
@@ -29,7 +29,6 @@ class MemberGenerationSyncServiceTest {
 
     private Member createApprovedMember(String email) {
         return Member.builder()
-                .kakaoId(System.nanoTime())
                 .name("승인회원")
                 .email(email)
                 .status(MemberStatus.APPROVED)

--- a/src/test/java/com/tavemakers/surf/domain/member/service/MemberUpsertServiceBlacklistTest.java
+++ b/src/test/java/com/tavemakers/surf/domain/member/service/MemberUpsertServiceBlacklistTest.java
@@ -45,8 +45,6 @@ class MemberUpsertServiceBlacklistTest {
     /** 온보딩 완료(APPROVED) 회원 — 통합 이메일/전화번호 보유. */
     private Member approvedMember(String email, String phone) {
         Member member = Member.builder()
-                .provider(Provider.KAKAO)
-                .providerId("legacy-" + System.nanoTime())
                 .name("기존회원")
                 .email(email)
                 .phoneNumber(phone)

--- a/src/test/java/com/tavemakers/surf/domain/member/service/MemberWithdrawServiceTest.java
+++ b/src/test/java/com/tavemakers/surf/domain/member/service/MemberWithdrawServiceTest.java
@@ -37,8 +37,6 @@ class MemberWithdrawServiceTest {
 
     private Member approvedMember(Long id, SocialAccount... socialAccounts) {
         Member member = Member.builder()
-                .provider(Provider.KAKAO) // 레거시 컬럼(Phase 6 제거 예정) — 스냅샷 캡처와 무관
-                .providerId("legacy-" + id)
                 .name("홍길동")
                 .email("hong" + id + "@test.com")
                 .status(MemberStatus.APPROVED)
@@ -155,8 +153,6 @@ class MemberWithdrawServiceTest {
     @DisplayName("expel — 이미 WITHDRAWN 상태면 연결 해제 이벤트는 발행하되 withdraw()는 다시 수행하지 않는다")
     void expel_whenAlreadyWithdrawn_skipsWithdrawButStillDisconnects() {
         Member member = Member.builder()
-                .provider(Provider.KAKAO)
-                .providerId("legacy-11")
                 .name("홍길동")
                 .email("hong2@test.com")
                 .status(MemberStatus.WITHDRAWN)

--- a/src/test/java/com/tavemakers/surf/domain/post/entity/PostContentLongTextTest.java
+++ b/src/test/java/com/tavemakers/surf/domain/post/entity/PostContentLongTextTest.java
@@ -1,6 +1,5 @@
 package com.tavemakers.surf.domain.post.entity;
 
-import com.tavemakers.surf.domain.auth.common.enums.Provider;
 import com.tavemakers.surf.domain.board.entity.Board;
 import com.tavemakers.surf.domain.board.entity.BoardCategory;
 import com.tavemakers.surf.domain.board.entity.BoardType;
@@ -39,9 +38,6 @@ class PostContentLongTextTest {
     void setUp() {
         // Member 생성
         member = Member.builder()
-                .provider(Provider.KAKAO)
-                .providerId("longtext-test-123456789")
-                .kakaoId(123456789L)
                 .name("테스트유저")
                 .email("test@test.com")
                 .phoneNumber("01000000000")

--- a/src/test/java/com/tavemakers/surf/domain/post/repository/PostSearchInBoardQueryTest.java
+++ b/src/test/java/com/tavemakers/surf/domain/post/repository/PostSearchInBoardQueryTest.java
@@ -1,6 +1,5 @@
 package com.tavemakers.surf.domain.post.repository;
 
-import com.tavemakers.surf.domain.auth.common.enums.Provider;
 import com.tavemakers.surf.domain.board.entity.Board;
 import com.tavemakers.surf.domain.board.entity.BoardCategory;
 import com.tavemakers.surf.domain.board.entity.BoardType;
@@ -96,9 +95,6 @@ class PostSearchInBoardQueryTest {
     private Member persistMember(String prefix) {
         long seed = System.nanoTime();
         Member member = Member.builder()
-                .provider(Provider.KAKAO)
-                .providerId(prefix + seed)
-                .kakaoId(seed)
                 .name("회원")
                 .email(prefix + seed + "@test.com")
                 .phoneNumber(String.valueOf(seed))

--- a/src/test/java/com/tavemakers/surf/domain/post/service/like/PostBodyEditCountPreservationTest.java
+++ b/src/test/java/com/tavemakers/surf/domain/post/service/like/PostBodyEditCountPreservationTest.java
@@ -1,6 +1,5 @@
 package com.tavemakers.surf.domain.post.service.like;
 
-import com.tavemakers.surf.domain.auth.common.enums.Provider;
 import com.tavemakers.surf.domain.board.entity.Board;
 import com.tavemakers.surf.domain.board.entity.BoardCategory;
 import com.tavemakers.surf.domain.board.entity.BoardType;
@@ -147,9 +146,6 @@ class PostBodyEditCountPreservationTest {
 
     private Member persistMember(String email) {
         Member member = Member.builder()
-                .provider(Provider.KAKAO)
-                .providerId(String.valueOf(System.nanoTime()))
-                .kakaoId(System.nanoTime())
                 .name("회원")
                 .email(email)
                 .status(MemberStatus.APPROVED)

--- a/src/test/java/com/tavemakers/surf/domain/post/service/like/PostLikeConcurrencyTest.java
+++ b/src/test/java/com/tavemakers/surf/domain/post/service/like/PostLikeConcurrencyTest.java
@@ -1,6 +1,5 @@
 package com.tavemakers.surf.domain.post.service.like;
 
-import com.tavemakers.surf.domain.auth.common.enums.Provider;
 import com.tavemakers.surf.domain.board.entity.Board;
 import com.tavemakers.surf.domain.board.entity.BoardCategory;
 import com.tavemakers.surf.domain.board.entity.BoardType;
@@ -121,9 +120,6 @@ class PostLikeConcurrencyTest {
 
     private Member persistMember(String email) {
         Member member = Member.builder()
-                .provider(Provider.KAKAO)
-                .providerId(String.valueOf(System.nanoTime()))
-                .kakaoId(System.nanoTime())
                 .name("회원")
                 .email(email)
                 .status(MemberStatus.APPROVED)

--- a/src/test/java/com/tavemakers/surf/domain/post/service/support/PostCommentCountConcurrencyTest.java
+++ b/src/test/java/com/tavemakers/surf/domain/post/service/support/PostCommentCountConcurrencyTest.java
@@ -1,6 +1,5 @@
 package com.tavemakers.surf.domain.post.service.support;
 
-import com.tavemakers.surf.domain.auth.common.enums.Provider;
 import com.tavemakers.surf.domain.board.entity.Board;
 import com.tavemakers.surf.domain.board.entity.BoardCategory;
 import com.tavemakers.surf.domain.board.entity.BoardType;
@@ -83,9 +82,6 @@ class PostCommentCountConcurrencyTest {
 
     private Member persistMember(String email) {
         Member member = Member.builder()
-                .provider(Provider.KAKAO)
-                .providerId(String.valueOf(System.nanoTime()))
-                .kakaoId(System.nanoTime())
                 .name("회원")
                 .email(email)
                 .status(MemberStatus.APPROVED)

--- a/src/test/java/com/tavemakers/surf/domain/scrap/service/ScrapAddConcurrencyTest.java
+++ b/src/test/java/com/tavemakers/surf/domain/scrap/service/ScrapAddConcurrencyTest.java
@@ -1,6 +1,5 @@
 package com.tavemakers.surf.domain.scrap.service;
 
-import com.tavemakers.surf.domain.auth.common.enums.Provider;
 import com.tavemakers.surf.domain.board.entity.Board;
 import com.tavemakers.surf.domain.board.entity.BoardCategory;
 import com.tavemakers.surf.domain.board.entity.BoardType;
@@ -138,9 +137,6 @@ class ScrapAddConcurrencyTest {
 
     private Member persistMember(String email) {
         Member member = Member.builder()
-                .provider(Provider.KAKAO)
-                .providerId(String.valueOf(System.nanoTime()))
-                .kakaoId(System.nanoTime())
                 .name("회원")
                 .email(email)
                 .status(MemberStatus.APPROVED)

--- a/src/test/java/com/tavemakers/surf/domain/team/service/TeamDeleteCleanupTest.java
+++ b/src/test/java/com/tavemakers/surf/domain/team/service/TeamDeleteCleanupTest.java
@@ -1,6 +1,5 @@
 package com.tavemakers.surf.domain.team.service;
 
-import com.tavemakers.surf.domain.auth.common.enums.Provider;
 import com.tavemakers.surf.application.member.query.MemberGetService;
 import com.tavemakers.surf.application.member.query.TrackGetService;
 import com.tavemakers.surf.domain.member.entity.Member;
@@ -118,9 +117,6 @@ class TeamDeleteCleanupTest {
 
     private Member persistMember(String prefix) {
         Member member = Member.builder()
-                .provider(Provider.KAKAO)
-                .providerId(String.valueOf(System.nanoTime()))
-                .kakaoId(System.nanoTime())
                 .name("회원")
                 .email(prefix + System.nanoTime() + "@test.com")
                 .phoneNumber(String.valueOf(System.nanoTime()))

--- a/src/test/java/com/tavemakers/surf/e2e/E2ESupport.java
+++ b/src/test/java/com/tavemakers/surf/e2e/E2ESupport.java
@@ -3,6 +3,7 @@ package com.tavemakers.surf.e2e;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.tavemakers.surf.domain.auth.common.enums.Provider;
 import com.tavemakers.surf.domain.member.entity.Member;
+import com.tavemakers.surf.domain.member.entity.SocialAccount;
 import com.tavemakers.surf.domain.member.entity.enums.MemberRole;
 import com.tavemakers.surf.domain.member.entity.enums.MemberStatus;
 import com.tavemakers.surf.domain.member.entity.enums.MemberType;
@@ -86,13 +87,10 @@ public abstract class E2ESupport {
     @MockBean
     protected JavaMailSender javaMailSender;
 
-    /** 승인 상태의 회원을 실제 DB에 저장한다(카카오 provider). */
+    /** 승인 상태의 회원을 카카오 SocialAccount 연결과 함께 실제 DB에 저장한다 (실 데이터와 동일한 형태). */
     protected Member persistMember(MemberRole role) {
         long seq = PROVIDER_SEQ.getAndIncrement();
         Member member = Member.builder()
-                .provider(Provider.KAKAO)
-                .providerId("e2e-provider-" + seq)
-                .kakaoId(900000L + seq)
                 .name("E2E회원" + seq)
                 .email("e2e" + seq + "@surf.local")
                 .phoneNumber("0101000" + String.format("%04d", seq))
@@ -102,6 +100,11 @@ public abstract class E2ESupport {
                 .memberType(MemberType.YB)
                 .activityStatus(true)
                 .build();
+        member.addSocialAccount(SocialAccount.builder()
+                .provider(Provider.KAKAO)
+                .providerId("e2e-provider-" + seq)
+                .kakaoId(900000L + seq)
+                .build());
         Member saved = memberRepository.save(member);
         memberRepository.flush();
         return saved;

--- a/src/test/java/com/tavemakers/surf/infrastructure/post/repository/PostJdbcRepositoryTest.java
+++ b/src/test/java/com/tavemakers/surf/infrastructure/post/repository/PostJdbcRepositoryTest.java
@@ -1,6 +1,5 @@
 package com.tavemakers.surf.infrastructure.post.repository;
 
-import com.tavemakers.surf.domain.auth.common.enums.Provider;
 import com.tavemakers.surf.domain.board.entity.Board;
 import com.tavemakers.surf.domain.board.entity.BoardCategory;
 import com.tavemakers.surf.domain.board.entity.BoardType;
@@ -55,9 +54,6 @@ class PostJdbcRepositoryTest {
         entityManager.persist(category);
 
         Member author = Member.builder()
-                .provider(Provider.KAKAO)
-                .providerId(String.valueOf(System.nanoTime()))
-                .kakaoId(System.nanoTime())
                 .name("회원")
                 .email("author" + System.nanoTime() + "@test.com")
                 .status(MemberStatus.APPROVED)


### PR DESCRIPTION
## 개요

소셜 로그인 통합 Phase 6 (docs/social-login-integration-plan.md §3.2 / Phase 6) — `Member`의 소셜 레거시 필드를 완전히 제거하고, provider 식별자·unlink/revoke 데이터의 유일한 정규 저장소를 `SocialAccount`로 확정한다.

Related to #348
Stacked on #352 (Phase 5)

## 주요 변경

### Member 엔티티
- `provider` / `providerId` / `kakaoId`(@Deprecated) / `appleRefreshToken` 필드 제거
- `uk_member_provider_provider_id` 유니크 제약 제거 (Phase 1에서 `social_account`로 이관 완료)
- builder·`createRegisteringFromOAuth` 팩토리에서 레거시 인자 제거 — provider 검증·식별은 `SocialAccount.createFromOAuth`가 전담
- `anonymizeOnWithdraw()`의 provider 초기화 제거 — 소셜 정리는 `withdraw()`의 `socialAccounts.clear()`(orphanRemoval)가 전담
- `updateAppleRefreshToken(Member)` 제거

### 이중 저장/잔여 참조 제거
- `AppleLoginUsecase`: Apple refresh_token을 SocialAccount에만 저장 (Member 이중 저장 제거)
- `SecurityUtils.getCurrentKakaoId()` 제거 (호출부 없음)
- `rg` 검증: `getKakaoId`/`getAppleRefreshToken`/`uk_member_provider_provider_id` 등 제거 대상 참조가 main 코드에 남아 있지 않음 (잔여 히트는 모두 `SocialAccount` 기준 — 정규 저장소)

### 테스트 fixture 전환
- 전 테스트의 `Member.builder()` 레거시 세터(`provider`/`providerId`/`kakaoId`) 제거
- 의미 있는 fixture(로그인·탈퇴·E2E)는 **Member + SocialAccount 조합**으로 전환 — `E2ESupport.persistMember`가 카카오 SocialAccount를 함께 저장해 실 데이터 형태 유지

## 검증

- 전체 테스트 `BUILD SUCCESSFUL` — Kakao/Apple Web/App 로그인(usecase 테스트), 기존/신규 회원 upsert, 온보딩 case A/B/C(`MemberServiceTest`·`OnboardingAccountValidatorTest`), 계정 통합 성공/거부(`SocialAccountIntegrateUsecaseTest`), 다중 계정 탈퇴(`MemberWithdrawServiceTest`·`MemberDisconnectedEventCommitTest`), 재가입(`WithdrawnMemberRejoinTest`), expel/dismiss(`MemberDismiss*Test`) 포함
- ArchUnit R1~R8 (`CleanArchitectureRulesTest`) 통과 — freeze store 신규 부채 없음

---

## 🔀 병합 안내 (Stacked PR)

```
#351  feat/#348/계정-연동-api            → dev             (최상위)
#352  feat/#348/탈퇴-블랙리스트-정비       → 계정-연동-api    (선행 PR)
#353  refactor/#348/소셜-레거시-컬럼-정리  → 탈퇴-블랙리스트-정비 (본 PR)
```

- **병합 위치**: 본 PR은 반드시 `feat/#348/탈퇴-블랙리스트-정비` 로 병합한다. **dev 직접 병합 금지.**
- **선행 조건**: 본 PR은 **#352가 먼저 병합된 뒤에만** 병합한다. #352가 병합되지 않은 상태에서 병합하면 Phase 5 변경 없이 Phase 6만 반영되어 diff가 어긋난다.
- **병합 순서**: `#352 → #353(본 PR) → #351(dev)`.
- 본 PR 병합 후 `refactor/#348/소셜-레거시-컬럼-정리` 브랜치를 삭제하면 GitHub이 base를 자동 재지정할 수 있다 — **#351 병합 전 base가 `feat/#348/계정-연동-api`(또는 dev로 최종 병합되는 대상)와 일치하는지 확인**.
- 본 PR 병합만으로는 운영 반영이 아니다. **#351이 dev에 병합되고 운영 배포·안정화가 완료된 뒤**에 아래 쿼리를 실행한다.

## 🗃️ 운영 배포 후 실행 쿼리 — `member` 소셜 레거시 컬럼 DROP

> 원본: `docs/sql/phase6-drop-member-social-legacy-columns.sql` (저장소 `.gitignore`의 `/docs/` 규칙으로 로컬 보관)
>
> ⚠️⚠️ **비가역**: `DROP COLUMN`은 되돌릴 수 없다. 실행 전 반드시 `member` 테이블 백업을 확보한다.
>
> **실행 순서 전제**: [PR #352의 `member_blacklist.kakao_id` 제거 쿼리](https://github.com/Tave-Makers/SURF-BE/pull/352)가 먼저 적용되어 있어야 하며, 본 PR 코드가 **운영에 배포되어 안정화된 후**에만 실행한다. 구버전 인스턴스가 살아 있으면 실행 금지(즉시 SELECT/INSERT 실패).

### 1) 이관 검증 (중단 조건)

```sql
-- [중단 조건] 이관 누락 — 활성 회원인데 social_account에 대응 행이 없으면 0건이어야 한다
SELECT m.member_id, m.provider, m.provider_id
FROM member m
WHERE m.provider IS NOT NULL
  AND m.provider_id IS NOT NULL
  AND m.is_deleted = FALSE
  AND m.provider_id NOT LIKE 'withdrawn\_%'
  AND NOT EXISTS (
      SELECT 1 FROM social_account s
      WHERE s.provider = m.provider AND s.provider_id = m.provider_id
  );

-- [중단 조건] social_account (provider, provider_id) 중복 — 0건이어야 한다
SELECT provider, provider_id, COUNT(*) AS cnt
FROM social_account
GROUP BY provider, provider_id
HAVING COUNT(*) > 1;

-- [중단 조건] 회원-provider 중복(1 provider = 1 account 위반) — 0건이어야 한다
SELECT member_id, provider, COUNT(*) AS cnt
FROM social_account
GROUP BY member_id, provider
HAVING COUNT(*) > 1;

-- [중단 조건] apple_refresh_token 이관 누락 — 0건이 아니면 social_account로 백필 후 진행
SELECT m.member_id
FROM member m
WHERE m.apple_refresh_token IS NOT NULL
  AND m.is_deleted = FALSE
  AND NOT EXISTS (
      SELECT 1 FROM social_account s
      WHERE s.member_id = m.member_id
        AND s.provider = 'APPLE'
        AND s.apple_refresh_token IS NOT NULL
  );

-- [참고] 실제 유니크 제약 이름 확인 — 기대값과 다르면 아래 DROP에서 실제 이름 사용
SELECT DISTINCT index_name
FROM information_schema.statistics
WHERE table_schema = DATABASE()
  AND table_name = 'member'
  AND column_name IN ('provider', 'provider_id');
```

### 2) DDL (재실행 안전 — 존재할 때만 수행)

```sql
-- 유니크 제약 제거
SET @idx_exists := (
    SELECT COUNT(*) FROM information_schema.statistics
    WHERE table_schema = DATABASE() AND table_name = 'member'
      AND index_name = 'uk_member_provider_provider_id');
SET @ddl := IF(@idx_exists > 0,
    'ALTER TABLE member DROP INDEX uk_member_provider_provider_id', 'DO 0');
PREPARE stmt FROM @ddl; EXECUTE stmt; DEALLOCATE PREPARE stmt;

-- provider 컬럼 DROP
SET @col_exists := (SELECT COUNT(*) FROM information_schema.columns
    WHERE table_schema = DATABASE() AND table_name = 'member' AND column_name = 'provider');
SET @ddl := IF(@col_exists > 0, 'ALTER TABLE member DROP COLUMN provider', 'DO 0');
PREPARE stmt FROM @ddl; EXECUTE stmt; DEALLOCATE PREPARE stmt;

-- provider_id 컬럼 DROP
SET @col_exists := (SELECT COUNT(*) FROM information_schema.columns
    WHERE table_schema = DATABASE() AND table_name = 'member' AND column_name = 'provider_id');
SET @ddl := IF(@col_exists > 0, 'ALTER TABLE member DROP COLUMN provider_id', 'DO 0');
PREPARE stmt FROM @ddl; EXECUTE stmt; DEALLOCATE PREPARE stmt;

-- kakao_id 컬럼 DROP
SET @col_exists := (SELECT COUNT(*) FROM information_schema.columns
    WHERE table_schema = DATABASE() AND table_name = 'member' AND column_name = 'kakao_id');
SET @ddl := IF(@col_exists > 0, 'ALTER TABLE member DROP COLUMN kakao_id', 'DO 0');
PREPARE stmt FROM @ddl; EXECUTE stmt; DEALLOCATE PREPARE stmt;

-- apple_refresh_token 컬럼 DROP
SET @col_exists := (SELECT COUNT(*) FROM information_schema.columns
    WHERE table_schema = DATABASE() AND table_name = 'member' AND column_name = 'apple_refresh_token');
SET @ddl := IF(@col_exists > 0, 'ALTER TABLE member DROP COLUMN apple_refresh_token', 'DO 0');
PREPARE stmt FROM @ddl; EXECUTE stmt; DEALLOCATE PREPARE stmt;
```

### 3) 적용 확인

```sql
-- 0 이어야 한다
SELECT COUNT(*) AS legacy_columns_remaining
FROM information_schema.columns
WHERE table_schema = DATABASE()
  AND table_name = 'member'
  AND column_name IN ('provider', 'provider_id', 'kakao_id', 'apple_refresh_token');

-- social_account 정규 제약이 살아 있어야 한다 (각 1건 이상)
SELECT DISTINCT index_name
FROM information_schema.statistics
WHERE table_schema = DATABASE()
  AND table_name = 'social_account'
  AND index_name IN ('uk_social_provider_provider_id', 'uk_social_member_provider');

-- 실행 전과 동일해야 한다 (DROP COLUMN은 행을 지우지 않는다)
SELECT COUNT(*) AS total_members FROM member;
```

## ⚠️ 주의사항

- **비가역**: 위 DDL은 되돌릴 수 없다. 실행 전 `mysqldump` 또는 스냅샷으로 `member` 테이블 전체 백업을 확보한다.
- `ddl-auto=update`는 컬럼/제약을 DROP하지 않으므로 **수동 실행 필수**.
- 1)의 네 가지 중단 조건 중 **하나라도 0건이 아니면 실행을 멈추고** 원인(이관 누락, 중복, 미백필 Apple 토큰)을 먼저 해결한다.
- 활성 회원인데 `social_account`가 하나도 없는 경우(관리자 비밀번호 로그인 전용 계정 등)가 있는지 별도로 확인하고, 정당한 예외인지 검토한 뒤 진행한다.
- 완료 후 애플리케이션 재기동은 불필요(엔티티가 이미 컬럼을 참조하지 않음)하나, 로그인(Kakao/Apple × Web/App)·온보딩·계정 통합·탈퇴 경로 스모크 테스트를 권장한다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **변경 사항**
  * 회원의 소셜 로그인 식별 정보가 회원 정보와 분리되어 소셜 계정으로 관리됩니다.
  * 회원 탈퇴 시 소셜 계정 정보가 정리되어 연결 해제 및 토큰 폐기가 일관되게 처리됩니다.
  * 현재 로그인한 회원을 회원 ID로 조회하는 인증 유틸리티가 제공됩니다.
  * 소셜 로그인 기반 회원 생성 및 관련 테스트가 변경된 계정 관리 방식에 맞게 정비되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->