### PR TITLE
[FEAT] 계정 통합 대상 조회 API 구현

### DIFF
--- a/src/main/java/com/tavemakers/surf/application/member/query/IntegrationTargetGetService.java
+++ b/src/main/java/com/tavemakers/surf/application/member/query/IntegrationTargetGetService.java
@@ -1,0 +1,108 @@
+package com.tavemakers.surf.application.member.query;
+
+import com.tavemakers.surf.domain.member.entity.Member;
+import com.tavemakers.surf.domain.member.entity.PendingSocialIntegration;
+import com.tavemakers.surf.domain.member.entity.SocialAccount;
+import com.tavemakers.surf.domain.member.entity.enums.MemberStatus;
+import com.tavemakers.surf.domain.member.exception.IntegrationNotEligibleException;
+import com.tavemakers.surf.domain.member.exception.PendingIntegrationExpiredException;
+import com.tavemakers.surf.domain.member.exception.PendingIntegrationNotFoundException;
+import com.tavemakers.surf.domain.member.repository.PendingSocialIntegrationRepository;
+import com.tavemakers.surf.domain.member.repository.SocialAccountRepository;
+import com.tavemakers.surf.presentation.member.dto.response.IntegrationTargetResDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/** 임시 회원의 계정 통합 대상을 조회한다. */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class IntegrationTargetGetService {
+
+    private final PendingSocialIntegrationRepository pendingSocialIntegrationRepository;
+    private final SocialAccountRepository socialAccountRepository;
+    private final MemberGetService memberGetService;
+
+    /** 임시 회원의 소셜 계정에 연결된 통합 대상을 조회한다. */
+    public IntegrationTargetResDTO getIntegrationTarget(Long tempMemberId) {
+        Member tempMember = memberGetService.getMember(tempMemberId);
+        validateRegisteringMember(tempMember);
+
+        SocialAccount ownedAccount = findSingleSocialAccount(tempMemberId);
+        PendingSocialIntegration pending = getPendingIntegration(ownedAccount.getId());
+        validatePendingContext(tempMemberId, ownedAccount, pending);
+
+        if (pending.isExpired(LocalDateTime.now())) {
+            throw new PendingIntegrationExpiredException();
+        }
+
+        // 확장 배포 중 구버전에서 생성한 대상 미기록 행은 통합할 수 없다.
+        if (!pending.hasTargetMember()) {
+            throw new IntegrationNotEligibleException();
+        }
+
+        Member target = memberGetService.getMember(pending.getTargetMemberId());
+        List<SocialAccount> targetSocialAccounts = socialAccountRepository.findAllByMemberId(target.getId());
+        validateEligibleTarget(pending, target, targetSocialAccounts);
+
+        return IntegrationTargetResDTO.of(pending, target, targetSocialAccounts);
+    }
+
+    /** 인증 회원이 온보딩 이전 상태인지 검증한다. */
+    private void validateRegisteringMember(Member tempMember) {
+        if (!tempMember.isRegistering()) {
+            throw new IntegrationNotEligibleException();
+        }
+    }
+
+    /** 임시 회원이 단독으로 보유한 소셜 계정을 조회한다. */
+    private SocialAccount findSingleSocialAccount(Long tempMemberId) {
+        List<SocialAccount> accounts = socialAccountRepository.findAllByMemberId(tempMemberId);
+        if (accounts.size() != 1) {
+            throw new IntegrationNotEligibleException();
+        }
+        return accounts.get(0);
+    }
+
+    /** 소셜 계정의 통합 대기 정보를 조회한다. */
+    private PendingSocialIntegration getPendingIntegration(Long socialAccountId) {
+        return pendingSocialIntegrationRepository.findBySocialAccountId(socialAccountId)
+                .orElseThrow(PendingIntegrationNotFoundException::new);
+    }
+
+    /** 통합 대기 정보가 인증 회원의 소셜 계정과 일치하는지 검증한다. */
+    private void validatePendingContext(
+            Long tempMemberId,
+            SocialAccount ownedAccount,
+            PendingSocialIntegration pending
+    ) {
+        if (!pending.getTempMemberId().equals(tempMemberId)
+                || ownedAccount.getProvider() != pending.getProvider()) {
+            throw new IntegrationNotEligibleException();
+        }
+    }
+
+    /** 대상 회원의 상태·연락처·소셜 계정이 통합 조건을 충족하는지 검증한다. */
+    private void validateEligibleTarget(
+            PendingSocialIntegration pending,
+            Member target,
+            List<SocialAccount> targetSocialAccounts
+    ) {
+        MemberStatus status = target.getStatus();
+        if (status != MemberStatus.WAITING && status != MemberStatus.APPROVED) {
+            throw new IntegrationNotEligibleException();
+        }
+        if (!pending.matchesContactInfo(target.getEmail(), target.getPhoneNumber())) {
+            throw new IntegrationNotEligibleException();
+        }
+        boolean alreadyLinked = targetSocialAccounts.stream()
+                .anyMatch(socialAccount -> socialAccount.getProvider() == pending.getProvider());
+        if (alreadyLinked) {
+            throw new IntegrationNotEligibleException();
+        }
+    }
+}

--- a/src/main/java/com/tavemakers/surf/application/member/query/IntegrationTargetGetService.java
+++ b/src/main/java/com/tavemakers/surf/application/member/query/IntegrationTargetGetService.java
@@ -49,7 +49,7 @@ public class IntegrationTargetGetService {
         List<SocialAccount> targetSocialAccounts = socialAccountRepository.findAllByMemberId(target.getId());
         validateEligibleTarget(pending, target, targetSocialAccounts);
 
-        return IntegrationTargetResDTO.of(pending, target, targetSocialAccounts);
+        return IntegrationTargetResDTO.from(pending, target, targetSocialAccounts);
     }
 
     /** 인증 회원이 온보딩 이전 상태인지 검증한다. */

--- a/src/main/java/com/tavemakers/surf/application/member/usecase/MemberUsecase.java
+++ b/src/main/java/com/tavemakers/surf/application/member/usecase/MemberUsecase.java
@@ -26,7 +26,6 @@ import com.tavemakers.surf.domain.member.service.MemberWithdrawService;
 import com.tavemakers.surf.application.score.query.PersonalScoreGetService;
 import com.tavemakers.surf.global.logging.LogEvent;
 import com.tavemakers.surf.global.logging.LogEventEmitter;
-import com.tavemakers.surf.global.logging.LogParam;
 import com.tavemakers.surf.global.util.SecurityUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -38,7 +37,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import com.tavemakers.surf.global.logging.LogEventEmitter;
 
 import java.math.BigDecimal;
 import java.time.Duration;
