### PR TITLE
[FEAT] 계정 통합 대상 조회 응답에 회원 역할(role) 추가

### DIFF
--- a/src/main/java/com/tavemakers/surf/presentation/member/dto/response/IntegrationTargetResDTO.java
+++ b/src/main/java/com/tavemakers/surf/presentation/member/dto/response/IntegrationTargetResDTO.java
@@ -26,6 +26,9 @@ public record IntegrationTargetResDTO(
         @Schema(description = "통합 대상 프로필 이미지 URL")
         String profileImageUrl,
 
+        @Schema(description = "통합 대상 역할", example = "MEMBER")
+        String role,
+
         @Schema(description = "통합 대상 트랙 목록")
         List<TrackResDTO> trackList,
 
@@ -52,6 +55,7 @@ public record IntegrationTargetResDTO(
                 pending.getNormalizedPhone(),
                 target.getName(),
                 target.getProfileImageUrl(),
+                target.getRole().name(),
                 trackList,
                 target.getSelfIntroduction()
         );

--- a/src/test/java/com/tavemakers/surf/application/member/query/IntegrationTargetGetServiceTest.java
+++ b/src/test/java/com/tavemakers/surf/application/member/query/IntegrationTargetGetServiceTest.java
@@ -4,6 +4,7 @@ import com.tavemakers.surf.domain.auth.common.enums.Provider;
 import com.tavemakers.surf.domain.member.entity.Member;
 import com.tavemakers.surf.domain.member.entity.PendingSocialIntegration;
 import com.tavemakers.surf.domain.member.entity.SocialAccount;
+import com.tavemakers.surf.domain.member.entity.enums.MemberRole;
 import com.tavemakers.surf.domain.member.entity.enums.MemberStatus;
 import com.tavemakers.surf.domain.member.entity.enums.Part;
 import com.tavemakers.surf.domain.member.exception.IntegrationNotEligibleException;
@@ -55,7 +56,9 @@ class IntegrationTargetGetServiceTest {
     }
 
     private Member targetOf(MemberStatus status, String email, String phone) {
-        Member m = Member.builder().status(status).name("홍길동").email(email).phoneNumber(phone).build();
+        // 기본값(MEMBER)이 아닌 역할을 넣어 대상 회원의 값이 그대로 실리는지 확인한다
+        Member m = Member.builder().status(status).role(MemberRole.MANAGER)
+                .name("홍길동").email(email).phoneNumber(phone).build();
         ReflectionTestUtils.setField(m, "id", TARGET_ID);
         ReflectionTestUtils.setField(m, "profileImageUrl", "https://cdn/profile.jpg");
         ReflectionTestUtils.setField(m, "selfIntroduction", "안녕하세요. 백엔드 개발자입니다.");
@@ -106,6 +109,7 @@ class IntegrationTargetGetServiceTest {
         assertThat(result.providers()).containsExactly("KAKAO"); // 임시 회원의 APPLE 이 섞이지 않는다
         assertThat(result.username()).isEqualTo("홍길동");
         assertThat(result.profileImageUrl()).isEqualTo("https://cdn/profile.jpg");
+        assertThat(result.role()).isEqualTo("MANAGER");
         assertThat(result.trackList())
                 .extracting("generation", "part")
                 .containsExactly(


### PR DESCRIPTION
## 📄 작업 내용 요약
> `GET /v1/user/social-accounts/integrate/target` 응답에 통합 대상 회원의 역할(`role`)을 추가

- 통합 확인 화면에서 대상 계정의 역할을 함께 노출할 수 있도록 `IntegrationTargetResDTO`에 `role` 필드 추가 (`profileImageUrl` 다음 위치)
- `MemberRole` enum을 직접 노출하지 않고 `target.getRole().name()`으로 매핑 — 같은 DTO의 `providers`, 그리고 `MyPageProfileResDTO`·`MemberInformationResDTO` 등 기존 member 응답 DTO 컨벤션과 일치시킴
- `role`은 `Member` 생성 시 `MEMBER`로 기본 세팅되어 null이 될 수 없으므로 별도 분기 없음
- 매핑이 응답 DTO 정적 팩토리 안에서만 이루어져 domain·usecase 계층 변경 없음

### 응답 예시
```json
{
  "code": 200,
  "message": "통합 대상 조회 완료",
  "data": {
    "providers": ["KAKAO"],
    "email": "hong@example.com",
    "phoneNumber": "01012345678",
    "username": "홍길동",
    "profileImageUrl": "https://cdn/profile.jpg",
    "role": "MEMBER",
    "trackList": [{ "generation": 15, "part": "BACKEND" }],
    "selfIntroduction": "안녕하세요. 백엔드 개발자 홍길동입니다."
  }
}
```

### 테스트
- `IntegrationTargetGetServiceTest`의 `targetOf()` 헬퍼가 기본값(`MEMBER`)이 아닌 `MANAGER`를 갖도록 하여, 응답의 `role`이 기본값이 아닌 대상 회원의 값에서 온다는 것을 검증
- 정상 조회 케이스에 `role` 응답 검증 추가
- `IntegrationTargetGetServiceTest`, `CleanArchitectureRulesTest` 통과

## 📎 Issue 번호
closed #360

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 통합 대상 조회 응답에 대상 회원의 역할 정보가 추가됩니다.

* **버그 수정**
  * 대상 회원의 역할이 응답에 정확히 반환되도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->