### PR TITLE
[HOTFIX] 관리자 팀 조회 API 기수 선택 필터 추가

### DIFF
--- a/src/main/java/com/tavemakers/surf/application/team/query/TeamGetService.java
+++ b/src/main/java/com/tavemakers/surf/application/team/query/TeamGetService.java
@@ -49,8 +49,8 @@ public class TeamGetService {
     }
 
     /** 팀 목록 조회 (기수별 섹션으로 구성) */
-    public List<TeamGenerationSectionResDTO> getTeams(TeamType type) {
-        List<TeamListResDTO> teams = teamRepository.findAllForAccordion(type).stream()
+    public List<TeamGenerationSectionResDTO> getTeams(TeamType type, Integer generation) {
+        List<TeamListResDTO> teams = teamRepository.findAllForAccordion(type, generation).stream()
                 .map(TeamListResDTO::from)
                 .toList();
 

--- a/src/main/java/com/tavemakers/surf/application/team/usecase/TeamUsecase.java
+++ b/src/main/java/com/tavemakers/surf/application/team/usecase/TeamUsecase.java
@@ -26,8 +26,8 @@ public class TeamUsecase {
 
     /** 팀 목록 조회 */
     @Transactional(readOnly = true)
-    public List<TeamGenerationSectionResDTO> getTeams(TeamType type) {
-        return teamGetService.getTeams(type);
+    public List<TeamGenerationSectionResDTO> getTeams(TeamType type, Integer generation) {
+        return teamGetService.getTeams(type, generation);
     }
 
     /** 팀 상세 조회 */

--- a/src/main/java/com/tavemakers/surf/domain/team/repository/TeamRepository.java
+++ b/src/main/java/com/tavemakers/surf/domain/team/repository/TeamRepository.java
@@ -17,9 +17,10 @@ public interface TeamRepository extends JpaRepository<Team, Long> {
         select t
           from Team t
          where (:type is null or t.type = :type)
+           and (:generation is null or t.generation = :generation)
          order by t.generation desc, t.id desc
     """)
-    List<Team> findAllForAccordion(TeamType type);
+    List<Team> findAllForAccordion(@Param("type") TeamType type, @Param("generation") Integer generation);
 
     @EntityGraph(attributePaths = {
             "leader",

--- a/src/main/java/com/tavemakers/surf/presentation/team/controller/TeamGetController.java
+++ b/src/main/java/com/tavemakers/surf/presentation/team/controller/TeamGetController.java
@@ -24,12 +24,13 @@ public class TeamGetController {
     private final TeamUsecase teamUsecase;
 
     /** 팀 목록 조회 (파라미터 미입력 시 전체 조회, STUDY, PROJECT로 구분)*/
-    @Operation(summary = "팀 목록 조회", description = "팀 목록을 기수별로 구분하여 조회합니다. type 파라미터로 스터디/프로젝트 분리 가능 (STUDY, PROJECT)")
+    @Operation(summary = "팀 목록 조회", description = "팀 목록을 기수별로 구분하여 조회합니다. type 파라미터로 스터디/프로젝트 분리 가능, generation 파라미터로 기수 선택 가능")
     @GetMapping("/v1/admin/teams")
     public ApiResponse<List<TeamGenerationSectionResDTO>> getTeams(
-            @RequestParam(required = false) TeamType type
+            @RequestParam(required = false) TeamType type,
+            @RequestParam(required = false) Integer generation
     ) {
-        List<TeamGenerationSectionResDTO> response = teamUsecase.getTeams(type);
+        List<TeamGenerationSectionResDTO> response = teamUsecase.getTeams(type, generation);
         return ApiResponse.response(HttpStatus.OK, TEAM_READ.getMessage(), response);
     }
 

--- a/src/test/java/com/tavemakers/surf/application/team/usecase/TeamUsecaseTest.java
+++ b/src/test/java/com/tavemakers/surf/application/team/usecase/TeamUsecaseTest.java
@@ -101,11 +101,11 @@ class TeamUsecaseTest {
     @DisplayName("getTeams: 조회를 TeamGetService 에 위임하고 결과를 그대로 반환한다 (순수 위임 대표 케이스)")
     void getTeams_위임() {
         List<TeamGenerationSectionResDTO> sections = List.of(new TeamGenerationSectionResDTO(9, List.of()));
-        given(teamGetService.getTeams(TeamType.STUDY)).willReturn(sections);
+        given(teamGetService.getTeams(TeamType.STUDY, null)).willReturn(sections);
 
-        List<TeamGenerationSectionResDTO> result = teamUsecase.getTeams(TeamType.STUDY);
+        List<TeamGenerationSectionResDTO> result = teamUsecase.getTeams(TeamType.STUDY, null);
 
         assertThat(result).isSameAs(sections);
-        then(teamGetService).should().getTeams(TeamType.STUDY);
+        then(teamGetService).should().getTeams(TeamType.STUDY, null);
     }
 }


### PR DESCRIPTION
## 📄 작업 내용 요약
- `GET /v1/admin/teams`에 `generation` 선택 파라미터 추가
- `generation` 값이 없으면 기존과 동일하게 전체 기수의 팀을 반환하도록 유지

### 해당 파라미터 추가 사유
- `admin` 회원 점수 조회의 스터디/프로젝트 탭은 활동 기수 팀만 보여줘야 하는데, 지금은 `type` 필터만 있어서 전 기수를 다 받아온 뒤 프론트에서 거르고 있으며 기수 쌓일수록 낭비가 커짐
- 해당 파라미터가 선택이어야 하는 이유는, 회원그룹 관리 화면에서 같은 API로 전 기수를 기수별로 보여줘야 하기 때문

## 📎 Issue 번호
closed #362 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 팀 목록 조회 시 팀 유형과 함께 기수로도 필터링할 수 있습니다.
  * 기수 조건은 선택 사항이며, 입력하지 않으면 기존 조회 방식이 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->