@@ -348,7 +346,7 @@ public class MemberUsecase {
         for (int attempt = 1; ; attempt++) {
             try {
                 return pendingIntegrationUsecase.issue(
-                        e.getTempMemberId(), e.getSocialAccountId(), e.getProvider(),
+                        e.getTempMemberId(), e.getSocialAccountId(), e.getTargetMemberId(), e.getProvider(),
                         e.getNormalizedEmail(), e.getNormalizedPhone());
             } catch (DataIntegrityViolationException | PessimisticLockingFailureException transientFailure) {
                 if (attempt >= ISSUE_MAX_ATTEMPTS) throw transientFailure;

--- a/src/main/java/com/tavemakers/surf/application/member/usecase/PendingIntegrationUsecase.java
+++ b/src/main/java/com/tavemakers/surf/application/member/usecase/PendingIntegrationUsecase.java
@@ -18,10 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDateTime;
 import java.util.Optional;
 
-/**
- * 통합 대기 row 발급 — 온보딩 case B 감지 시 호출된다.
- * 온보딩 트랜잭션은 감지 예외로 롤백되므로, pending row는 {@code REQUIRES_NEW}로 독립 커밋해야 살아남는다. (§3.6)
- */
+/** 온보딩 트랜잭션과 분리해 계정 통합 대기 정보를 발급한다. */
 @Service
 @RequiredArgsConstructor
 public class PendingIntegrationUsecase {
@@ -30,11 +27,11 @@ public class PendingIntegrationUsecase {
     private final MemberRepository memberRepository;
     private final SocialAccountRepository socialAccountRepository;
 
-    /** 온보딩 롤백과 독립적으로(REQUIRES_NEW) 통합 대기 row를 커밋하고 멱등 토큰을 반환한다 — 유효·동일 컨텍스트면 재사용, 아니면 재검증 후 재발급. (§3.6) */
+    /** 동일한 발급 요청은 기존 토큰을 반환하고 변경된 요청은 토큰을 재발급한다. */
     // READ_COMMITTED: 부재 pending 락 조회의 gap lock 데드락 회피
     @Transactional(propagation = Propagation.REQUIRES_NEW, isolation = Isolation.READ_COMMITTED)
-    public IssuedIntegrationToken issue(Long tempMemberId, Long socialAccountId, Provider provider,
-                                        String normalizedEmail, String normalizedPhone) {
+    public IssuedIntegrationToken issue(Long tempMemberId, Long socialAccountId, Long targetMemberId,
+                                        Provider provider, String normalizedEmail, String normalizedPhone) {
         LocalDateTime now = LocalDateTime.now();
 
         // 기존 pending 행 쓰기 락 — integrate·동시 발급과 직렬화
@@ -42,9 +39,9 @@ public class PendingIntegrationUsecase {
                 pendingSocialIntegrationRepository.findBySocialAccountIdForUpdate(socialAccountId);
         if (existing.isPresent()) {
             PendingSocialIntegration pending = existing.get();
-            // 유효·동일 컨텍스트면 그대로 반환(멱등). 연락처가 바뀐 재요청은 다른 명령이라 아래에서 교체한다
+            // 유효·동일 컨텍스트면 그대로 반환(멱등). 연락처·대상이 바뀐 재요청은 다른 명령이라 아래에서 교체한다
             if (!pending.isExpired(now)
-                    && pending.matchesContext(tempMemberId, provider, normalizedEmail, normalizedPhone)) {
+                    && pending.matchesContext(tempMemberId, targetMemberId, provider, normalizedEmail, normalizedPhone)) {
                 return new IssuedIntegrationToken(pending.getToken(), pending.getExpiresAt());
             }
             // 만료/컨텍스트 불일치 — 삭제를 먼저 flush해야 재발급 INSERT가 UNIQUE에 걸리지 않는다
@@ -57,12 +54,12 @@ public class PendingIntegrationUsecase {
 
         // 신규 발급 — 동시 발급의 UNIQUE 경쟁은 호출부 재시도로 수렴한다
         PendingSocialIntegration pending = PendingSocialIntegration.issue(
-                tempMemberId, socialAccountId, provider, normalizedEmail, normalizedPhone, now);
+                tempMemberId, socialAccountId, targetMemberId, provider, normalizedEmail, normalizedPhone, now);
         pendingSocialIntegrationRepository.saveAndFlush(pending);
         return new IssuedIntegrationToken(pending.getToken(), pending.getExpiresAt());
     }
 
-    /** 신규 pending 생성 전 재검증 — 임시 회원이 REGISTERING이고 SocialAccount 소유·provider가 일치하는지 확인해 좀비 pending을 막는다. */
+    /** 통합 대기 정보 생성 전 임시 회원과 소셜 계정의 이전 가능 여부를 검증한다. */
     private void revalidateTransferable(Long tempMemberId, Long socialAccountId, Provider provider) {
         Member tempMember = memberRepository.findWithLockingById(tempMemberId)
                 .orElseThrow(IntegrationNotEligibleException::new);

--- a/src/main/java/com/tavemakers/surf/application/member/usecase/SocialAccountIntegrateUsecase.java
+++ b/src/main/java/com/tavemakers/surf/application/member/usecase/SocialAccountIntegrateUsecase.java
@@ -25,10 +25,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 
-/**
- * 소셜 계정 통합(연동) — 기존 계정 로그인 권한으로 호출한다. (§3.6)
- * pending 토큰·email·phone·상태·provider·블랙리스트를 재검증하고, 신규 SocialAccount를 기존 회원으로 재연결한다.
- */
+/** 기존 회원에게 신규 소셜 계정을 통합한다. */
 @Service
 @RequiredArgsConstructor
 public class SocialAccountIntegrateUsecase {
@@ -42,10 +39,7 @@ public class SocialAccountIntegrateUsecase {
     private final MemberBlacklistGetService memberBlacklistGetService;
     private final ApplicationEventPublisher eventPublisher;
 
-    /**
-     * 기존 회원 로그인 권한으로 pending 토큰·연락처·상태·provider·블랙리스트를 재검증한 뒤 SocialAccount를 기존 회원에 재연결한다.
-     * 발급(issue) 부재 경로와의 lock 교차로 생기는 transient 데드락/락 타임아웃 재시도는 호출부(컨트롤러)가 담당한다.
-     */
+    /** 통합 조건을 검증하고 소셜 계정을 기존 회원에게 이전한다. */
     @Transactional
     public SocialAccountIntegrateResDTO integrate(Long existingMemberId, String integrationToken) {
         // 행 쓰기 락으로 동시 통합 요청을 직렬화한다 — 부재는 이미 사용/무효(1회성 보장)
@@ -55,9 +49,14 @@ public class SocialAccountIntegrateUsecase {
             throw new PendingIntegrationExpiredException();
         }
 
+        // 감지 시점에 확정된 대상과 현재 인증 회원이 일치해야 한다.
+        if (!pending.isTargetMember(existingMemberId)) {
+            throw new IntegrationNotEligibleException();
+        }
+
+        // 통합 감지 후 대상 회원의 연락처가 변경되었는지 다시 확인한다.
         Member existingMember = memberGetService.getMember(existingMemberId);
-        if (!pending.getNormalizedEmail().equals(existingMember.getEmail())
-                || !pending.getNormalizedPhone().equals(existingMember.getPhoneNumber())) {
+        if (!pending.matchesContactInfo(existingMember.getEmail(), existingMember.getPhoneNumber())) {
             throw new IntegrationNotEligibleException();
         }
         MemberStatus status = existingMember.getStatus();

--- a/src/main/java/com/tavemakers/surf/domain/member/entity/PendingSocialIntegration.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/entity/PendingSocialIntegration.java
@@ -9,6 +9,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.Objects;
 import java.util.UUID;
 
 /**
@@ -47,6 +48,10 @@ public class PendingSocialIntegration extends BaseEntity {
     @Column(nullable = false)
     private Long socialAccountId;
 
+    /** 통합 필요 감지 시점에 확정된 기존 회원 */
+    @Column(nullable = false)
+    private Long targetMemberId;
+
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 16)
     private Provider provider;
@@ -64,24 +69,28 @@ public class PendingSocialIntegration extends BaseEntity {
 
     @Builder
     private PendingSocialIntegration(String token, Long tempMemberId, Long socialAccountId,
-                                     Provider provider, String normalizedEmail, String normalizedPhone,
+                                     Long targetMemberId, Provider provider,
+                                     String normalizedEmail, String normalizedPhone,
                                      LocalDateTime expiresAt) {
         this.token = token;
         this.tempMemberId = tempMemberId;
         this.socialAccountId = socialAccountId;
+        this.targetMemberId = targetMemberId;
         this.provider = provider;
         this.normalizedEmail = normalizedEmail;
         this.normalizedPhone = normalizedPhone;
         this.expiresAt = expiresAt;
     }
 
-    /** 임시 회원·소셜 계정·온보딩 입력값으로 대기 row를 발급한다. 토큰은 1회성 예측 불가 값, 만료는 {@code now + TTL}. */
-    public static PendingSocialIntegration issue(Long tempMemberId, Long socialAccountId, Provider provider,
-                                                 String normalizedEmail, String normalizedPhone, LocalDateTime now) {
+    /** 임시 회원과 통합 대상 정보로 1회성 통합 대기 정보를 발급한다. */
+    public static PendingSocialIntegration issue(Long tempMemberId, Long socialAccountId, Long targetMemberId,
+                                                 Provider provider, String normalizedEmail, String normalizedPhone,
+                                                 LocalDateTime now) {
         return PendingSocialIntegration.builder()
                 .token(UUID.randomUUID().toString().replace("-", ""))
                 .tempMemberId(tempMemberId)
                 .socialAccountId(socialAccountId)
+                .targetMemberId(targetMemberId)
                 .provider(provider)
                 .normalizedEmail(normalizedEmail)
                 .normalizedPhone(normalizedPhone)
@@ -94,12 +103,28 @@ public class PendingSocialIntegration extends BaseEntity {
         return !now.isBefore(expiresAt);
     }
 
-    /** 발급 컨텍스트 동일성 — 임시 회원·provider·연락처가 같은 재요청만 멱등 재사용 대상이다(연락처가 바뀐 요청은 다른 명령). */
-    public boolean matchesContext(Long tempMemberId, Provider provider,
+    /** 임시 회원·통합 대상·소셜 제공자·연락처가 동일한 발급 요청인지 확인한다. */
+    public boolean matchesContext(Long tempMemberId, Long targetMemberId, Provider provider,
                                   String normalizedEmail, String normalizedPhone) {
         return this.tempMemberId.equals(tempMemberId)
+                && Objects.equals(this.targetMemberId, targetMemberId)
                 && this.provider == provider
                 && this.normalizedEmail.equals(normalizedEmail)
                 && this.normalizedPhone.equals(normalizedPhone);
+    }
+
+    /** 저장된 통합 대상과 회원이 일치하는지 확인한다. */
+    public boolean isTargetMember(Long memberId) {
+        return this.targetMemberId != null && Objects.equals(this.targetMemberId, memberId);
+    }
+
+    /** 통합 대상 회원이 기록되어 있는지 확인한다. */
+    public boolean hasTargetMember() {
+        return this.targetMemberId != null;
+    }
+
+    /** 발급 시점 연락처와 대상 회원의 현재 연락처가 일치하는지 확인한다. */
+    public boolean matchesContactInfo(String email, String phoneNumber) {
+        return this.normalizedEmail.equals(email) && this.normalizedPhone.equals(phoneNumber);
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/member/exception/AccountIntegrationAvailableException.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/exception/AccountIntegrationAvailableException.java
@@ -6,31 +6,30 @@ import lombok.Getter;
 
 import static com.tavemakers.surf.domain.member.exception.ErrorMessage.ACCOUNT_INTEGRATION_AVAILABLE;
 
-/**
- * 온보딩 통합 이메일·전화번호가 모두 동일한 온보딩 완료(WAITING/APPROVED) 회원이 존재할 때 (§3.5 case B).
- * 검증기가 {@link #detected}로 감지 컨텍스트를 던지면, 온보딩 롤백 후 pending 발급을 거쳐 {@link #issued}로 재전파된다. (§3.6)
- */
+/** 기존 회원과의 계정 통합이 가능한 온보딩 요청임을 알린다. */
 @Getter
 public class AccountIntegrationAvailableException extends BaseException {
 
-    // 감지 컨텍스트 (case B) — PendingSocialIntegration 발급에 사용
+    // 통합 대기 정보 발급에 사용하는 감지 컨텍스트
     private final Long tempMemberId;
     private final Long socialAccountId;
+    private final Long targetMemberId;
     private final Provider provider;
     private final String normalizedEmail;
     private final String normalizedPhone;
 
-    // 응답 페이로드 — pending 발급 후 채워짐(감지 단계에서는 null)
+    // 통합 대기 정보 발급 후 채우는 응답 값
     private final String integrationToken;
     private final Long expiresInSeconds;
     private final String guideMessage;
 
-    private AccountIntegrationAvailableException(Long tempMemberId, Long socialAccountId, Provider provider,
-                                                String normalizedEmail, String normalizedPhone,
-                                                String integrationToken, Long expiresInSeconds, String guideMessage) {
+    private AccountIntegrationAvailableException(Long tempMemberId, Long socialAccountId, Long targetMemberId,
+                                                 Provider provider, String normalizedEmail, String normalizedPhone,
+                                                 String integrationToken, Long expiresInSeconds, String guideMessage) {
         super(ACCOUNT_INTEGRATION_AVAILABLE.getStatus(), ACCOUNT_INTEGRATION_AVAILABLE.getMessage());
         this.tempMemberId = tempMemberId;
         this.socialAccountId = socialAccountId;
+        this.targetMemberId = targetMemberId;
         this.provider = provider;
         this.normalizedEmail = normalizedEmail;
         this.normalizedPhone = normalizedPhone;
@@ -39,16 +38,22 @@ public class AccountIntegrationAvailableException extends BaseException {
         this.guideMessage = guideMessage;
     }
 
-    /** 검증 단계 — 통합 필요 감지. pending 발급에 필요한 컨텍스트를 담는다. */
-    public static AccountIntegrationAvailableException detected(Long tempMemberId, Long socialAccountId, Provider provider,
-                                                               String normalizedEmail, String normalizedPhone) {
+    /** 통합 필요 감지 결과와 대기 정보 발급 컨텍스트를 생성한다. */
+    public static AccountIntegrationAvailableException detected(Long tempMemberId, Long socialAccountId,
+                                                                 Long targetMemberId, Provider provider,
+                                                                 String normalizedEmail, String normalizedPhone) {
         return new AccountIntegrationAvailableException(
-                tempMemberId, socialAccountId, provider, normalizedEmail, normalizedPhone, null, null, null);
+                tempMemberId, socialAccountId, targetMemberId, provider,
+                normalizedEmail, normalizedPhone, null, null, null);
     }
 
-    /** pending 발급 후 — 응답 페이로드(토큰/만료/안내)를 담아 재전파한다. */
-    public static AccountIntegrationAvailableException issued(String integrationToken, Long expiresInSeconds, String guideMessage) {
+    /** 발급된 통합 토큰과 안내 정보를 포함한 예외를 생성한다. */
+    public static AccountIntegrationAvailableException issued(
+            String integrationToken,
+            Long expiresInSeconds,
+            String guideMessage
+    ) {
         return new AccountIntegrationAvailableException(
-                null, null, null, null, null, integrationToken, expiresInSeconds, guideMessage);
+                null, null, null, null, null, null, integrationToken, expiresInSeconds, guideMessage);
     }
 }

--- a/src/main/java/com/tavemakers/surf/domain/member/repository/PendingSocialIntegrationRepository.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/repository/PendingSocialIntegrationRepository.java
@@ -21,4 +21,7 @@ public interface PendingSocialIntegrationRepository extends JpaRepository<Pendin
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("select p from PendingSocialIntegration p where p.socialAccountId = :socialAccountId")
     Optional<PendingSocialIntegration> findBySocialAccountIdForUpdate(@Param("socialAccountId") Long socialAccountId);
+
+    /** SocialAccount ID로 통합 대기 정보를 락 없이 조회한다. */
+    Optional<PendingSocialIntegration> findBySocialAccountId(Long socialAccountId);
 }

--- a/src/main/java/com/tavemakers/surf/domain/member/repository/SocialAccountRepository.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/repository/SocialAccountRepository.java
@@ -5,11 +5,15 @@ import com.tavemakers.surf.domain.member.entity.SocialAccount;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface SocialAccountRepository extends JpaRepository<SocialAccount, Long> {
 
-    /** provider + providerId 복합 식별자로 소셜 계정을 조회한다 (로그인 upsert 진입점). */
+    /** 소셜 제공자와 제공자 식별자로 소셜 계정을 조회한다. */
     Optional<SocialAccount> findByProviderAndProviderId(Provider provider, String providerId);
+
+    /** 회원에게 연결된 소셜 계정 목록을 조회한다. */
+    List<SocialAccount> findAllByMemberId(Long memberId);
 }

--- a/src/main/java/com/tavemakers/surf/domain/member/validator/OnboardingAccountValidator.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/validator/OnboardingAccountValidator.java
@@ -13,10 +13,7 @@ import org.springframework.stereotype.Component;
 import java.util.List;
 import java.util.Optional;
 
-/**
- * 온보딩 시 통합 이메일·전화번호를 기존 회원과 대조해 case A(정상)/B(통합 필요 감지)/C(부분 일치 차단)를 판별한다. (§3.5)
- * 부분 일치는 어떤 경우에도 통과시키지 않는다. (5.A-7)
- */
+/** 온보딩 연락처를 기존 회원과 대조해 계정 통합 가능 여부를 검증한다. */
 @Component
 @RequiredArgsConstructor
 public class OnboardingAccountValidator {
@@ -35,7 +32,7 @@ public class OnboardingAccountValidator {
             return;
         }
 
-        // case B) REGISTERING self 기준, 이메일·전화번호가 모두 동일한 단일 회원이 온보딩 완료 상태 + 연동 가능 provider(정확히 1개·미보유)일 때만 통합 필요 감지 — 비REGISTERING self(WAITING 재제출 등)는 case C로 차단 (5.A-4)
+        // case B) 연락처 소유자가 같고 신규 소셜 계정을 연결할 수 있으면 통합 대상으로 판정한다.
         if (self.isRegistering()
                 && emailOwner != null && phoneOwner != null
                 && emailOwner.getId().equals(phoneOwner.getId())
@@ -43,7 +40,7 @@ public class OnboardingAccountValidator {
                 && isProviderLinkable(self, emailOwner)) {
             SocialAccount socialAccount = self.getSocialAccounts().get(0); // isProviderLinkable에서 정확히 1개 보장
             throw AccountIntegrationAvailableException.detected(
-                    self.getId(), socialAccount.getId(), socialAccount.getProvider(),
+                    self.getId(), socialAccount.getId(), emailOwner.getId(), socialAccount.getProvider(),
                     normalizedEmail, normalizedPhone);
         }
 
@@ -54,18 +51,18 @@ public class OnboardingAccountValidator {
         throw new PhoneAlreadyUsedException();
     }
 
-    /** 조회 결과에서 본인(self)은 제외한다. (REGISTERING self 는 email/phone 이 비어 있어 실제로는 매칭되지 않음) */
+    /** 연락처 조회 결과에서 온보딩 요청 회원을 제외한다. */
     private Member findOtherOwner(Optional<Member> found, Member self) {
         return found.filter(m -> !m.getId().equals(self.getId())).orElse(null);
     }
 
-    /** 통합 대상은 온보딩 완료(WAITING/APPROVED) 회원으로 제한한다. (5.A-4) */
+    /** 회원 상태가 계정 통합 대상에 해당하는지 확인한다. */
     private boolean isIntegrationTarget(Member member) {
         MemberStatus status = member.getStatus();
         return status == MemberStatus.WAITING || status == MemberStatus.APPROVED;
     }
 
-    /** self 소셜 계정이 정확히 1개이고 기존 회원이 그 provider 를 미보유해야 연동 가능하다 (1 provider=1 account, 5.A-3). */
+    /** 임시 회원의 단일 소셜 계정을 기존 회원에게 연결할 수 있는지 확인한다. */
     private boolean isProviderLinkable(Member self, Member existing) {
         List<SocialAccount> accounts = self.getSocialAccounts();
         if (accounts.size() != 1) {

--- a/src/main/java/com/tavemakers/surf/presentation/member/controller/SocialAccountGetController.java
+++ b/src/main/java/com/tavemakers/surf/presentation/member/controller/SocialAccountGetController.java
@@ -1,0 +1,34 @@
+package com.tavemakers.surf.presentation.member.controller;
+
+import com.tavemakers.surf.application.member.query.IntegrationTargetGetService;
+import com.tavemakers.surf.global.common.response.ApiResponse;
+import com.tavemakers.surf.global.util.SecurityUtils;
+import com.tavemakers.surf.presentation.member.dto.response.IntegrationTargetResDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "계정 통합", description = "소셜 계정 통합(연동) API")
+public class SocialAccountGetController {
+
+    private final IntegrationTargetGetService integrationTargetGetService;
+
+    /** 임시 회원의 계정 통합 대상을 조회한다. */
+    @Operation(
+            summary = "계정 통합 대상 확인",
+            description = "온보딩 case B 직후, 통합될 기존 계정의 정보와 로그인해야 할 소셜(provider)을 조회합니다. "
+                    + "대기 건을 소비하지 않는 읽기 전용 API 입니다."
+    )
+    @GetMapping("/v1/user/social-accounts/integrate/target")
+    public ApiResponse<IntegrationTargetResDTO> getIntegrationTarget() {
+        Long tempMemberId = SecurityUtils.getCurrentMemberId();
+        IntegrationTargetResDTO data = integrationTargetGetService.getIntegrationTarget(tempMemberId);
+
+        return ApiResponse.response(HttpStatus.OK, "통합 대상 조회 완료", data);
+    }
+}

--- a/src/main/java/com/tavemakers/surf/presentation/member/dto/response/IntegrationTargetResDTO.java
+++ b/src/main/java/com/tavemakers/surf/presentation/member/dto/response/IntegrationTargetResDTO.java
@@ -1,0 +1,48 @@
+package com.tavemakers.surf.presentation.member.dto.response;
+
+import com.tavemakers.surf.domain.member.entity.Member;
+import com.tavemakers.surf.domain.member.entity.PendingSocialIntegration;
+import com.tavemakers.surf.domain.member.entity.SocialAccount;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+/** 계정 통합 대상 확인에 필요한 최소 정보를 반환한다. */
+@Schema(description = "계정 통합 대상 확인 응답 DTO")
+public record IntegrationTargetResDTO(
+
+        @Schema(description = "통합 대상에 연결된 소셜 목록 — 이 값으로 로그인 버튼을 렌더링한다", example = "[\"KAKAO\"]")
+        List<String> providers,
+
+        @Schema(description = "온보딩에 입력했던 이메일", example = "hong@example.com")
+        String email,
+
+        @Schema(description = "온보딩에 입력했던 전화번호", example = "01012345678")
+        String phoneNumber,
+
+        @Schema(description = "통합 대상 이름", example = "홍길동")
+        String username,
+
+        @Schema(description = "통합 대상 프로필 이미지 URL")
+        String profileImageUrl
+) {
+
+    /** 통합 대기 정보와 대상 회원으로 응답을 생성한다. */
+    public static IntegrationTargetResDTO of(
+            PendingSocialIntegration pending,
+            Member target,
+            List<SocialAccount> targetSocialAccounts
+    ) {
+        List<String> providers = targetSocialAccounts.stream()
+                .map(socialAccount -> socialAccount.getProvider().name())
+                .toList();
+
+        return new IntegrationTargetResDTO(
+                providers,
+                pending.getNormalizedEmail(),
+                pending.getNormalizedPhone(),
+                target.getName(),
+                target.getProfileImageUrl()
+        );
+    }
+}

--- a/src/main/java/com/tavemakers/surf/presentation/member/dto/response/IntegrationTargetResDTO.java
+++ b/src/main/java/com/tavemakers/surf/presentation/member/dto/response/IntegrationTargetResDTO.java
@@ -28,7 +28,7 @@ public record IntegrationTargetResDTO(
 ) {
 
     /** 통합 대기 정보와 대상 회원으로 응답을 생성한다. */
-    public static IntegrationTargetResDTO of(
+    public static IntegrationTargetResDTO from(
             PendingSocialIntegration pending,
             Member target,
             List<SocialAccount> targetSocialAccounts

--- a/src/test/java/com/tavemakers/surf/application/member/query/IntegrationTargetGetServiceTest.java
+++ b/src/test/java/com/tavemakers/surf/application/member/query/IntegrationTargetGetServiceTest.java
@@ -1,0 +1,256 @@
+package com.tavemakers.surf.application.member.query;
+
+import com.tavemakers.surf.domain.auth.common.enums.Provider;
+import com.tavemakers.surf.domain.member.entity.Member;
+import com.tavemakers.surf.domain.member.entity.PendingSocialIntegration;
+import com.tavemakers.surf.domain.member.entity.SocialAccount;
+import com.tavemakers.surf.domain.member.entity.enums.MemberStatus;
+import com.tavemakers.surf.domain.member.exception.IntegrationNotEligibleException;
+import com.tavemakers.surf.domain.member.exception.PendingIntegrationExpiredException;
+import com.tavemakers.surf.domain.member.exception.PendingIntegrationNotFoundException;
+import com.tavemakers.surf.domain.member.repository.PendingSocialIntegrationRepository;
+import com.tavemakers.surf.domain.member.repository.SocialAccountRepository;
+import com.tavemakers.surf.presentation.member.dto.response.IntegrationTargetResDTO;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+/** 계정 통합 대상 확인 (§3.6.2) — 조회 판정은 통합 API(POST)와 동일해야 한다. */
+@ExtendWith(MockitoExtension.class)
+class IntegrationTargetGetServiceTest {
+
+    @Mock private PendingSocialIntegrationRepository pendingSocialIntegrationRepository;
+    @Mock private SocialAccountRepository socialAccountRepository;
+    @Mock private MemberGetService memberGetService;
+
+    @InjectMocks private IntegrationTargetGetService service;
+
+    private static final Long TEMP_ID = 1L;
+    private static final Long SA_ID = 2L;
+    private static final Long TARGET_ID = 3L;
+    private static final String EMAIL = "hong@test.com";
+    private static final String PHONE = "01011112222";
+    /** 임시 회원이 새로 들고 온 provider — 대상은 이 provider 를 아직 보유하지 않아야 한다. */
+    private static final Provider PROVIDER = Provider.APPLE;
+
+    private Member memberOf(Long id, MemberStatus status) {
+        Member m = Member.builder().status(status).build();
+        ReflectionTestUtils.setField(m, "id", id);
+        return m;
+    }
+
+    private Member targetOf(MemberStatus status, String email, String phone) {
+        Member m = Member.builder().status(status).name("홍길동").email(email).phoneNumber(phone).build();
+        ReflectionTestUtils.setField(m, "id", TARGET_ID);
+        ReflectionTestUtils.setField(m, "profileImageUrl", "https://cdn/profile.jpg");
+        return m;
+    }
+
+    private SocialAccount socialAccountOf(Long id, Provider provider) {
+        SocialAccount sa = SocialAccount.builder().provider(provider).providerId("pid-" + provider).build();
+        ReflectionTestUtils.setField(sa, "id", id);
+        return sa;
+    }
+
+    private PendingSocialIntegration pending(LocalDateTime now) {
+        return PendingSocialIntegration.issue(TEMP_ID, SA_ID, TARGET_ID, PROVIDER, EMAIL, PHONE, now);
+    }
+
+    /** 임시 회원이 REGISTERING 이고 소셜 계정 1개를 보유한 상태. */
+    private void givenTempMemberWithSingleAccount() {
+        given(memberGetService.getMember(TEMP_ID)).willReturn(memberOf(TEMP_ID, MemberStatus.REGISTERING));
+        given(socialAccountRepository.findAllByMemberId(TEMP_ID))
+                .willReturn(List.of(socialAccountOf(SA_ID, PROVIDER)));
+    }
+
+    /** 대상 검증 직전까지의 스텁 — 임시 회원·소셜 계정·유효 pending. */
+    private void givenEligibleUntilTarget() {
+        givenTempMemberWithSingleAccount();
+        given(pendingSocialIntegrationRepository.findBySocialAccountId(SA_ID))
+                .willReturn(Optional.of(pending(LocalDateTime.now())));
+    }
+
+    /** 정상 조회 전체 스텁 — 대상은 KAKAO 만 보유(임시 회원의 APPLE 미보유). */
+    private void givenEligible(Member target) {
+        givenEligibleUntilTarget();
+        given(memberGetService.getMember(TARGET_ID)).willReturn(target);
+        given(socialAccountRepository.findAllByMemberId(TARGET_ID))
+                .willReturn(List.of(socialAccountOf(10L, Provider.KAKAO)));
+    }
+
+    @Test
+    @DisplayName("성공 — 대상 프로필과 연결된 provider 를 반환한다")
+    void getTarget_success() {
+        givenEligible(targetOf(MemberStatus.APPROVED, EMAIL, PHONE));
+
+        IntegrationTargetResDTO result = service.getIntegrationTarget(TEMP_ID);
+
+        assertThat(result.providers()).containsExactly("KAKAO"); // 임시 회원의 APPLE 이 섞이지 않는다
+        assertThat(result.username()).isEqualTo("홍길동");
+        assertThat(result.profileImageUrl()).isEqualTo("https://cdn/profile.jpg");
+    }
+
+    @Test
+    @DisplayName("승인 대기(WAITING) 대상도 조회할 수 있다 — 통합 대상 범위와 일치")
+    void getTarget_waitingTarget() {
+        givenEligible(targetOf(MemberStatus.WAITING, EMAIL, PHONE));
+
+        assertThat(service.getIntegrationTarget(TEMP_ID).username()).isEqualTo("홍길동");
+    }
+
+    @Test
+    @DisplayName("이메일·전화번호는 대상 회원이 아니라 pending 값을 반환한다 — 호출자가 입력한 값의 에코")
+    void getTarget_contactComesFromPending() {
+        givenEligible(targetOf(MemberStatus.APPROVED, EMAIL, PHONE));
+
+        IntegrationTargetResDTO result = service.getIntegrationTarget(TEMP_ID);
+
+        assertThat(result.email()).isEqualTo(EMAIL);
+        assertThat(result.phoneNumber()).isEqualTo(PHONE);
+    }
+
+    @Test
+    @DisplayName("조회는 부수효과가 없다 — pending 을 삭제·저장하지 않는다")
+    void getTarget_hasNoSideEffect() {
+        givenEligible(targetOf(MemberStatus.APPROVED, EMAIL, PHONE));
+
+        service.getIntegrationTarget(TEMP_ID);
+
+        then(pendingSocialIntegrationRepository).should(never()).delete(org.mockito.ArgumentMatchers.any());
+        then(pendingSocialIntegrationRepository).should(never()).save(org.mockito.ArgumentMatchers.any());
+        then(pendingSocialIntegrationRepository).should(never()).saveAndFlush(org.mockito.ArgumentMatchers.any());
+        // 쓰기 락 조회를 재사용하지 않는다 — 통합·발급 경로와 경합하면 안 된다
+        then(pendingSocialIntegrationRepository).should(never()).findByToken(org.mockito.ArgumentMatchers.anyString());
+        then(pendingSocialIntegrationRepository).should(never())
+                .findBySocialAccountIdForUpdate(org.mockito.ArgumentMatchers.anyLong());
+    }
+
+    @Test
+    @DisplayName("인증 주체가 REGISTERING 이 아니면 IntegrationNotEligibleException — pending 을 조회하지 않는다")
+    void getTarget_tempMemberNotRegistering() {
+        given(memberGetService.getMember(TEMP_ID)).willReturn(memberOf(TEMP_ID, MemberStatus.WAITING));
+
+        assertThatThrownBy(() -> service.getIntegrationTarget(TEMP_ID))
+                .isInstanceOf(IntegrationNotEligibleException.class);
+    }
+
+    @Test
+    @DisplayName("임시 회원의 소셜 계정이 1개가 아니면 IntegrationNotEligibleException — 이전할 로그인 수단을 특정할 수 없다")
+    void getTarget_multipleSocialAccounts() {
+        given(memberGetService.getMember(TEMP_ID)).willReturn(memberOf(TEMP_ID, MemberStatus.REGISTERING));
+        given(socialAccountRepository.findAllByMemberId(TEMP_ID)).willReturn(
+                List.of(socialAccountOf(SA_ID, PROVIDER), socialAccountOf(99L, Provider.KAKAO)));
+
+        assertThatThrownBy(() -> service.getIntegrationTarget(TEMP_ID))
+                .isInstanceOf(IntegrationNotEligibleException.class);
+    }
+
+    @Test
+    @DisplayName("보유한 소셜 계정에 대기 건이 없으면 PendingIntegrationNotFoundException (이미 사용됨/무효)")
+    void getTarget_pendingNotFound() {
+        givenTempMemberWithSingleAccount();
+        given(pendingSocialIntegrationRepository.findBySocialAccountId(SA_ID)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.getIntegrationTarget(TEMP_ID))
+                .isInstanceOf(PendingIntegrationNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("pending 의 임시 회원이 인증 주체와 다르면 IntegrationNotEligibleException")
+    void getTarget_tempMemberMismatch() {
+        givenTempMemberWithSingleAccount();
+        PendingSocialIntegration other = PendingSocialIntegration.issue(
+                999L, SA_ID, TARGET_ID, PROVIDER, EMAIL, PHONE, LocalDateTime.now());
+        given(pendingSocialIntegrationRepository.findBySocialAccountId(SA_ID)).willReturn(Optional.of(other));
+
+        assertThatThrownBy(() -> service.getIntegrationTarget(TEMP_ID))
+                .isInstanceOf(IntegrationNotEligibleException.class);
+    }
+
+    @Test
+    @DisplayName("보유한 소셜 계정의 provider 가 pending 과 다르면 IntegrationNotEligibleException — 통합 API 판정과 일치시킨다")
+    void getTarget_providerMismatch() {
+        given(memberGetService.getMember(TEMP_ID)).willReturn(memberOf(TEMP_ID, MemberStatus.REGISTERING));
+        given(socialAccountRepository.findAllByMemberId(TEMP_ID))
+                .willReturn(List.of(socialAccountOf(SA_ID, Provider.KAKAO))); // pending 은 APPLE
+        given(pendingSocialIntegrationRepository.findBySocialAccountId(SA_ID))
+                .willReturn(Optional.of(pending(LocalDateTime.now())));
+
+        assertThatThrownBy(() -> service.getIntegrationTarget(TEMP_ID))
+                .isInstanceOf(IntegrationNotEligibleException.class);
+    }
+
+    @Test
+    @DisplayName("만료된 pending — PendingIntegrationExpiredException")
+    void getTarget_expired() {
+        givenTempMemberWithSingleAccount();
+        given(pendingSocialIntegrationRepository.findBySocialAccountId(SA_ID))
+                .willReturn(Optional.of(pending(LocalDateTime.now().minusHours(1))));
+
+        assertThatThrownBy(() -> service.getIntegrationTarget(TEMP_ID))
+                .isInstanceOf(PendingIntegrationExpiredException.class);
+    }
+
+    @Test
+    @DisplayName("대상이 기록되지 않은 구버전 pending — NPE 대신 IntegrationNotEligibleException")
+    void getTarget_legacyPendingWithoutTarget() {
+        // 컬럼 추가(expand) 후 구버전 인스턴스가 만든 행 — 롤링 배포 공존 구간에서 실제로 발생할 수 있다
+        PendingSocialIntegration legacy = pending(LocalDateTime.now());
+        ReflectionTestUtils.setField(legacy, "targetMemberId", null);
+        givenTempMemberWithSingleAccount();
+        given(pendingSocialIntegrationRepository.findBySocialAccountId(SA_ID)).willReturn(Optional.of(legacy));
+
+        assertThatThrownBy(() -> service.getIntegrationTarget(TEMP_ID))
+                .isInstanceOf(IntegrationNotEligibleException.class);
+    }
+
+    @Test
+    @DisplayName("대상이 WAITING·APPROVED 가 아니면 IntegrationNotEligibleException")
+    void getTarget_targetStatusNotEligible() {
+        givenEligibleUntilTarget();
+        given(memberGetService.getMember(TARGET_ID)).willReturn(targetOf(MemberStatus.REJECTED, EMAIL, PHONE));
+        given(socialAccountRepository.findAllByMemberId(TARGET_ID))
+                .willReturn(List.of(socialAccountOf(10L, Provider.KAKAO)));
+
+        assertThatThrownBy(() -> service.getIntegrationTarget(TEMP_ID))
+                .isInstanceOf(IntegrationNotEligibleException.class);
+    }
+
+    @Test
+    @DisplayName("대상이 연락처를 바꿔 pending 값과 달라지면 IntegrationNotEligibleException — 조회 통과 후 POST 409 를 막는다")
+    void getTarget_targetContactChanged() {
+        givenEligibleUntilTarget();
+        given(memberGetService.getMember(TARGET_ID)).willReturn(targetOf(MemberStatus.APPROVED, "changed@test.com", PHONE));
+        given(socialAccountRepository.findAllByMemberId(TARGET_ID))
+                .willReturn(List.of(socialAccountOf(10L, Provider.KAKAO)));
+
+        assertThatThrownBy(() -> service.getIntegrationTarget(TEMP_ID))
+                .isInstanceOf(IntegrationNotEligibleException.class);
+    }
+
+    @Test
+    @DisplayName("대상이 이미 같은 provider 를 보유하면 IntegrationNotEligibleException (1 provider = 1 account)")
+    void getTarget_targetAlreadyLinked() {
+        givenEligibleUntilTarget();
+        given(memberGetService.getMember(TARGET_ID)).willReturn(targetOf(MemberStatus.APPROVED, EMAIL, PHONE));
+        given(socialAccountRepository.findAllByMemberId(TARGET_ID))
+                .willReturn(List.of(socialAccountOf(10L, Provider.KAKAO), socialAccountOf(11L, PROVIDER)));
+
+        assertThatThrownBy(() -> service.getIntegrationTarget(TEMP_ID))
+                .isInstanceOf(IntegrationNotEligibleException.class);
+    }
+}

--- a/src/test/java/com/tavemakers/surf/application/member/usecase/PendingIntegrationUsecaseTest.java
+++ b/src/test/java/com/tavemakers/surf/application/member/usecase/PendingIntegrationUsecaseTest.java
@@ -39,6 +39,7 @@ class PendingIntegrationUsecaseTest {
 
     private static final Long TEMP_ID = 1L;
     private static final Long SA_ID = 2L;
+    private static final Long TARGET_ID = 3L;
     private static final Provider PROVIDER = Provider.KAKAO;
     private static final String EMAIL = "user@test.com";
     private static final String PHONE = "01011112222";
@@ -63,7 +64,7 @@ class PendingIntegrationUsecaseTest {
     }
 
     private IssuedIntegrationToken issue() {
-        return pendingIntegrationUsecase.issue(TEMP_ID, SA_ID, PROVIDER, EMAIL, PHONE);
+        return pendingIntegrationUsecase.issue(TEMP_ID, SA_ID, TARGET_ID, PROVIDER, EMAIL, PHONE);
     }
 
     @Test
@@ -81,6 +82,7 @@ class PendingIntegrationUsecaseTest {
         assertThat(issued.expiresAt()).isEqualTo(saved.getExpiresAt());
         assertThat(saved.getTempMemberId()).isEqualTo(TEMP_ID);
         assertThat(saved.getSocialAccountId()).isEqualTo(SA_ID);
+        assertThat(saved.getTargetMemberId()).isEqualTo(TARGET_ID);
         assertThat(saved.getProvider()).isEqualTo(PROVIDER);
     }
 
@@ -88,7 +90,7 @@ class PendingIntegrationUsecaseTest {
     @DisplayName("유효한 기존 pending — 동일 토큰·만료를 그대로 반환하고 삭제·재발급하지 않는다(멱등)")
     void issue_existingValid_returnsSameToken() {
         PendingSocialIntegration valid = PendingSocialIntegration.issue(
-                TEMP_ID, SA_ID, PROVIDER, EMAIL, PHONE, LocalDateTime.now());
+                TEMP_ID, SA_ID, TARGET_ID, PROVIDER, EMAIL, PHONE, LocalDateTime.now());
         given(pendingSocialIntegrationRepository.findBySocialAccountIdForUpdate(SA_ID)).willReturn(Optional.of(valid));
 
         IssuedIntegrationToken issued = issue();
@@ -104,7 +106,7 @@ class PendingIntegrationUsecaseTest {
     @DisplayName("만료된 기존 pending — 삭제 후 재검증하고 새 토큰을 발급한다")
     void issue_existingExpired_deletesAndReissues() {
         PendingSocialIntegration expired = PendingSocialIntegration.issue(
-                TEMP_ID, SA_ID, PROVIDER, EMAIL, PHONE,
+                TEMP_ID, SA_ID, TARGET_ID, PROVIDER, EMAIL, PHONE,
                 LocalDateTime.now().minusSeconds(PendingSocialIntegration.TTL_SECONDS + 60));
         given(pendingSocialIntegrationRepository.findBySocialAccountIdForUpdate(SA_ID)).willReturn(Optional.of(expired));
         givenTransferable();
@@ -147,7 +149,7 @@ class PendingIntegrationUsecaseTest {
     void issue_existingValid_differentContext_replaces() {
         // 같은 SocialAccount지만 이메일이 다른(온보딩 연락처를 바꿔 재제출한) 유효 pending
         PendingSocialIntegration otherContext = PendingSocialIntegration.issue(
-                TEMP_ID, SA_ID, PROVIDER, "other@test.com", PHONE, LocalDateTime.now());
+                TEMP_ID, SA_ID, TARGET_ID, PROVIDER, "other@test.com", PHONE, LocalDateTime.now());
         given(pendingSocialIntegrationRepository.findBySocialAccountIdForUpdate(SA_ID)).willReturn(Optional.of(otherContext));
         givenTransferable();
 
@@ -161,5 +163,43 @@ class PendingIntegrationUsecaseTest {
                 .isEqualTo(captor.getValue().getToken())
                 .isNotEqualTo(otherContext.getToken());
         assertThat(captor.getValue().getNormalizedEmail()).isEqualTo(EMAIL); // 현재 요청의 새 컨텍스트로 발급
+    }
+
+    @Test
+    @DisplayName("통합 대상이 달라진 재요청 — 멱등 재사용이 아니라 삭제 후 새 대상으로 재발급한다")
+    void issue_existingValid_differentTarget_replaces() {
+        // 연락처는 그대로지만 감지된 대상이 바뀐 유효 pending — 이전 대상을 가리키는 토큰이 재사용되면 안 된다
+        PendingSocialIntegration otherTarget = PendingSocialIntegration.issue(
+                TEMP_ID, SA_ID, 999L, PROVIDER, EMAIL, PHONE, LocalDateTime.now());
+        given(pendingSocialIntegrationRepository.findBySocialAccountIdForUpdate(SA_ID)).willReturn(Optional.of(otherTarget));
+        givenTransferable();
+
+        IssuedIntegrationToken issued = issue();
+
+        then(pendingSocialIntegrationRepository).should().delete(otherTarget);
+        ArgumentCaptor<PendingSocialIntegration> captor = ArgumentCaptor.forClass(PendingSocialIntegration.class);
+        then(pendingSocialIntegrationRepository).should().saveAndFlush(captor.capture());
+        assertThat(issued.token())
+                .isEqualTo(captor.getValue().getToken())
+                .isNotEqualTo(otherTarget.getToken());
+        assertThat(captor.getValue().getTargetMemberId()).isEqualTo(TARGET_ID);
+    }
+
+    @Test
+    @DisplayName("대상이 기록되지 않은 구버전 pending — NPE 없이 삭제 후 재발급한다")
+    void issue_legacyPendingWithoutTarget_replaces() {
+        PendingSocialIntegration legacy = PendingSocialIntegration.issue(
+                TEMP_ID, SA_ID, TARGET_ID, PROVIDER, EMAIL, PHONE, LocalDateTime.now());
+        ReflectionTestUtils.setField(legacy, "targetMemberId", null);
+        given(pendingSocialIntegrationRepository.findBySocialAccountIdForUpdate(SA_ID)).willReturn(Optional.of(legacy));
+        givenTransferable();
+
+        IssuedIntegrationToken issued = issue();
+
+        then(pendingSocialIntegrationRepository).should().delete(legacy);
+        ArgumentCaptor<PendingSocialIntegration> captor = ArgumentCaptor.forClass(PendingSocialIntegration.class);
+        then(pendingSocialIntegrationRepository).should().saveAndFlush(captor.capture());
+        assertThat(issued.token()).isEqualTo(captor.getValue().getToken());
+        assertThat(captor.getValue().getTargetMemberId()).isEqualTo(TARGET_ID);
     }
 }

--- a/src/test/java/com/tavemakers/surf/application/member/usecase/SocialAccountIntegrateUsecaseTest.java
+++ b/src/test/java/com/tavemakers/surf/application/member/usecase/SocialAccountIntegrateUsecaseTest.java
@@ -71,7 +71,7 @@ class SocialAccountIntegrateUsecaseTest {
     }
 
     private PendingSocialIntegration pending(LocalDateTime now) {
-        return PendingSocialIntegration.issue(TEMP_ID, SA_ID, PROVIDER, EMAIL, PHONE, now);
+        return PendingSocialIntegration.issue(TEMP_ID, SA_ID, EXISTING_ID, PROVIDER, EMAIL, PHONE, now);
     }
 
     private Member memberOf(Long id, MemberStatus status) {
@@ -134,7 +134,32 @@ class SocialAccountIntegrateUsecaseTest {
     }
 
     @Test
-    @DisplayName("이메일 불일치 — IntegrationNotEligibleException")
+    @DisplayName("감지된 대상이 아닌 회원의 통합 시도 — IntegrationNotEligibleException, 연락처 대조 전에 차단한다")
+    void integrate_notDetectedTarget() {
+        // 대상(EXISTING_ID)이 연락처를 바꾸고 제3자가 그 값을 점유한 상황 — 연락처만 보면 통과한다
+        PendingSocialIntegration pending = pending(LocalDateTime.now());
+        Long squatterId = 999L;
+        given(pendingSocialIntegrationRepository.findByToken(pending.getToken())).willReturn(Optional.of(pending));
+
+        assertThatThrownBy(() -> usecase.integrate(squatterId, pending.getToken()))
+                .isInstanceOf(IntegrationNotEligibleException.class);
+        then(memberGetService).should(never()).getMember(squatterId);
+    }
+
+    @Test
+    @DisplayName("대상이 기록되지 않은 구버전 pending — NPE 없이 IntegrationNotEligibleException")
+    void integrate_legacyPendingWithoutTarget() {
+        // 컬럼 추가(expand) 후 구버전 인스턴스가 만든 행 — 롤링 배포 공존 구간에서 발생 가능
+        PendingSocialIntegration legacy = pending(LocalDateTime.now());
+        ReflectionTestUtils.setField(legacy, "targetMemberId", null);
+        given(pendingSocialIntegrationRepository.findByToken(legacy.getToken())).willReturn(Optional.of(legacy));
+
+        assertThatThrownBy(() -> usecase.integrate(EXISTING_ID, legacy.getToken()))
+                .isInstanceOf(IntegrationNotEligibleException.class);
+    }
+
+    @Test
+    @DisplayName("이메일 불일치 — 대상이 맞아도 연락처가 바뀌었으면 IntegrationNotEligibleException (TOCTOU 방어선 유지)")
     void integrate_emailMismatch() {
         PendingSocialIntegration pending = pending(LocalDateTime.now());
         Member existing = existingMember(MemberStatus.WAITING, "other@test.com", PHONE);

--- a/src/test/java/com/tavemakers/surf/domain/member/entity/PendingSocialIntegrationTest.java
+++ b/src/test/java/com/tavemakers/surf/domain/member/entity/PendingSocialIntegrationTest.java
@@ -3,6 +3,7 @@ package com.tavemakers.surf.domain.member.entity;
 import com.tavemakers.surf.domain.auth.common.enums.Provider;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDateTime;
 
@@ -16,12 +17,13 @@ class PendingSocialIntegrationTest {
         LocalDateTime now = LocalDateTime.of(2026, 1, 1, 0, 0);
 
         PendingSocialIntegration pending = PendingSocialIntegration.issue(
-                1L, 2L, Provider.KAKAO, "user@test.com", "01011112222", now);
+                1L, 2L, 3L, Provider.KAKAO, "user@test.com", "01011112222", now);
 
         assertThat(pending.getToken()).isNotBlank();
         assertThat(pending.getToken()).doesNotContain("-");
         assertThat(pending.getTempMemberId()).isEqualTo(1L);
         assertThat(pending.getSocialAccountId()).isEqualTo(2L);
+        assertThat(pending.getTargetMemberId()).isEqualTo(3L);
         assertThat(pending.getProvider()).isEqualTo(Provider.KAKAO);
         assertThat(pending.getNormalizedEmail()).isEqualTo("user@test.com");
         assertThat(pending.getNormalizedPhone()).isEqualTo("01011112222");
@@ -33,12 +35,65 @@ class PendingSocialIntegrationTest {
     void isExpired_afterExpiry() {
         LocalDateTime now = LocalDateTime.now();
         PendingSocialIntegration pending = PendingSocialIntegration.issue(
-                1L, 2L, Provider.KAKAO, "user@test.com", "01011112222", now);
+                1L, 2L, 3L, Provider.KAKAO, "user@test.com", "01011112222", now);
 
         assertThat(pending.isExpired(now)).isFalse();
         assertThat(pending.isExpired(now.plusSeconds(PendingSocialIntegration.TTL_SECONDS - 1))).isFalse();
         // 경계: 정확히 expiresAt(= now + TTL)이면 만료로 판정한다
         assertThat(pending.isExpired(now.plusSeconds(PendingSocialIntegration.TTL_SECONDS))).isTrue();
         assertThat(pending.isExpired(now.plusSeconds(PendingSocialIntegration.TTL_SECONDS + 1))).isTrue();
+    }
+
+    @Test
+    @DisplayName("matchesContext()는 임시 회원·대상·provider·연락처가 모두 같을 때만 true")
+    void matchesContext_allFields() {
+        PendingSocialIntegration pending = PendingSocialIntegration.issue(
+                1L, 2L, 3L, Provider.KAKAO, "user@test.com", "01011112222", LocalDateTime.now());
+
+        assertThat(pending.matchesContext(1L, 3L, Provider.KAKAO, "user@test.com", "01011112222")).isTrue();
+        // 대상이 바뀐 재요청은 다른 명령이므로 멱등 재사용 대상이 아니다 — 빠뜨리면 이전 대상 토큰이 재사용된다
+        assertThat(pending.matchesContext(1L, 999L, Provider.KAKAO, "user@test.com", "01011112222")).isFalse();
+        assertThat(pending.matchesContext(999L, 3L, Provider.KAKAO, "user@test.com", "01011112222")).isFalse();
+        assertThat(pending.matchesContext(1L, 3L, Provider.APPLE, "user@test.com", "01011112222")).isFalse();
+        assertThat(pending.matchesContext(1L, 3L, Provider.KAKAO, "other@test.com", "01011112222")).isFalse();
+        assertThat(pending.matchesContext(1L, 3L, Provider.KAKAO, "user@test.com", "01099998888")).isFalse();
+    }
+
+    @Test
+    @DisplayName("isTargetMember()는 감지 시점에 확정된 대상만 true")
+    void isTargetMember() {
+        PendingSocialIntegration pending = PendingSocialIntegration.issue(
+                1L, 2L, 3L, Provider.KAKAO, "user@test.com", "01011112222", LocalDateTime.now());
+
+        assertThat(pending.isTargetMember(3L)).isTrue();
+        assertThat(pending.isTargetMember(4L)).isFalse();
+    }
+
+    @Test
+    @DisplayName("targetMemberId가 비어 있는 구버전 행 — NPE 없이 재사용 거부·통합 거부로 처리한다")
+    void legacyRow_withoutTarget() {
+        // 컬럼 추가(expand) 직후 구버전 인스턴스가 만든 행: target_member_id = NULL
+        PendingSocialIntegration legacy = PendingSocialIntegration.issue(
+                1L, 2L, 3L, Provider.KAKAO, "user@test.com", "01011112222", LocalDateTime.now());
+        ReflectionTestUtils.setField(legacy, "targetMemberId", null);
+
+        assertThat(legacy.hasTargetMember()).isFalse();
+        // 동일 컨텍스트로 보지 않는다 → 삭제 후 재발급 경로로 흘러간다
+        assertThat(legacy.matchesContext(1L, 3L, Provider.KAKAO, "user@test.com", "01011112222")).isFalse();
+        // 어떤 주체와도 일치하지 않는다 → 통합 거부
+        assertThat(legacy.isTargetMember(3L)).isFalse();
+        assertThat(legacy.isTargetMember(null)).isFalse();
+    }
+
+    @Test
+    @DisplayName("matchesContactInfo()는 이메일·전화번호가 모두 같을 때만 true")
+    void matchesContactInfo() {
+        PendingSocialIntegration pending = PendingSocialIntegration.issue(
+                1L, 2L, 3L, Provider.KAKAO, "user@test.com", "01011112222", LocalDateTime.now());
+
+        assertThat(pending.matchesContactInfo("user@test.com", "01011112222")).isTrue();
+        assertThat(pending.matchesContactInfo("other@test.com", "01011112222")).isFalse();
+        assertThat(pending.matchesContactInfo("user@test.com", "01099998888")).isFalse();
+        assertThat(pending.matchesContactInfo(null, null)).isFalse();
     }
 }

--- a/src/test/java/com/tavemakers/surf/domain/member/validator/OnboardingAccountValidatorTest.java
+++ b/src/test/java/com/tavemakers/surf/domain/member/validator/OnboardingAccountValidatorTest.java
@@ -18,6 +18,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.Optional;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
@@ -65,7 +66,14 @@ class OnboardingAccountValidatorTest {
         given(memberRepository.findByPhoneNumber(PHONE)).willReturn(Optional.of(owner));
 
         assertThatThrownBy(() -> validator.validateForOnboarding(self, EMAIL, PHONE))
-                .isInstanceOf(AccountIntegrationAvailableException.class);
+                .isInstanceOfSatisfying(AccountIntegrationAvailableException.class, e -> {
+                    // 감지 시점에 확정된 대상이 pending 발급 컨텍스트로 전달되어야 한다 (이슈 #354)
+                    assertThat(e.getTargetMemberId()).isEqualTo(owner.getId());
+                    assertThat(e.getTempMemberId()).isEqualTo(self.getId());
+                    assertThat(e.getProvider()).isEqualTo(Provider.KAKAO);
+                    assertThat(e.getNormalizedEmail()).isEqualTo(EMAIL);
+                    assertThat(e.getNormalizedPhone()).isEqualTo(PHONE);
+                });
     }
 
     @Test

--- a/src/test/java/com/tavemakers/surf/global/common/advice/OnboardingConflictResponseTest.java
+++ b/src/test/java/com/tavemakers/surf/global/common/advice/OnboardingConflictResponseTest.java
@@ -42,7 +42,7 @@ class OnboardingConflictResponseTest {
     @DisplayName("case B (detected) — 토큰 미발급 단계면 data 는 reason 만 담고 토큰 키는 없다")
     void caseB_detected() {
         ResponseEntity<ApiResponse<Map<String, Object>>> res = handler.handleAccountIntegrationAvailable(
-                AccountIntegrationAvailableException.detected(1L, 2L, Provider.KAKAO, "e@test.com", "01011112222"));
+                AccountIntegrationAvailableException.detected(1L, 2L, 3L, Provider.KAKAO, "e@test.com", "01011112222"));
 
         assertThat(res.getBody().data())
                 .containsEntry("reason", "ACCOUNT_INTEGRATION_REQUIRED")


### PR DESCRIPTION
## 📄 작업 내용 요약

온보딩 case B로 통합이 감지된 직후, **어떤 계정과 통합되는지 확인**할 수 있는 조회 API를 추가한다.
그 전제로 `PendingSocialIntegration`에 **통합 대상(`targetMemberId`)을 저장**하고, 통합 API의 대상 검증을 보강한다.

기존에는 case B 응답이 `integrationToken`과 안내 문구만 내려주어, 사용자는
**본인 계정인지 확인하지 못한 채** 로그인 전환 → 통합(비가역)으로 넘어가야 했고,
프론트는 **어떤 소셜로 로그인해야 하는지**도 알 수 없었다.

---

### 1. `pending_social_integration.target_member_id` 추가

통합 대상은 지금까지 pending에 저장되지 않고, 통합 시점의 **연락처 대조로 매번 다시 결정**됐다.

```java
pending.normalizedEmail == 로그인 회원.email
pending.normalizedPhone == 로그인 회원.phoneNumber
```

이 방식은 **발급 이후 대상 A가 연락처를 바꾸고 회원 B가 그 값을 점유하면 B가 조건을 통과**한다.
감지 시점에 확정된 대상을 저장해 이 경로를 막는다.

**감지 → 발급 체인 (6곳)**

| 위치 | 변경 |
|---|---|
| `OnboardingAccountValidator` | 이미 보유 중인 `emailOwner.getId()`를 `detected(...)`로 전달 |
| `AccountIntegrationAvailableException` | `targetMemberId` 필드 + `detected(...)` 시그니처 |
| `MemberUsecase#issueIntegrationToken` | `e.getTargetMemberId()` 전달 |
| `PendingIntegrationUsecase#issue` | 파라미터 추가 |
| `PendingSocialIntegration` | 필드·`issue(...)`·빌더 |
| `PendingSocialIntegration#matchesContext` | **비교 대상에 `targetMemberId` 포함** |

`matchesContext`가 핵심이다. 대상이 달라진 재요청은 **다른 명령**이므로 멱등 재사용이 아니라
삭제 후 재발급되어야 한다. 빠뜨리면 이전 대상을 가리키는 토큰이 그대로 재사용된다.

**통합 API 보강** — 기존 연락처 대조는 **유지**하고 대상 검증을 앞에 **추가**했다.
(연락처 대조는 대상 확정 이후의 데이터 변경(TOCTOU)을 잡는 별개 방어선이라 대체하지 않는다.)

```java
if (!pending.isTargetMember(existingMemberId)) {
    throw new IntegrationNotEligibleException();
}
```

### 2. 통합 대상 조회 API

```
GET /v1/user/social-accounts/integrate/target
Authorization: Bearer {임시 계정(REGISTERING) accessToken}
```

**`integrationToken`을 파라미터로 받지 않는다.** 인증 주체에서 대기 건을 역참조한다.

```
임시 계정 AT → tempMemberId → 소유 SocialAccount → pending → targetMemberId → 대상 조회
```

1회성 토큰이 URL·프록시 로그·Referer에 남지 않고, 토큰은 **통합 확정(POST) 전용**으로 유지된다.

**응답**

```json
{
  "code": 200,
  "message": "통합 대상 조회 완료",
  "data": {
    "providers": ["KAKAO"],
    "email": "hong@example.com",
    "phoneNumber": "01012345678",
    "username": "홍길동",
    "profileImageUrl": "https://k.kakaocdn.net/.../img_640x640.jpg"
  }
}
```

- `providers` — 프론트가 이 값으로 "카카오로 로그인하기" 버튼을 **확정 렌더링**한다(추론 불필요).
- `email`/`phoneNumber` — **pending에서 읽는다.** 임시 회원의 `member.email`은 온보딩 롤백으로 `NULL`이라,
  프론트가 앱 재시작·로그인 전환 후 복원할 방법이 없다. 호출자가 입력한 값의 **에코**이므로 신규 노출이 없다.
  (대상 회원의 현재 값을 쓰면 30분 창 안에 값이 바뀌었을 때 호출자가 모르던 값이 노출된다.)
- 자기소개·트랙·경력·활동점수는 제외했다. `WAITING` 회원 프로필은 회원 검색·마이페이지 어디에서도
  타인에게 노출되지 않으므로, 확인 목적을 넘는 항목은 싣지 않는다.

**읽기 전용·부수효과 없음** — pending을 소비·갱신·TTL 연장하지 않는다. 여러 번 호출해도 무방하다.

**검증은 통합 API와 동일하게 맞췄다.** 상태만 검사하면 이미 통합 불가능해진 pending으로
프로필을 보여준 뒤 POST에서 409가 나기 때문이다.

- 인증 주체가 `REGISTERING`
- 소셜 계정이 **정확히 1개**이고 pending의 `socialAccountId`·provider와 일치
- `pending.tempMemberId == 인증 주체`
- pending 미만료
- 대상이 `WAITING` 또는 `APPROVED`
- **대상의 현재 연락처가 pending 값과 여전히 일치**
- **대상이 pending provider를 아직 미보유**

### 3. 조회 경로 — 쓰기 락 회피

기존 `findByToken` / `findBySocialAccountIdForUpdate`는 **둘 다 `@Lock(PESSIMISTIC_WRITE)`** 다.
읽기 전용 조회에 재사용하면 통합·발급 경로와 경합·데드락을 유발한다(#348에서 데드락 재시도를 넣었던 지점).
락 없는 `findBySocialAccountId`를 별도로 추가했다.

조회 순서는 **소유권을 먼저 확정**하도록 잡았다.

```
회원 ID로 SocialAccount 조회  → 소유권이 조회 조건으로 성립. 정확히 1개인지 검증
그 계정 ID로 pending 조회      → social_account_id가 UNIQUE라 결과가 0~1건으로 확정
```

`tempMemberId`(UNIQUE 없음)를 조회 키로 쓰면 이론상 복수 행 → `Optional` 매핑 예외 → 500 경로가 생긴다.
UNIQUE 컬럼을 키로 쓰면 원천 차단되고 커스텀 JPQL도 필요 없다.

`Member#getSocialAccounts()` LAZY 컬렉션 대신 `SocialAccountRepository.findAllByMemberId`를 쓴다 —
트랜잭션 경계·OSIV 설정(현재 미설정 = 기본 `true`, 언제든 꺼질 수 있다)에 의존하지 않기 위함이다.

---

## 🗄️ 병합 후 실행해야 하는 쿼리

> **⚠️ 1) 섹션은 애플리케이션 배포 _전_ 에 실행해야 한다.**
> 순서를 지키지 않으면 배포 직후 회원 가입·통합 경로에 장애가 발생한다.

### 왜 순서가 중요한가

`target_member_id`는 `NOT NULL` 컬럼이다. 한 번에 `NOT NULL`로 추가하면
컬럼을 모르는 **구버전 인스턴스의 INSERT가 즉시 실패**한다.

```
ERROR 1364: Field 'target_member_id' doesn't have a default value
```

PR #351 배포 때 `member.provider`로 겪은 것과 같은 함정이다.

또한 `ddl-auto=update`에 맡기면 안 된다. Hibernate는 매핑대로 `NOT NULL` 컬럼 추가를 시도하는데,
- 테이블에 행이 있으면 → **실패하고 그대로 기동**된다. 이후 모든 pending INSERT가 `Unknown column`으로 실패한다.
- 테이블이 비어 있으면 → **성공해 버려서**, 아직 살아 있는 구버전 인스턴스가 위 1364로 죽는다.

**1) 을 먼저 실행해 컬럼을 nullable로 만들어 두면** Hibernate는 컬럼이 이미 있으므로 아무 것도 하지 않는다.

### 실행 순서

```
1) [앱 배포 전]        expand   — nullable 컬럼 추가
2)                     신버전 애플리케이션 배포
3) [배포 안정화 후]     migrate  — 구버전이 만든 잔여 행 정리
4) [3) 완료 후]        contract — NOT NULL 전환
5)                     적용 확인
```

### 1) [앱 배포 전, 필수] expand — nullable 컬럼 추가

```sql
-- 1-a) [사전 확인] 컬럼 존재 여부 — 1이면 1-b)는 no-op
SELECT COUNT(*) AS column_exists
FROM information_schema.columns
WHERE table_schema = DATABASE()
  AND table_name = 'pending_social_integration'
  AND column_name = 'target_member_id';

-- 1-b) 컬럼 추가 — 존재하지 않을 때만 (재실행 안전)
SET @col_exists := (
    SELECT COUNT(*)
    FROM information_schema.columns
    WHERE table_schema = DATABASE()
      AND table_name = 'pending_social_integration'
      AND column_name = 'target_member_id'
);
SET @ddl := IF(@col_exists = 0,
    'ALTER TABLE pending_social_integration ADD COLUMN target_member_id BIGINT NULL',
    'DO 0 /* target_member_id 이미 존재 — skip */');
PREPARE stmt FROM @ddl;
EXECUTE stmt;
DEALLOCATE PREPARE stmt;
```

FK·인덱스는 두지 않는다 — 기존 `social_account_id`도 FK가 없어 일관되며, 조회는 PK 단건이다.

### 2) 신버전 애플리케이션 배포

롤링 배포 중 구버전·신버전이 공존하는 구간에는 `target_member_id = NULL`인 pending이 계속 생긴다.
**이 구간은 코드에서 이미 처리했다** — NPE 없이 아래와 같이 동작한다.

| 경로 | 처리 |
|---|---|
| 온보딩 재제출 (`matchesContext`) | 동일 컨텍스트로 보지 않음 → **삭제 후 재발급** |
| 통합 POST (`isTargetMember`) | 어떤 주체와도 불일치 → `409` |
| 대상 조회 GET (`hasTargetMember`) | 명시 가드 → `409` |

사용자는 온보딩을 다시 제출하면 정상 토큰을 재발급받아 복구된다.

### 3) [배포 안정화 확인 후, 필수] migrate — 잔여 행 정리

```sql
-- 3-a) [사전 확인] 정리 대상 건수 — 배포 후 30분이 지났다면 대부분 0건이다
SELECT COUNT(*) AS rows_to_delete
FROM pending_social_integration
WHERE target_member_id IS NULL;

-- 3-b) 잔여 행 삭제 (재실행 안전)
DELETE FROM pending_social_integration
WHERE target_member_id IS NULL;
```

pending은 **TTL 30분의 1회성 데이터**이고 사용자는 온보딩 재제출로 즉시 재발급받을 수 있다.
연락처 역조회 백필은 그 사이 대상이 값을 바꿨을 수 있어 부정확하므로 **삭제**를 택한다.

### 4) [3) 완료 후, 필수] contract — NOT NULL 전환

```sql
-- 4-a) [중단 조건] NULL 행이 남아 있으면 아래 ALTER가 실패한다 — 0건이어야 한다
SELECT COUNT(*) AS remaining_null_rows
FROM pending_social_integration
WHERE target_member_id IS NULL;

-- 4-b) NOT NULL 전환 — 아직 nullable일 때만 (재실행 안전)
SET @is_nullable := (
    SELECT is_nullable
    FROM information_schema.columns
    WHERE table_schema = DATABASE()
      AND table_name = 'pending_social_integration'
      AND column_name = 'target_member_id'
);
SET @ddl := IF(@is_nullable = 'YES',
    'ALTER TABLE pending_social_integration MODIFY target_member_id BIGINT NOT NULL',
    'DO 0 /* 이미 NOT NULL 이거나 컬럼 없음 — skip */');
PREPARE stmt FROM @ddl;
EXECUTE stmt;
DEALLOCATE PREPARE stmt;
```

### 5) 적용 확인

```sql
-- 5-a) 컬럼이 NOT NULL로 존재하는지 (is_nullable = NO)
SELECT column_name, is_nullable, column_type
FROM information_schema.columns
WHERE table_schema = DATABASE()
  AND table_name = 'pending_social_integration'
  AND column_name = 'target_member_id';

-- 5-b) 기존 UNIQUE 제약 생존 확인 (각 1건)
SELECT DISTINCT index_name
FROM information_schema.statistics
WHERE table_schema = DATABASE()
  AND table_name = 'pending_social_integration'
  AND index_name IN ('uk_pending_integration_token', 'uk_pending_integration_social_account');

-- 5-c) 잔존 행 전수 확인 — null_target_rows 는 0이어야 한다
SELECT COUNT(*) AS total_rows,
       SUM(target_member_id IS NULL) AS null_target_rows
FROM pending_social_integration;
```

### 롤백

컬럼 추가는 되돌릴 수 있다(기존 컬럼 데이터에는 영향이 없지만 `target_member_id`에 저장된 통합 대상 정보는 삭제된다).

```sql
ALTER TABLE pending_social_integration DROP COLUMN target_member_id;
```

단 구버전으로 되돌린 뒤 실행해야 한다. 신버전이 떠 있는 상태로 DROP하면 pending 발급이 실패한다.

---

## 🧪 테스트

전체 테스트 통과 (ArchUnit 규칙 포함).

| 대상 | 추가한 검증 |
|---|---|
| `IntegrationTargetGetServiceTest` (신규) | 정상 조회, `WAITING` 대상 조회, 연락처가 pending 에코인지, 부수효과 없음, **쓰기 락 메서드 미호출**, 거부 케이스 8종 |
| `PendingSocialIntegrationTest` | `matchesContext` 전 필드, `isTargetMember`, `matchesContactInfo`, **구버전 null 행 처리** |
| `PendingIntegrationUsecaseTest` | 대상이 달라진 재요청 → 삭제·재발급, 구버전 null 행 → 재발급 |
| `SocialAccountIntegrateUsecaseTest` | 감지 대상이 아닌 회원의 통합 시도 → `409`, 구버전 null 행 → `409` |
| `OnboardingAccountValidatorTest` | `targetMemberId == emailOwner.id` 전달 확인 |

## 👀 리뷰 포인트

1. **`matchesContext`에 `targetMemberId`를 포함한 것** — 대상이 달라진 재요청을 재발급으로 흘려보내는 근거입니다.
2. **`email`/`phoneNumber`를 `pending`에서 읽는 것** — `target`에서 읽도록 바꾸면 정보 노출 경로가 생깁니다.
3. **응답 필드 범위** — `profileImageUrl` 포함 여부는 정책 판단이 필요하면 말씀해 주세요(필드 1개 삭제로 제외 가능).
4. **DDL 실행 순서** — 위 1)을 배포 전에 실행하는 것이 전제입니다.

## 📎 Issue 번호

Closes #354


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 계정 통합 대상 회원을 확인할 수 있는 조회 API를 추가했습니다.
  * 통합 대상의 이름, 프로필 이미지, 연락처 및 연결된 소셜 제공자 정보를 제공합니다.

* **개선**
  * 통합 대기 정보에 대상 회원을 포함해 잘못된 대상에 대한 토큰 재사용을 방지했습니다.
  * 회원 상태, 연락처, 만료 여부 및 소셜 계정 조건 검증을 강화했습니다.

* **버그 수정**
  * 기존 통합 정보가 없거나 불완전한 경우에도 안전하게 처리하도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->