### PR TITLE
[FEAT] admin 활동점수 관련 API 및 기능 개선

### DIFF
--- a/src/main/java/com/tavemakers/surf/application/activity/usecase/ActivityRecordUsecase.java
+++ b/src/main/java/com/tavemakers/surf/application/activity/usecase/ActivityRecordUsecase.java
@@ -160,9 +160,14 @@ public class ActivityRecordUsecase {
 
     /** 관리자용 회원의 전체 활동기록 페이징 조회 */
     @Transactional(readOnly = true)
-    public AdminActivityRecordSliceResDTO getAdminActivityRecordList(Long memberId, int pageNum, int pageSize) {
+    public AdminActivityRecordSliceResDTO getAdminActivityRecordList(
+            Long memberId,
+            ScoreType scoreType,
+            int pageNum,
+            int pageSize
+    ) {
         Pageable pageable = PageRequest.of(pageNum, pageSize, Sort.by(Sort.Direction.DESC, "createdAt"));
-        Slice<ActivityRecord> slice = activityRecordGetService.findAllActiveByMemberId(memberId, pageable);
+        Slice<ActivityRecord> slice = activityRecordGetService.findActivityRecordList(memberId, scoreType, pageable);
 
         return AdminActivityRecordSliceResDTO.from(slice.map(AdminActivityRecordResDTO::from));
     }

--- a/src/main/java/com/tavemakers/surf/application/member/query/TrackGetService.java
+++ b/src/main/java/com/tavemakers/surf/application/member/query/TrackGetService.java
@@ -33,9 +33,14 @@ public class TrackGetService {
                 .toList();
     }
 
-    //트랙과 함께 모든 회원 반환
+    /** 트랙과 함께 모든 회원 반환 */
     public List<Track> getAllTracksWithMember() {
         return trackRepository.findAllWithActiveMember();
+    }
+
+    /** 특정 기수의 활동 멤버 track 조회 */
+    public List<Track> getActiveTracksByGenerationWithMember(Integer generation) {
+        return trackRepository.findAllActiveByGenerationWithMember(generation);
     }
 
     public List<Integer> getExistsAllGenerations() {

--- a/src/main/java/com/tavemakers/surf/application/member/usecase/MemberUsecase.java
+++ b/src/main/java/com/tavemakers/surf/application/member/usecase/MemberUsecase.java
@@ -201,6 +201,7 @@ public class MemberUsecase {
     }
 
     /** 활동 기수에 해당하는 멤버를 파트별로 조회 */
+    @Transactional(readOnly = true)
     public List<MemberGroupedByPartResDTO> getMembersGroupedByPart(Integer generation) {
         List<Track> generationTracks = trackGetService.getActiveTracksByGenerationWithMember(generation);
 

--- a/src/main/java/com/tavemakers/surf/application/member/usecase/MemberUsecase.java
+++ b/src/main/java/com/tavemakers/surf/application/member/usecase/MemberUsecase.java
@@ -42,6 +42,8 @@ import java.math.BigDecimal;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -196,6 +198,48 @@ public class MemberUsecase {
                                 Collectors.toList()
                         )
                 ));
+    }
+
+    /** 활동 기수에 해당하는 멤버를 파트별로 조회 */
+    public List<MemberGroupedByPartResDTO> getMembersGroupedByPart(Integer generation) {
+        List<Track> generationTracks = trackGetService.getActiveTracksByGenerationWithMember(generation);
+
+        if (generationTracks.isEmpty()) {
+            return List.of();
+        }
+
+        Map<Part, List<MemberGroupedByPartResDTO.MemberCardDTO>> groupedByPart = generationTracks.stream()
+                .collect(Collectors.groupingBy(
+                        Track::getPart,
+                        Collectors.mapping(
+                                track -> MemberGroupedByPartResDTO.MemberCardDTO.of(
+                                        track.getMember(),
+                                        List.of(track)
+                                ),
+                                Collectors.toList()
+                        )
+                ));
+
+        return Arrays.stream(Part.values())
+                .filter(groupedByPart::containsKey)
+                .map(part -> MemberGroupedByPartResDTO.of(
+                        part,
+                        groupedByPart.get(part).stream()
+                                .collect(Collectors.collectingAndThen(
+                                        Collectors.toMap(
+                                                MemberGroupedByPartResDTO.MemberCardDTO::memberId,
+                                                member -> member,
+                                                (left, right) -> left
+                                        ),
+                                        deduped -> deduped.values().stream()
+                                                .sorted(Comparator.comparing(
+                                                        MemberGroupedByPartResDTO.MemberCardDTO::name,
+                                                        Comparator.nullsLast(String::compareTo)
+                                                ))
+                                                .toList()
+                                ))
+                ))
+                .toList();
     }
 
     /** 회원 프로필 및 경력 정보 수정 */

--- a/src/main/java/com/tavemakers/surf/application/score/usecase/ScoreRankingUsecase.java
+++ b/src/main/java/com/tavemakers/surf/application/score/usecase/ScoreRankingUsecase.java
@@ -1,18 +1,18 @@
 package com.tavemakers.surf.application.score.usecase;
 
-import com.tavemakers.surf.presentation.activity.dto.activityRecord.response.TeamMemberScoreListResDTO;
+import com.tavemakers.surf.application.member.query.MemberGetService;
+import com.tavemakers.surf.application.score.query.PersonalScoreGetService;
+import com.tavemakers.surf.application.team.query.TeamGetService;
 import com.tavemakers.surf.domain.member.entity.Member;
 import com.tavemakers.surf.domain.member.entity.Track;
 import com.tavemakers.surf.domain.member.entity.enums.Part;
-import com.tavemakers.surf.application.member.query.MemberGetService;
+import com.tavemakers.surf.domain.score.entity.PersonalActivityScore;
+import com.tavemakers.surf.domain.team.entity.Team;
+import com.tavemakers.surf.presentation.activity.dto.activityRecord.response.TeamMemberScoreListResDTO;
 import com.tavemakers.surf.presentation.score.dto.response.MemberScoreRankingResDTO;
 import com.tavemakers.surf.presentation.score.dto.response.MemberScoreRankingSliceResDTO;
 import com.tavemakers.surf.presentation.score.dto.response.TeamScoreRankingResDTO;
 import com.tavemakers.surf.presentation.score.dto.response.TeamScoreRankingSliceResDTO;
-import com.tavemakers.surf.domain.score.entity.PersonalActivityScore;
-import com.tavemakers.surf.application.score.query.PersonalScoreGetService;
-import com.tavemakers.surf.domain.team.entity.Team;
-import com.tavemakers.surf.application.team.query.TeamGetService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.SliceImpl;
@@ -20,7 +20,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
-import java.util.*;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @Service
@@ -34,61 +36,54 @@ public class ScoreRankingUsecase {
 
     /** 개인별 상/벌점 현황 조회 (무한스크롤) */
     public MemberScoreRankingSliceResDTO getMemberScoreRanking(int pageNum, int pageSize) {
-        // 1. 활동 멤버 ID 목록 조회
         List<Long> memberIds = memberGetService.getActiveMemberIds();
         if (memberIds.isEmpty()) {
             return MemberScoreRankingSliceResDTO.from(
-                    new SliceImpl<>(List.of(), PageRequest.of(pageNum, pageSize), false));
+                    new SliceImpl<>(List.of(), PageRequest.of(pageNum, pageSize), false)
+            );
         }
 
-        // 2. Member 엔티티 목록 조회
         List<Member> members = memberGetService.findMembersByIds(memberIds);
         Map<Long, Member> memberMap = members.stream()
                 .collect(Collectors.toMap(Member::getId, m -> m, (a, b) -> a));
 
-        // 3. 누적 점수 조회
         Map<Long, PersonalActivityScore> scoreMap = personalScoreGetService.getPersonalScoreListByIds(memberIds).stream()
                 .collect(Collectors.toMap(s -> s.getMember().getId(), s -> s, (a, b) -> a));
 
-        // 4. DTO 조립 후 totalScore DESC 정렬
         List<MemberScoreRankingResDTO> dtoList = memberIds.stream()
                 .filter(memberMap::containsKey)
                 .map(id -> {
                     Member member = memberMap.get(id);
+                    Integer generation = extractLatestGeneration(member);
                     Part part = extractLatestPart(member);
                     PersonalActivityScore score = scoreMap.get(id);
                     BigDecimal rewardTotal = score != null ? score.getRewardPrefixSum() : BigDecimal.ZERO;
                     BigDecimal penaltyTotal = score != null ? score.getPenaltyPrefixSum().abs() : BigDecimal.ZERO;
                     BigDecimal totalScore = score != null ? score.getScore() : BigDecimal.ZERO;
-                    return MemberScoreRankingResDTO.of(member, part, rewardTotal, penaltyTotal, totalScore);
+                    return MemberScoreRankingResDTO.of(member, generation, part, rewardTotal, penaltyTotal, totalScore);
                 })
                 .sorted(Comparator.comparing(MemberScoreRankingResDTO::totalScore).reversed())
                 .toList();
 
-        // 5. 수동 Slice 생성
         return MemberScoreRankingSliceResDTO.from(createSlice(dtoList, pageNum, pageSize));
     }
 
     /** 팀별 상/벌점 현황 조회 (무한스크롤) */
     public TeamScoreRankingSliceResDTO getTeamScoreRanking(Integer generation, int pageNum, int pageSize) {
-        // 1. 팀 목록 조회
         List<Team> teams = teamGetService.getTeamsWithMembers(generation);
         if (teams.isEmpty()) {
             return TeamScoreRankingSliceResDTO.from(
-                    new SliceImpl<>(List.of(), PageRequest.of(pageNum, pageSize), false));
+                    new SliceImpl<>(List.of(), PageRequest.of(pageNum, pageSize), false)
+            );
         }
 
-        // 2. 팀 ID 수집
         List<Long> teamIds = teams.stream()
                 .map(Team::getId)
                 .toList();
 
-        // 3. 팀 자체 누적 점수 조회
-        Map<Long, PersonalActivityScore> teamScoreMap =
-                personalScoreGetService.getTeamScoreListByIds(teamIds).stream()
-                        .collect(Collectors.toMap(s -> s.getTeam().getId(), s -> s, (a, b) -> a));
+        Map<Long, PersonalActivityScore> teamScoreMap = personalScoreGetService.getTeamScoreListByIds(teamIds).stream()
+                .collect(Collectors.toMap(s -> s.getTeam().getId(), s -> s, (a, b) -> a));
 
-        // 4. DTO 조립 후 totalScore DESC 정렬
         List<TeamScoreRankingResDTO> dtoList = teams.stream()
                 .map(team -> {
                     PersonalActivityScore teamScore = teamScoreMap.get(team.getId());
@@ -100,7 +95,6 @@ public class ScoreRankingUsecase {
                 .sorted(Comparator.comparing(TeamScoreRankingResDTO::totalScore).reversed())
                 .toList();
 
-        // 5. 수동 Slice 생성
         return TeamScoreRankingSliceResDTO.from(createSlice(dtoList, pageNum, pageSize));
     }
 
@@ -122,12 +116,13 @@ public class ScoreRankingUsecase {
         List<MemberScoreRankingResDTO> members = team.getTeamMembers().stream()
                 .map(tm -> {
                     Member member = tm.getMember();
+                    Integer generation = extractLatestGeneration(member);
                     Part part = extractLatestPart(member);
                     PersonalActivityScore score = scoreMap.get(member.getId());
                     BigDecimal rewardTotal = score != null ? score.getRewardPrefixSum() : BigDecimal.ZERO;
                     BigDecimal penaltyTotal = score != null ? score.getPenaltyPrefixSum().abs() : BigDecimal.ZERO;
                     BigDecimal totalScore = score != null ? score.getScore() : BigDecimal.ZERO;
-                    return MemberScoreRankingResDTO.of(member, part, rewardTotal, penaltyTotal, totalScore);
+                    return MemberScoreRankingResDTO.of(member, generation, part, rewardTotal, penaltyTotal, totalScore);
                 })
                 .sorted(Comparator.comparing(MemberScoreRankingResDTO::totalScore).reversed())
                 .toList();
@@ -135,7 +130,7 @@ public class ScoreRankingUsecase {
         return TeamMemberScoreListResDTO.of(team.getId(), team.getName(), members);
     }
 
-    /** 멤버의 최신 기수 Track에서 Part를 추출합니다. 조회 가능한 Track이 없으면 null을 반환합니다. */
+    /** 멤버의 최신 기수 Track에서 Part를 추출합니다. */
     private Part extractLatestPart(Member member) {
         return member.getTracks().stream()
                 .max(Comparator.comparing(Track::getGeneration))
@@ -143,7 +138,15 @@ public class ScoreRankingUsecase {
                 .orElse(null);
     }
 
-    /** 리스트에서 수동 Slice 생성 (offset/limit 기반) */
+    /** 멤버의 최신 기수를 추출합니다. */
+    private Integer extractLatestGeneration(Member member) {
+        return member.getTracks().stream()
+                .map(Track::getGeneration)
+                .max(Integer::compareTo)
+                .orElse(null);
+    }
+
+    /** 리스트를 기반으로 수동 Slice를 생성합니다. */
     private <T> SliceImpl<T> createSlice(List<T> list, int pageNum, int pageSize) {
         int start = pageNum * pageSize;
         int end = Math.min(start + pageSize, list.size());
@@ -156,5 +159,4 @@ public class ScoreRankingUsecase {
         boolean hasNext = end < list.size();
         return new SliceImpl<>(content, PageRequest.of(pageNum, pageSize), hasNext);
     }
-
 }

--- a/src/main/java/com/tavemakers/surf/domain/member/repository/TrackRepository.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/repository/TrackRepository.java
@@ -34,6 +34,8 @@ public interface TrackRepository extends JpaRepository<Track, Long> {
             "AND m.activityStatus = true " +
             "AND m.status = com.tavemakers.surf.domain.member.entity.enums.MemberStatus.APPROVED " +
             "AND m.isDeleted = false")
+
+    /** 특정 기수의 활동 회원 트랙 목록을 조회합니다. */
     List<Track> findAllActiveByGenerationWithMember(@Param("generation") Integer generation);
 
     List<Track> findByMemberId(Long memberId);

--- a/src/main/java/com/tavemakers/surf/domain/member/repository/TrackRepository.java
+++ b/src/main/java/com/tavemakers/surf/domain/member/repository/TrackRepository.java
@@ -29,6 +29,13 @@ public interface TrackRepository extends JpaRepository<Track, Long> {
             "AND t.generation = (SELECT MAX(t2.generation) FROM Track t2 WHERE t2.member = t.member)")
     List<Track> findAllWithActiveMember();
 
+    @Query("SELECT t FROM Track t JOIN FETCH t.member m " +
+            "WHERE t.generation = :generation " +
+            "AND m.activityStatus = true " +
+            "AND m.status = com.tavemakers.surf.domain.member.entity.enums.MemberStatus.APPROVED " +
+            "AND m.isDeleted = false")
+    List<Track> findAllActiveByGenerationWithMember(@Param("generation") Integer generation);
+
     List<Track> findByMemberId(Long memberId);
 
     @Query("SELECT DISTINCT t.generation FROM Track t ORDER BY t.generation DESC")

--- a/src/main/java/com/tavemakers/surf/presentation/activity/controller/activityRecord/ActivityRecordGetController.java
+++ b/src/main/java/com/tavemakers/surf/presentation/activity/controller/activityRecord/ActivityRecordGetController.java
@@ -1,5 +1,6 @@
 package com.tavemakers.surf.presentation.activity.controller.activityRecord;
 
+import com.tavemakers.surf.domain.activity.entity.enums.ScoreType;
 import com.tavemakers.surf.presentation.activity.dto.activityRecord.response.AdminActivityRecordSliceResDTO;
 import com.tavemakers.surf.application.activity.usecase.ActivityRecordUsecase;
 import com.tavemakers.surf.global.common.response.ApiResponse;
@@ -23,10 +24,12 @@ public class ActivityRecordGetController {
     @GetMapping("/v1/admin/scores/members/{memberId}/activity-records")
     public ApiResponse<AdminActivityRecordSliceResDTO> getAdminActivityRecords(
             @PathVariable Long memberId,
+            @RequestParam ScoreType scoreType,
             @RequestParam int pageNum,
             @RequestParam int pageSize
     ) {
-        AdminActivityRecordSliceResDTO response = activityRecordUsecase.getAdminActivityRecordList(memberId, pageNum, pageSize);
+        AdminActivityRecordSliceResDTO response =
+                activityRecordUsecase.getAdminActivityRecordList(memberId, scoreType, pageNum, pageSize);
         return ApiResponse.response(HttpStatus.OK, ACTIVITY_RECORD_READ.getMessage(), response);
     }
 

--- a/src/main/java/com/tavemakers/surf/presentation/activity/dto/activityRecord/response/AdminActivityRecordResDTO.java
+++ b/src/main/java/com/tavemakers/surf/presentation/activity/dto/activityRecord/response/AdminActivityRecordResDTO.java
@@ -18,6 +18,7 @@ public record AdminActivityRecordResDTO(
         String activityName,
         ScoreType scoreType,
         LocalDate activityDate,
+        BigDecimal prefixSum,
         BigDecimal appliedScore
 ) {
     /** 관리자용 활동기록 응답 DTO 생성 */
@@ -28,6 +29,7 @@ public record AdminActivityRecordResDTO(
                 .activityName(record.getActivityType().getDisplayName())
                 .scoreType(record.getScoreType())
                 .activityDate(record.getActivityDate())
+                .prefixSum(record.getPrefixSum())
                 .appliedScore(record.getAppliedScore())
                 .build();
     }

--- a/src/main/java/com/tavemakers/surf/presentation/member/controller/MemberGetController.java
+++ b/src/main/java/com/tavemakers/surf/presentation/member/controller/MemberGetController.java
@@ -1,20 +1,33 @@
 package com.tavemakers.surf.presentation.member.controller;
 
-import com.tavemakers.surf.presentation.member.dto.response.*;
 import com.tavemakers.surf.application.member.usecase.MemberUsecase;
 import com.tavemakers.surf.global.common.response.ApiResponse;
 import com.tavemakers.surf.global.util.SecurityUtils;
+import com.tavemakers.surf.presentation.member.dto.response.GenerationInfoListResDTO;
+import com.tavemakers.surf.presentation.member.dto.response.MemberGroupedByPartResDTO;
+import com.tavemakers.surf.presentation.member.dto.response.MemberSearchResDTO;
+import com.tavemakers.surf.presentation.member.dto.response.MemberSearchSliceResDTO;
+import com.tavemakers.surf.presentation.member.dto.response.MemberSimpleResDTO;
+import com.tavemakers.surf.presentation.member.dto.response.MembersCountByMemberStatusResDTO;
+import com.tavemakers.surf.presentation.member.dto.response.MyPageProfileResDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 import java.util.Map;
 
-import static com.tavemakers.surf.presentation.member.controller.ResponseMessage.*;
+import static com.tavemakers.surf.presentation.member.controller.ResponseMessage.APPROVED_ALL_GENERATION;
+import static com.tavemakers.surf.presentation.member.controller.ResponseMessage.MEMBER_GROUP_SUCCESS;
+import static com.tavemakers.surf.presentation.member.controller.ResponseMessage.MEMBER_LIST_SEARCH_SUCCESS;
+import static com.tavemakers.surf.presentation.member.controller.ResponseMessage.MEMBERS_COUNT_READ;
+import static com.tavemakers.surf.presentation.member.controller.ResponseMessage.MYPAGE_MY_PROFILE_READ;
 
 @RestController
 @RequiredArgsConstructor
@@ -24,35 +37,49 @@ public class MemberGetController {
 
     private final MemberUsecase memberUsecase;
 
-    //이름 기반 조회
     @Operation(
             summary = "이름 기반 회원 조회",
-            description = "파라미터로 특정 이름을 받아 해당하는 회원 리스트를 반환합니다.")
+            description = "특정 이름을 가진 회원 목록을 조회합니다.")
     @GetMapping("/v1/admin/members/search")
     public ApiResponse<List<MemberSearchResDTO>> searchMemberByName(
-            @RequestParam @NotBlank(message = "검색어(name)은 필수입니다.") String name) {
-
+            @RequestParam @NotBlank(message = "검색어(name)는 필수입니다.") String name
+    ) {
         return ApiResponse.response(
                 HttpStatus.OK,
-                ResponseMessage.MEMBER_GROUP_SUCCESS.getFormattedMessage(name),
-                memberUsecase.findMemberByNameAndTrack(name));
+                MEMBER_GROUP_SUCCESS.getFormattedMessage(name),
+                memberUsecase.findMemberByNameAndTrack(name)
+        );
     }
 
-    //유저 전체 출력시 트랙+기수별 묶어서 출력
     @Operation(
-            summary = "활동 중인 회원 전체 출력시 트랙+기수별로 출력 ",
-            description = "활동 중인 회원 전체 출력시 트랙+기수별로 출력")
+            summary = "활동 회원 트랙별 조회",
+            description = "활동 중인 회원을 트랙과 기수 기준으로 그룹화해 조회합니다.")
     @GetMapping("/v1/admin/members/search/grouped-by-track")
     public ApiResponse<Map<String, List<MemberSimpleResDTO>>> getGroupedMembers() {
         return ApiResponse.response(
                 HttpStatus.OK,
-                ResponseMessage.MEMBER_GROUP_SUCCESS.getMessage(),
-                memberUsecase.getMembersGroupedByTrack());
+                MEMBER_GROUP_SUCCESS.getMessage(),
+                memberUsecase.getMembersGroupedByTrack()
+        );
     }
 
     @Operation(
-            summary = "마이페이지에서 프로필 정보 조회",
-            description = "마이페이지에서 프로필 정보 조회")
+            summary = "활동 기수 기준 파트별 멤버 조회",
+            description = "활동 기수에 해당하는 활동 멤버를 파트별로 묶어 조회합니다.")
+    @GetMapping("/v1/admin/members/grouped-by-part")
+    public ApiResponse<List<MemberGroupedByPartResDTO>> getGroupedMembersByPart(
+            @RequestParam Integer generation
+    ) {
+        return ApiResponse.response(
+                HttpStatus.OK,
+                MEMBER_GROUP_SUCCESS.getMessage(),
+                memberUsecase.getMembersGroupedByPart(generation)
+        );
+    }
+
+    @Operation(
+            summary = "마이페이지 프로필 조회",
+            description = "마이페이지에서 프로필 정보를 조회합니다.")
     @GetMapping("/v1/user/members/profile")
     public ApiResponse<MyPageProfileResDTO> getMyPageAndProfile(
             @RequestParam(required = false) Long memberId
@@ -64,7 +91,7 @@ public class MemberGetController {
 
     @Operation(
             summary = "회원이름 및 학교로 검색 (기수/파트 필터링)",
-            description = "회원이름 및 학교로 검색 (기수/파트 필터링)"
+            description = "회원이름 및 학교로 회원을 검색합니다. (기수/파트 필터링)"
     )
     @GetMapping("/v1/user/members")
     public ApiResponse<MemberSearchSliceResDTO> searchMembers(
@@ -79,9 +106,8 @@ public class MemberGetController {
     }
 
     @Operation(
-            summary = "멤버 상태에 따른 전체 회원 수 조회",
-            description = "멤버 상태에 따른 전체 회원 수 조회"
-    )
+            summary = "회원 수 조회",
+            description = "회원 상태 목록과 키워드 기준으로 회원 수를 조회합니다.")
     @GetMapping("/v1/user/members-count")
     public ApiResponse<MembersCountByMemberStatusResDTO> getMembersCount(
             @RequestParam List<String> memberStatuses,
@@ -91,11 +117,12 @@ public class MemberGetController {
         return ApiResponse.response(HttpStatus.OK, MEMBERS_COUNT_READ.getMessage(), data);
     }
 
-    @Operation(summary = "존재하는 회원들의 [모든 기수 정보] 조회", description = "존재하는 회원들의 [모든 기수 정보] 조회")
+    @Operation(
+            summary = "전체 기수 조회",
+            description = "존재하는 모든 기수 정보를 조회합니다.")
     @GetMapping("/v1/user/generations")
     public ApiResponse<GenerationInfoListResDTO> readAllMemberCountAndGeneration() {
         GenerationInfoListResDTO data = memberUsecase.readExistingGenerations();
         return ApiResponse.response(HttpStatus.OK, APPROVED_ALL_GENERATION.getMessage(), data);
     }
-
 }

--- a/src/main/java/com/tavemakers/surf/presentation/member/dto/response/MemberGroupedByPartResDTO.java
+++ b/src/main/java/com/tavemakers/surf/presentation/member/dto/response/MemberGroupedByPartResDTO.java
@@ -1,0 +1,43 @@
+package com.tavemakers.surf.presentation.member.dto.response;
+
+import com.tavemakers.surf.domain.member.entity.Member;
+import com.tavemakers.surf.domain.member.entity.Track;
+import com.tavemakers.surf.domain.member.entity.enums.Part;
+
+import java.util.Comparator;
+import java.util.List;
+
+public record MemberGroupedByPartResDTO(
+        String part,
+        String partDisplayName,
+        List<MemberCardDTO> members
+) {
+    public static MemberGroupedByPartResDTO of(Part part, List<MemberCardDTO> members) {
+        return new MemberGroupedByPartResDTO(
+                part.name(),
+                part.getDisplayName(),
+                members
+        );
+    }
+
+    public record MemberCardDTO(
+            Long memberId,
+            String name,
+            String profileImageUrl,
+            List<TrackResDTO> tracks
+    ) {
+        public static MemberCardDTO of(Member member, List<Track> tracks) {
+            List<TrackResDTO> trackDtos = tracks.stream()
+                    .sorted(Comparator.reverseOrder())
+                    .map(TrackResDTO::from)
+                    .toList();
+
+            return new MemberCardDTO(
+                    member.getId(),
+                    member.getName(),
+                    member.getProfileImageUrl(),
+                    trackDtos
+            );
+        }
+    }
+}

--- a/src/main/java/com/tavemakers/surf/presentation/member/dto/response/MemberGroupedByPartResDTO.java
+++ b/src/main/java/com/tavemakers/surf/presentation/member/dto/response/MemberGroupedByPartResDTO.java
@@ -12,6 +12,7 @@ public record MemberGroupedByPartResDTO(
         String partDisplayName,
         List<MemberCardDTO> members
 ) {
+    /** 파트별 회원 응답을 생성합니다. */
     public static MemberGroupedByPartResDTO of(Part part, List<MemberCardDTO> members) {
         return new MemberGroupedByPartResDTO(
                 part.name(),
@@ -26,6 +27,7 @@ public record MemberGroupedByPartResDTO(
             String profileImageUrl,
             List<TrackResDTO> tracks
     ) {
+        /** 회원과 트랙 정보를 회원 카드 응답으로 변환합니다. */
         public static MemberCardDTO of(Member member, List<Track> tracks) {
             List<TrackResDTO> trackDtos = tracks.stream()
                     .sorted(Comparator.reverseOrder())

--- a/src/main/java/com/tavemakers/surf/presentation/score/dto/response/MemberScoreRankingResDTO.java
+++ b/src/main/java/com/tavemakers/surf/presentation/score/dto/response/MemberScoreRankingResDTO.java
@@ -9,19 +9,25 @@ public record MemberScoreRankingResDTO(
         Long memberId,
         String profileImageUrl,
         String name,
+        Integer generation,
         String part,
         BigDecimal rewardTotal,
         BigDecimal penaltyTotal,
         BigDecimal totalScore
 ) {
-    /** 개인별 상/벌점 현황 DTO 생성 */
-    public static MemberScoreRankingResDTO of(Member member, Part part,
-                                               BigDecimal rewardTotal, BigDecimal penaltyTotal,
-                                               BigDecimal totalScore) {
+    public static MemberScoreRankingResDTO of(
+            Member member,
+            Integer generation,
+            Part part,
+            BigDecimal rewardTotal,
+            BigDecimal penaltyTotal,
+            BigDecimal totalScore
+    ) {
         return new MemberScoreRankingResDTO(
                 member.getId(),
                 member.getProfileImageUrl(),
                 member.getName(),
+                generation,
                 part != null ? part.getDisplayName() : null,
                 rewardTotal,
                 penaltyTotal,


### PR DESCRIPTION
## 📄 작업 내용 요약
> 어드민 활동점수 관리 화면에서 필요한 백엔드 응답 구조와 조회 조건을 화면 요구사항에 맞게 보완


## 1. 회원 활동기록 조회에 `scoreType` 파라미터 추가
- 관리자 회원 활동기록 조회 API에 `scoreType` 파라미터를 반영하여, 상점/벌점 탭이 서버 기준으로 분리되도록 함
- 이로 인해 FE가 응답을 받은 뒤 별도로 필터링하지 않아도 되고, 탭별 페이징 기준도 독립적으로 맞출 수 있도록 정리함

> 변경 이유: 관리자용 활동기록 조회 API가 `pageNum`, `pageSize`만 받고 있어 FE가 응답 DTO의 `scoreType` 값을 기준으로 클라이언트에서 후처리해야 했음. 이 구조에서는 서버 페이징 이후에 필터링이 이루어져 페이지마다 실제 표시 개수가 달라지고, 상점/벌점 탭의 무한스크롤이 정상적으로 동작하지 않는 문제가 있었음.

<img width="320" height="281" alt="image" src="https://github.com/user-attachments/assets/0226d92b-7a78-4f02-a133-10de537f731f" />


## 2. 파트별 대상 목록 API 추가
- 회원 점수 부여 화면의 `파트` 탭 구현을 위해, 활동 기수 기준으로 멤버를 파트별로 묶어 내려주는 신규 API 추가
- `tracks`는 전체 이력이 아니라 현재 활동 기수에 해당하는 정보만 내려가도록 정리

> 변경 이유: `grouped-by-track` API는 응답이 `Map<String, MemberSimpleResDTO[]>` 구조라 파트 탭 UI와 맞지 않았고, `memberId`, `name`만 제공하여 파트별 아코디언 UI를 FE에서 바로 구성하기 어려웠고, 화면 요구사항에 맞는 별도 응답 구조가 필요했음.

<img width="394" height="281" alt="image" src="https://github.com/user-attachments/assets/6c14f46f-623b-49b4-b51f-646403b054ba" />

### 응답 예시
```
{
  "code": 200,
  "message": "[트랙별로 현재 활동 중인 [회원]을 조회했습니다.",
  "data": [
    {
      "part": "BACKEND",
      "partDisplayName": "백엔드",
      "members": [
        {
          "memberId": 1,
          "name": "홍길동",
          "profileImageUrl": "http://img1.kakaocdn.net/thumb/R640x640.q70/?fname=http%3A%2F%2Ft1.kakaocdn.net%2Faccount_images%2Fdefault_profile.jpeg",
          "tracks": [
            {
              "generation": 14,
              "part": "BACKEND"
            }
          ]
        }
      ]
    }
  ]
}
```

## 3. 관리자용 활동기록 응답에 `prefixSum` 추가
- 관리자용 활동기록 응답 DTO에 `prefixSum` 필드를 추가하여 각 기록 시점의 누적 점수를 함께 내려주도록 보완함

> 변경 이유: 기존에는 관리자용 활동기록 응답에 `appliedScore`만 있고 `prefixSum`이 없어, FE가 조회된 페이지 범위 안에서 누적값을 임시 계산해 표시하고 있었음. 이 방식은 2페이지 이상으로 넘어가면 이전 페이지 정보가 반영되지 않아 값이 틀어짐.

### 응답 예시
```
{
  "activityRecordId": 871716006922516961,
  "activityType": "EARLY_BIRD",
  "activityName": "얼리버드",
  "scoreType": "REWARD",
  "activityDate": "2026-09-06",
  "prefixSum": 110. 
  "appliedScore": 10
}

```

## 4. 개인별 점수 랭킹 응답에 `generation` 추가
- 개인별 점수 랭킹 응답에 `generation` 필드를 추가하여, 각 멤버의 기수 정보를 함께 표기
- 별도의 추가 API 호출 없이 응답만으로 필요한 정보 구성

> 변경 이유: 기존 응답에는 `part`만 존재해 개별 회원 점수 조회 시 화면 상단 배지에서 기수를 표시할 수 없었음. 이를 위해서는 멤버별 상세 조회 API를 추가로 호출해야 했지만, 목록 진입 시 멤버마다 별도 요청이 발생하여 비효율적이었음.

<img width="374" height="236" alt="image" src="https://github.com/user-attachments/assets/e8bb4576-876e-4863-97be-c9b38f8f778e" />


## 📎 Issue 번호
closed #358

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 기수별 회원을 파트 단위로 그룹화해 조회할 수 있는 기능이 추가되었습니다.
  * 관리자 활동 기록 조회 시 점수 유형으로 필터링할 수 있습니다.
  * 관리자 활동 기록에 누적 점수 정보가 표시됩니다.
  * 개인 및 팀 점수 랭킹에 회원의 활동 기수와 파트 정보가 함께 제공됩니다.
* **개선**
  * 회원 검색 및 조회 API 설명이 보다 명확하게 정리되었습니다.
  * 활동 중인 회원 트랙을 기수별로 정확히 조회할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->