### PR TITLE
[FEAT] 게시판·댓글 조회에 사용자 차단 필터 적용

### DIFF
--- a/src/main/java/com/tavemakers/surf/application/comment/query/CommentGetService.java
+++ b/src/main/java/com/tavemakers/surf/application/comment/query/CommentGetService.java
@@ -1,5 +1,6 @@
 package com.tavemakers.surf.application.comment.query;
 
+import com.tavemakers.surf.application.block.query.BlockGetService;
 import com.tavemakers.surf.presentation.comment.dto.response.CommentListResDTO;
 import com.tavemakers.surf.presentation.comment.dto.response.CommentResDTO;
 import com.tavemakers.surf.presentation.comment.dto.response.MentionResDTO;
@@ -13,6 +14,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * 댓글 목록 read-model 조립. 댓글/멘션/좋아요 조회를 오케스트레이션하고 표현형(DTO)을 구성한다.
@@ -25,16 +27,21 @@ public class CommentGetService {
     private final CommentRepository commentRepository;
     private final CommentMentionGetService commentMentionGetService;
     private final CommentLikeService commentLikeService;
+    private final BlockGetService blockGetService;
 
-    /** 댓글 목록 조회 */
+    /** 댓글 목록 조회 — 차단한 작성자의 댓글·대댓글은 제외한다 */
     public CommentListResDTO getComments(Long postId, Pageable pageable, Long memberId) {
+
+        // 0) 차단 작성자 집합 — Slice와 count에 반드시 같은 값을 넘긴다.
+        //    다르면 "댓글 3개"라고 표시되는데 목록은 비어 보이는 불일치가 생긴다.
+        Set<Long> excludedAuthorIds = blockGetService.getMyBlockedMemberIds(memberId);
 
         // 1) 댓글 Slice 조회
         Slice<Comment> commentSlice =
-                commentRepository.findByPostIdOrderByCreatedAtAsc(postId, pageable);
+                commentRepository.findByPostIdExcludingAuthors(postId, excludedAuthorIds, pageable);
 
         // 2) 댓글 총 개수 조회
-        long totalCount = commentRepository.countByPostId(postId);
+        long totalCount = commentRepository.countByPostIdExcludingAuthors(postId, excludedAuthorIds);
 
         // 3) 각 댓글 → DTO 변환 (멘션 일괄 조회로 N+1 방지)
         List<Comment> comments = commentSlice.getContent();

--- a/src/main/java/com/tavemakers/surf/application/comment/usecase/CommentUsecase.java
+++ b/src/main/java/com/tavemakers/surf/application/comment/usecase/CommentUsecase.java
@@ -6,6 +6,7 @@ import com.tavemakers.surf.presentation.comment.dto.response.CommentResDTO;
 import com.tavemakers.surf.presentation.comment.dto.response.MentionResDTO;
 import com.tavemakers.surf.application.comment.query.CommentGetService;
 import com.tavemakers.surf.application.comment.query.CommentMentionGetService;
+import com.tavemakers.surf.application.post.query.PostGetService;
 import com.tavemakers.surf.domain.comment.entity.Comment;
 import com.tavemakers.surf.domain.comment.service.CommentService;
 import com.tavemakers.surf.global.logging.LogEvent;
@@ -30,6 +31,7 @@ public class CommentUsecase {
     private final CommentService commentService;
     private final CommentGetService commentGetService;
     private final CommentMentionGetService commentMentionGetService;
+    private final PostGetService postGetService;
     private final LogEventEmitter logEventEmitter;
 
     /** 댓글 생성 */
@@ -62,9 +64,12 @@ public class CommentUsecase {
         commentService.deleteComment(postId, commentId, memberId);
     }
 
-    /** 댓글 목록 조회 */
+    /** 댓글 목록 조회 — 게시글 자체가 차단으로 가려지면 댓글도 보여주지 않는다 */
     @Transactional(readOnly = true)
     public CommentListResDTO getComments(Long postId, Pageable pageable, Long memberId) {
+
+        // 게시글 작성자를 차단했으면 상세와 동일하게 404. 댓글로 우회 열람되면 안 된다.
+        postGetService.validateVisiblePost(postId, memberId);
 
         CommentListResDTO result = commentGetService.getComments(postId, pageable, memberId);
 

--- a/src/main/java/com/tavemakers/surf/application/letter/usecase/LetterUsecase.java
+++ b/src/main/java/com/tavemakers/surf/application/letter/usecase/LetterUsecase.java
@@ -45,7 +45,14 @@ public class LetterUsecase {
         Member receiver = memberGetService.getMember(req.receiverId());
 
         // 3) 어느 방향이든 차단 관계가 있으면 저장·이벤트·메일보다 먼저 거부한다
-        if (blockGetService.existsBetween(senderId, receiver.getId())) {
+        if (blockGetService.existsBetween(senderId, req.receiverId())) {
+            // 차단 방향은 응답과 마찬가지로 로그에도 남기지 않는다
+            Map<String, Object> blockedProps = new HashMap<>();
+            blockedProps.put("sender_id", senderId);
+            blockedProps.put("receiver_id", req.receiverId());
+            blockedProps.put("status_code", 403);
+            blockedProps.put("error_code", "LETTER_BLOCKED");
+            logEventEmitter.emitError("letter_send_api_failed", blockedProps, "쪽지 전송 실패 - 차단 관계");
             throw new LetterBlockedException();
         }
 

--- a/src/main/java/com/tavemakers/surf/application/letter/usecase/LetterUsecase.java
+++ b/src/main/java/com/tavemakers/surf/application/letter/usecase/LetterUsecase.java
@@ -1,14 +1,16 @@
 package com.tavemakers.surf.application.letter.usecase;
 
-import com.tavemakers.surf.presentation.letter.dto.request.LetterCreateReqDTO;
-import com.tavemakers.surf.presentation.letter.dto.response.LetterResDTO;
-import com.tavemakers.surf.domain.letter.entity.Letter;
-import com.tavemakers.surf.domain.letter.exception.LetterMailSendFailException;
+import com.tavemakers.surf.application.block.query.BlockGetService;
 import com.tavemakers.surf.application.letter.query.LetterGetService;
-import com.tavemakers.surf.domain.member.entity.Member;
 import com.tavemakers.surf.application.member.query.MemberGetService;
+import com.tavemakers.surf.domain.letter.entity.Letter;
+import com.tavemakers.surf.domain.letter.exception.LetterBlockedException;
+import com.tavemakers.surf.domain.letter.exception.LetterMailSendFailException;
+import com.tavemakers.surf.domain.member.entity.Member;
 import com.tavemakers.surf.global.logging.LogEventEmitter;
 import com.tavemakers.surf.global.util.EmailSender;
+import com.tavemakers.surf.presentation.letter.dto.request.LetterCreateReqDTO;
+import com.tavemakers.surf.presentation.letter.dto.response.LetterResDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -23,6 +25,7 @@ import java.util.Map;
 public class LetterUsecase {
 
     private final MemberGetService memberGetService;
+    private final BlockGetService blockGetService;
     private final LetterCreateService letterCreateService;
     private final EmailSender emailSender;
     private final LetterGetService letterGetService;
@@ -41,7 +44,12 @@ public class LetterUsecase {
         // 2) 수신자 조회
         Member receiver = memberGetService.getMember(req.receiverId());
 
-        // validation 로그 (@Valid 통과 이후 실행되므로 result=true)
+        // 3) 어느 방향이든 차단 관계가 있으면 저장·이벤트·메일보다 먼저 거부한다
+        if (blockGetService.existsBetween(senderId, receiver.getId())) {
+            throw new LetterBlockedException();
+        }
+
+        // 4) validation 로그 (@Valid 통과 이후 실행되므로 result=true)
         String replyEmail = req.replyEmail();
         String emailDomain = replyEmail.contains("@")
                 ? replyEmail.substring(replyEmail.indexOf('@') + 1) : "";
@@ -61,7 +69,7 @@ public class LetterUsecase {
                 "validation_result", true
         ));
 
-        // 3) 엔티티 생성
+        // 5) 엔티티 생성
         Letter letter = Letter.create(
                 req.title(),
                 req.content(),
@@ -71,10 +79,10 @@ public class LetterUsecase {
                 receiver
         );
 
-        // 4) 저장 + 알림 이벤트 발행 (트랜잭션 커밋 → AFTER_COMMIT 리스너 발화)
+        // 6) 저장 + 알림 이벤트 발행 (트랜잭션 커밋 → AFTER_COMMIT 리스너 발화)
         Letter saved = letterCreateService.save(letter);
 
-        // 5) 이메일 본문 생성
+        // 7) 이메일 본문 생성
         String emailBody = """
         [Surf에서 %s님이 보낸 쪽지입니다.]
 
@@ -90,7 +98,7 @@ public class LetterUsecase {
                         req.sns() != null ? req.sns() : "-"
                 );
 
-        // 6) 이메일 전송 (트랜잭션 밖, 실패 시 예외 — 저장된 쪽지는 유지)
+        // 8) 이메일 전송 (트랜잭션 밖, 실패 시 예외 — 저장된 쪽지는 유지)
         boolean emailSent = false;
         try {
             emailSender.sendMail(receiver.getEmail(), req.title(), emailBody);
@@ -113,7 +121,7 @@ public class LetterUsecase {
                 "email_sent", emailSent
         ));
 
-        // 7) 저장된 엔티티 기반으로 Response 생성
+        // 9) 저장된 엔티티 기반으로 Response 생성
         return LetterResDTO.from(saved);
     }
 

--- a/src/main/java/com/tavemakers/surf/application/notification/event/NotificationEventListener.java
+++ b/src/main/java/com/tavemakers/surf/application/notification/event/NotificationEventListener.java
@@ -1,5 +1,6 @@
 package com.tavemakers.surf.application.notification.event;
 
+import com.tavemakers.surf.application.block.query.BlockGetService;
 import com.tavemakers.surf.domain.comment.event.CommentCreatedEvent;
 import com.tavemakers.surf.domain.comment.event.CommentLikedEvent;
 import com.tavemakers.surf.domain.comment.event.CommentReplyEvent;
@@ -30,7 +31,27 @@ public class NotificationEventListener {
 
     private final PostGetService postGetService;
     private final NotificationUsecase notificationUsecase;
+    private final BlockGetService blockGetService;
     private final LogEventEmitterImpl logEventEmitter;
+
+    /**
+     * 차단 관계이면 개인 알림을 만들지 않는다.
+     *
+     * <p>어느 방향이든 차단이 있으면 막는다(쪽지와 동일한 상호작용 정책). 콘텐츠 숨김의
+     * 단방향 필터와 달리, 알림은 직접 접촉이라 한쪽만 차단해도 접촉 경로가 남으면 안 된다.
+     *
+     * <p><b>가드는 반드시 알림 생성 이전에 둔다.</b> Notification을 저장하고 FCM만 막으면
+     * 알림함 목록과 미읽음 뱃지에는 차단한 상대의 이름이 계속 쌓인다.
+     *
+     * <p>공지 알림은 개인 간 상호작용이 아니므로 이 가드를 적용하지 않는다.
+     */
+    private boolean blockedBetween(Long receiverId, Long actorId, NotificationType type) {
+        if (!blockGetService.existsBetween(receiverId, actorId)) {
+            return false;
+        }
+        log.info("[BlockedNotification] skipped type={} receiverId={} actorId={}", type, receiverId, actorId);
+        return true;
+    }
 
     @Async
     @Transactional
@@ -53,6 +74,10 @@ public class NotificationEventListener {
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleCommentCreated(CommentCreatedEvent event) {
+        if (blockedBetween(event.getReceiverId(), event.getActorId(), NotificationType.POST_COMMENT)) {
+            return;
+        }
+
         notificationUsecase.createAndSend(
                 event.getReceiverId(),
                 NotificationType.POST_COMMENT,
@@ -72,6 +97,10 @@ public class NotificationEventListener {
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleCommentReply(CommentReplyEvent event) {
+        if (blockedBetween(event.getReceiverId(), event.getActorId(), NotificationType.COMMENT_REPLY)) {
+            return;
+        }
+
         notificationUsecase.createAndSend(
                 event.getReceiverId(),
                 NotificationType.COMMENT_REPLY,
@@ -91,6 +120,10 @@ public class NotificationEventListener {
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleCommentLiked(CommentLikedEvent event) {
+        if (blockedBetween(event.getReceiverId(), event.getActorId(), NotificationType.COMMENT_LIKE)) {
+            return;
+        }
+
         notificationUsecase.createAndSend(
                 event.getReceiverId(),
                 NotificationType.COMMENT_LIKE,
@@ -110,6 +143,10 @@ public class NotificationEventListener {
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handlePostLiked(PostLikedEvent event) {
+        if (blockedBetween(event.getReceiverId(), event.getActorId(), NotificationType.POST_LIKE)) {
+            return;
+        }
+
         notificationUsecase.createAndSend(
                 event.getReceiverId(),
                 NotificationType.POST_LIKE,
@@ -129,6 +166,14 @@ public class NotificationEventListener {
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleLetterSent(LetterSentEvent event) {
+        // 방어선 — 쪽지는 발송 단계에서 이미 거부되므로 이 이벤트 자체가 발행되지 않아야 한다.
+        // 여기서 걸린다면 LetterUsecase의 차단 가드가 우회된 것이므로 경고로 남긴다.
+        if (blockedBetween(event.getReceiverId(), event.getSenderId(), NotificationType.MESSAGE)) {
+            log.warn("[LetterNotification] 쪽지 발송 가드를 통과한 차단 관계 - receiverId={} senderId={}",
+                    event.getReceiverId(), event.getSenderId());
+            return;
+        }
+
         logEventEmitter.emit("letter_notification_requested", Map.of(
                 "sender_id", event.getSenderId(),
                 "receiver_id", event.getReceiverId(),

--- a/src/main/java/com/tavemakers/surf/application/post/query/PostGetService.java
+++ b/src/main/java/com/tavemakers/surf/application/post/query/PostGetService.java
@@ -1,5 +1,6 @@
 package com.tavemakers.surf.application.post.query;
 
+import com.tavemakers.surf.application.block.query.BlockGetService;
 import com.tavemakers.surf.presentation.post.dto.response.PostDetailResDTO;
 import com.tavemakers.surf.presentation.post.dto.response.PostFileResDTO;
 import com.tavemakers.surf.presentation.post.dto.response.PostImageResDTO;
@@ -29,6 +30,7 @@ public class PostGetService {
 
     private final PostRepository postRepository;
 
+    private final BlockGetService blockGetService;
     private final ScrapGetService scrapGetService;
     private final PostLikeService postLikeService;
     private final PostImageGetService imageGetService;
@@ -80,11 +82,30 @@ public class PostGetService {
         return postRepository.existsByCategoryId(categoryId);
     }
 
+    /**
+     * 사용자에게 보여도 되는 게시글인지 검증 — 없거나 작성자를 차단했으면 404.
+     *
+     * <p>댓글 목록처럼 게시글에 딸린 사용자 조회가 앞단에서 호출한다.
+     * 차단 사실을 상대에게 노출하지 않기 위해 403이 아니라 404로 존재 자체를 숨긴다.
+     *
+     * <p>scheduler/event가 쓰는 {@link #getPost}·{@link #readPost}·{@link #findPostById}에는
+     * 이 필터를 적용하지 않는다 — 내부 조합까지 차단으로 가리면 예약 발행·알림이 깨진다.
+     */
+    @Transactional(readOnly = true)
+    public void validateVisiblePost(Long postId, Long viewerId) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(PostNotFoundException::new);
+        validateNotBlockedAuthor(post, viewerId);
+    }
+
     /** 게시글 상세 조회 (DTO 반환) */
     @Transactional
     public PostDetailResDTO getPostDetail(Long postId, Long memberId) {
         Post post = postRepository.findById(postId)
                 .orElseThrow(PostNotFoundException::new);
+        // 차단 가드는 조회수 증가·스크랩·좋아요·첨부 조회보다 먼저 둔다.
+        // 뒤로 밀리면 숨겨야 할 글의 조회수가 오르고 부수효과가 남는다.
+        validateNotBlockedAuthor(post, memberId);
         boolean scrappedByMe = scrapGetService.isScrappedByMe(memberId, postId);
         boolean likedByMe = postLikeService.isLikedByMe(memberId, postId);
         boolean isMine = post.isOwner(memberId);
@@ -103,6 +124,13 @@ public class PostGetService {
         }
 
         return PostDetailResDTO.of(post, scrappedByMe, likedByMe, isMine, imageUrlList, fileUrlList, reservedAt, viewCount);
+    }
+
+    /** 내가 차단한 작성자의 글이면 존재하지 않는 것으로 취급한다 */
+    private void validateNotBlockedAuthor(Post post, Long viewerId) {
+        if (blockGetService.isBlockedByMe(viewerId, post.getMember().getId())) {
+            throw new PostNotFoundException();
+        }
     }
 
     /** 스크랩 수 원자적 증가 */

--- a/src/main/java/com/tavemakers/surf/application/post/query/PostListService.java
+++ b/src/main/java/com/tavemakers/surf/application/post/query/PostListService.java
@@ -1,5 +1,6 @@
 package com.tavemakers.surf.application.post.query;
 
+import com.tavemakers.surf.application.block.query.BlockGetService;
 import com.tavemakers.surf.domain.board.entity.Board;
 import com.tavemakers.surf.domain.board.entity.BoardCategory;
 import com.tavemakers.surf.domain.board.entity.BoardType;
@@ -18,8 +19,12 @@ import com.tavemakers.surf.global.logging.LogParam;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Set;
 
 /** 게시글 목록 조회 관련 서비스 */
 @Service
@@ -32,6 +37,7 @@ public class PostListService {
     private final MemberGetService memberGetService;
     private final BoardGetService boardGetService;
     private final BoardCategoryGetService boardCategoryGetService;
+    private final BlockGetService blockGetService;
     private final FlagsMapper flagsMapper;
 
     /** 내가 작성한 게시글 목록 조회 */
@@ -42,11 +48,22 @@ public class PostListService {
         return slice.map(p -> flagsMapper.toRes(p, flags));
     }
 
-    /** 특정 작성자의 게시글 목록 조회 */
+    /**
+     * 특정 작성자의 게시글 목록 조회.
+     *
+     * <p>차단한 작성자면 JPQL을 늘리지 않고 <b>조회 자체를 생략</b>하고 빈 Slice를 돌려준다.
+     * DB 페이지를 읽은 뒤 걸러내는 방식이 아니라 페이지네이션이 깨지지 않는다.
+     */
     @LogEvent(value = "post.by.author.list", message = "특정 작성자 게시글 목록 조회")
     public Slice<PostResDTO> getPostsByMember(
             @LogParam(value = "author_id") Long authorId, Long viewerId, Pageable pageable) {
         memberGetService.validateMember(authorId);
+
+        if (blockGetService.isBlockedByMe(viewerId, authorId)) {
+            LogEventContext.put("count", 0);
+            return new SliceImpl<>(List.of(), pageable, false);
+        }
+
         Slice<Post> slice = postRepository.findByMemberId(authorId, pageable);
         LogEventContext.put("count", slice.getNumberOfElements());
         FlagsMapper.Flags flags = flagsMapper.resolveFlags(viewerId, slice.getContent());
@@ -71,17 +88,23 @@ public class PostListService {
 
         boolean isNotice = board.getType() == BoardType.NOTICE;
 
+        // 차단 작성자는 쿼리에서 제외한다 — DTO 생성 후 걸러내면 페이지 크기가 들쭉날쭉해진다
+        Set<Long> excludedAuthorIds = blockGetService.getMyBlockedMemberIds(viewerId);
+
         Slice<Post> slice;
         if (all) {
             slice = isManager
-                    ? postRepository.findByBoardId(boardId, pageable)
-                    : postRepository.findByBoardIdAndIsReservedFalse(boardId, pageable);
+                    ? postRepository.findByBoardIdExcludingAuthors(boardId, excludedAuthorIds, pageable)
+                    : postRepository.findByBoardIdAndIsReservedFalseExcludingAuthors(
+                            boardId, excludedAuthorIds, pageable);
         } else {
             BoardCategory category = boardCategoryGetService.getCategoryByBoardAndSlug(boardId, categorySlug);
 
             slice = isManager
-                    ? postRepository.findByBoardIdAndCategoryId(boardId, category.getId(), pageable)
-                    : postRepository.findByBoardIdAndCategoryIdAndIsReservedFalse(boardId, category.getId(), pageable);
+                    ? postRepository.findByBoardIdAndCategoryIdExcludingAuthors(
+                            boardId, category.getId(), excludedAuthorIds, pageable)
+                    : postRepository.findByBoardIdAndCategoryIdAndIsReservedFalseExcludingAuthors(
+                            boardId, category.getId(), excludedAuthorIds, pageable);
         }
 
         if (isNotice) {
@@ -105,7 +128,9 @@ public class PostListService {
     public Slice<PostResDTO> getPostsByBoardAndCategory(Long boardId, Long categoryId, Long viewerId, Pageable pageable) {
         Board board = boardGetService.getBoard(boardId);
         resolveCategory(board, categoryId);
-        Slice<Post> slice = postRepository.findByBoardIdAndCategoryId(boardId, categoryId, pageable);
+        Set<Long> excludedAuthorIds = blockGetService.getMyBlockedMemberIds(viewerId);
+        Slice<Post> slice = postRepository.findByBoardIdAndCategoryIdExcludingAuthors(
+                boardId, categoryId, excludedAuthorIds, pageable);
         FlagsMapper.Flags flags = flagsMapper.resolveFlags(viewerId, slice.getContent());
         return slice.map(p -> flagsMapper.toRes(p, flags));
     }

--- a/src/main/java/com/tavemakers/surf/application/post/query/PostSearchService.java
+++ b/src/main/java/com/tavemakers/surf/application/post/query/PostSearchService.java
@@ -1,5 +1,6 @@
 package com.tavemakers.surf.application.post.query;
 
+import com.tavemakers.surf.application.block.query.BlockGetService;
 import com.tavemakers.surf.presentation.post.dto.response.PostResDTO;
 import com.tavemakers.surf.domain.post.entity.Post;
 import com.tavemakers.surf.domain.post.repository.PostRepository;
@@ -10,6 +11,8 @@ import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Set;
+
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -17,14 +20,18 @@ public class PostSearchService {
 
     private final PostRepository postRepository;
     private final RecentSearchService recentSearchService;
+    private final BlockGetService blockGetService;
     private final FlagsMapper flagsMapper;
 
     /** 게시글 제목 및 내용 검색 — boardId 지정 시 해당 게시판 내에서만 검색 */
     public Slice<PostResDTO> search(Long viewerId, String param, Long boardId, Pageable pageable) {
+        // 0) 차단 작성자는 쿼리에서 제외한다 — 검색 결과에서도 숨김 정책은 동일하다
+        Set<Long> excludedAuthorIds = blockGetService.getMyBlockedMemberIds(viewerId);
+
         // 1) 게시글 검색 (boardId 있으면 게시판 내 검색, 없으면 통합 검색)
         Slice<Post> slice = (boardId != null)
-                ? postRepository.searchInBoard(boardId, param, pageable)
-                : postRepository.findByTitleContainingIgnoreCaseOrContentContainingIgnoreCase(param, param, pageable);
+                ? postRepository.searchInBoardExcludingAuthors(boardId, param, excludedAuthorIds, pageable)
+                : postRepository.searchExcludingAuthors(param, excludedAuthorIds, pageable);
 
         // 2) 최근 검색어 저장
         recentSearchService.saveQuery(viewerId, param);

--- a/src/main/java/com/tavemakers/surf/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/tavemakers/surf/domain/comment/repository/CommentRepository.java
@@ -3,6 +3,7 @@ package com.tavemakers.surf.domain.comment.repository;
 import com.tavemakers.surf.domain.comment.entity.Comment;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Set;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -19,6 +20,31 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     /** 댓글 총 개수 */
     long countByPostId(Long postId);
+
+    // ===== 차단 필터 변형 (이슈 #370) =====
+    // 대댓글은 별도 테이블이 아니라 같은 Slice 의 depth>0 행이므로 이 두 쿼리로 함께 걸러진다.
+    // Slice 와 count 에 반드시 같은 집합을 넘겨야 한다 — 다르면 "댓글 3개"인데 0개가 보이는 불일치가 생긴다.
+    // excludedAuthorIds 는 BlockGetService.getMyBlockedMemberIds 가 돌려주는 값이라 절대 비어 있지 않다.
+
+    /** 게시글 내 댓글 + 대댓글 조회 (작성 시간순) — 차단 작성자 제외 */
+    @Query("""
+        select c from Comment c
+        where c.post.id = :postId
+          and c.member.id not in :excludedAuthorIds
+        order by c.createdAt asc
+    """)
+    Slice<Comment> findByPostIdExcludingAuthors(@Param("postId") Long postId,
+                                                @Param("excludedAuthorIds") Set<Long> excludedAuthorIds,
+                                                Pageable pageable);
+
+    /** 댓글 총 개수 — 차단 작성자 제외 */
+    @Query("""
+        select count(c) from Comment c
+        where c.post.id = :postId
+          and c.member.id not in :excludedAuthorIds
+    """)
+    long countByPostIdExcludingAuthors(@Param("postId") Long postId,
+                                       @Param("excludedAuthorIds") Set<Long> excludedAuthorIds);
 
     /**
      * 직전 중복 댓글 감지 — 같은 작성자가 같은 게시글·같은 부모에 같은 내용을

--- a/src/main/java/com/tavemakers/surf/domain/letter/exception/LetterBlockedException.java
+++ b/src/main/java/com/tavemakers/surf/domain/letter/exception/LetterBlockedException.java
@@ -1,0 +1,14 @@
+package com.tavemakers.surf.domain.letter.exception;
+
+import com.tavemakers.surf.global.common.exception.BaseException;
+
+/** 차단 관계로 인해 쪽지를 보낼 수 없을 때 발생하는 예외 */
+public class LetterBlockedException extends BaseException {
+
+    public LetterBlockedException() {
+        super(
+                LetterErrorMessage.LETTER_BLOCKED.getStatus(),
+                LetterErrorMessage.LETTER_BLOCKED.getMessage()
+        );
+    }
+}

--- a/src/main/java/com/tavemakers/surf/domain/letter/exception/LetterErrorMessage.java
+++ b/src/main/java/com/tavemakers/surf/domain/letter/exception/LetterErrorMessage.java
@@ -8,7 +8,8 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum LetterErrorMessage {
 
-    LETTER_MAIL_SEND_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "메일 발송에 실패했습니다.");
+    LETTER_MAIL_SEND_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "메일 발송에 실패했습니다."),
+    LETTER_BLOCKED(HttpStatus.FORBIDDEN, "쪽지를 보낼 수 없는 상대입니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/tavemakers/surf/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/tavemakers/surf/domain/post/repository/PostRepository.java
@@ -4,6 +4,7 @@ import com.tavemakers.surf.domain.post.entity.Post;
 import jakarta.persistence.LockModeType;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -31,6 +32,60 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     boolean existsByCategoryId(Long categoryId);
 
     Slice<Post> findByMemberId(Long memberId, Pageable pageable);
+
+    // ===== 차단 필터 변형 (이슈 #370) =====
+    // 위 파생 메서드는 내부 작업·관리자 흐름용으로 그대로 두고, 사용자 조회용 변형을 따로 둔다.
+    // excludedAuthorIds 는 BlockGetService.getMyBlockedMemberIds 가 돌려주는 값이라 절대 비어 있지 않다
+    // (빈 컬렉션을 JPQL not in 에 넘기면 공급자·DB별로 렌더링이 갈려 목록이 통째로 비거나 문법 오류가 난다).
+
+    /** 게시판 전체 — 차단 작성자 제외 (관리자 뷰) */
+    @Query("""
+        select p from Post p
+        where p.board.id = :boardId
+          and p.member.id not in :excludedAuthorIds
+    """)
+    Slice<Post> findByBoardIdExcludingAuthors(@Param("boardId") Long boardId,
+                                              @Param("excludedAuthorIds") Set<Long> excludedAuthorIds,
+                                              Pageable pageable);
+
+    /** 게시판 전체 — 예약글 제외 + 차단 작성자 제외 (일반 사용자 뷰) */
+    @Query("""
+        select p from Post p
+        where p.board.id = :boardId
+          and p.isReserved = false
+          and p.member.id not in :excludedAuthorIds
+    """)
+    Slice<Post> findByBoardIdAndIsReservedFalseExcludingAuthors(
+            @Param("boardId") Long boardId,
+            @Param("excludedAuthorIds") Set<Long> excludedAuthorIds,
+            Pageable pageable);
+
+    /** 게시판 + 카테고리 — 차단 작성자 제외 (관리자 뷰) */
+    @Query("""
+        select p from Post p
+        where p.board.id = :boardId
+          and p.category.id = :categoryId
+          and p.member.id not in :excludedAuthorIds
+    """)
+    Slice<Post> findByBoardIdAndCategoryIdExcludingAuthors(
+            @Param("boardId") Long boardId,
+            @Param("categoryId") Long categoryId,
+            @Param("excludedAuthorIds") Set<Long> excludedAuthorIds,
+            Pageable pageable);
+
+    /** 게시판 + 카테고리 — 예약글 제외 + 차단 작성자 제외 (일반 사용자 뷰) */
+    @Query("""
+        select p from Post p
+        where p.board.id = :boardId
+          and p.category.id = :categoryId
+          and p.isReserved = false
+          and p.member.id not in :excludedAuthorIds
+    """)
+    Slice<Post> findByBoardIdAndCategoryIdAndIsReservedFalseExcludingAuthors(
+            @Param("boardId") Long boardId,
+            @Param("categoryId") Long categoryId,
+            @Param("excludedAuthorIds") Set<Long> excludedAuthorIds,
+            Pageable pageable);
 
     /** 스크랩 수 원자적 증가 (동시 요청 lost update 방지) */
     @Modifying(clearAutomatically = true, flushAutomatically = true)
@@ -71,6 +126,30 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     Slice<Post> searchInBoard(@Param("boardId") Long boardId,
                               @Param("param") String param,
                               Pageable pageable);
+
+    /** 통합 제목/내용 검색 — 차단 작성자 제외 */
+    @Query("""
+        select p from Post p
+        where (lower(p.title) like lower(concat('%', :param, '%'))
+            or lower(p.content) like lower(concat('%', :param, '%')))
+          and p.member.id not in :excludedAuthorIds
+    """)
+    Slice<Post> searchExcludingAuthors(@Param("param") String param,
+                                       @Param("excludedAuthorIds") Set<Long> excludedAuthorIds,
+                                       Pageable pageable);
+
+    /** 게시판 내 제목/내용 검색 — 차단 작성자 제외 */
+    @Query("""
+        select p from Post p
+        where p.board.id = :boardId
+          and (lower(p.title) like lower(concat('%', :param, '%'))
+            or lower(p.content) like lower(concat('%', :param, '%')))
+          and p.member.id not in :excludedAuthorIds
+    """)
+    Slice<Post> searchInBoardExcludingAuthors(@Param("boardId") Long boardId,
+                                              @Param("param") String param,
+                                              @Param("excludedAuthorIds") Set<Long> excludedAuthorIds,
+                                              Pageable pageable);
 
     @Query("""
         select p.member.id

--- a/src/test/java/com/tavemakers/surf/application/comment/query/CommentGetServiceBlockFilterTest.java
+++ b/src/test/java/com/tavemakers/surf/application/comment/query/CommentGetServiceBlockFilterTest.java
@@ -1,0 +1,75 @@
+package com.tavemakers.surf.application.comment.query;
+
+import com.tavemakers.surf.application.block.query.BlockGetService;
+import com.tavemakers.surf.domain.comment.entity.Comment;
+import com.tavemakers.surf.domain.comment.repository.CommentRepository;
+import com.tavemakers.surf.domain.comment.service.CommentLikeService;
+import com.tavemakers.surf.presentation.comment.dto.response.CommentListResDTO;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.SliceImpl;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+/**
+ * 댓글 목록의 차단 필터 배선 (이슈 #370).
+ *
+ * <p>Slice 와 totalCount 에 <b>같은 제외 집합</b>이 가는지 고정한다. 하나만 필터링하면
+ * "댓글 3개"라고 표시되는데 목록은 비어 보이는 화면이 나온다.
+ */
+@ExtendWith(MockitoExtension.class)
+class CommentGetServiceBlockFilterTest {
+
+    private static final Long POST_ID = 100L;
+    private static final Long VIEWER = 1L;
+    private static final Pageable PAGEABLE = PageRequest.of(0, 10);
+
+    @Mock
+    private CommentRepository commentRepository;
+    @Mock
+    private CommentMentionGetService commentMentionGetService;
+    @Mock
+    private CommentLikeService commentLikeService;
+    @Mock
+    private BlockGetService blockGetService;
+
+    @InjectMocks
+    private CommentGetService commentGetService;
+
+    @Test
+    @DisplayName("Slice 와 totalCount 에 같은 제외 집합을 넘긴다")
+    void 목록과_카운트에_같은_집합을_넘긴다() {
+        Set<Long> excluded = Set.of(2L, 3L);
+        given(blockGetService.getMyBlockedMemberIds(VIEWER)).willReturn(excluded);
+        given(commentRepository.findByPostIdExcludingAuthors(POST_ID, excluded, PAGEABLE))
+                .willReturn(new SliceImpl<>(List.<Comment>of(), PAGEABLE, false));
+        given(commentRepository.countByPostIdExcludingAuthors(POST_ID, excluded)).willReturn(0L);
+        given(commentMentionGetService.getMentionsByCommentIds(anyList())).willReturn(Map.of());
+
+        CommentListResDTO result = commentGetService.getComments(POST_ID, PAGEABLE, VIEWER);
+
+        then(commentRepository).should().findByPostIdExcludingAuthors(POST_ID, excluded, PAGEABLE);
+        then(commentRepository).should().countByPostIdExcludingAuthors(POST_ID, excluded);
+        assertThat(result.totalCount()).isZero();
+
+        // 필터 없는 기존 쿼리로 회귀하면 차단한 사람의 댓글이 그대로 보인다
+        then(commentRepository).should(never()).findByPostIdOrderByCreatedAtAsc(anyLong(), any());
+        then(commentRepository).should(never()).countByPostId(anyLong());
+    }
+}

--- a/src/test/java/com/tavemakers/surf/application/comment/usecase/CommentUsecaseBlockGuardTest.java
+++ b/src/test/java/com/tavemakers/surf/application/comment/usecase/CommentUsecaseBlockGuardTest.java
@@ -1,0 +1,63 @@
+package com.tavemakers.surf.application.comment.usecase;
+
+import com.tavemakers.surf.application.comment.query.CommentGetService;
+import com.tavemakers.surf.application.comment.query.CommentMentionGetService;
+import com.tavemakers.surf.application.post.query.PostGetService;
+import com.tavemakers.surf.domain.comment.service.CommentService;
+import com.tavemakers.surf.domain.post.exception.PostNotFoundException;
+import com.tavemakers.surf.global.logging.LogEventEmitter;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.never;
+
+/**
+ * 댓글 목록의 게시글 가시성 선행 가드 (이슈 #370).
+ *
+ * <p>게시글 상세가 404로 막히는데 댓글 목록은 열려 있으면, 차단한 상대의 글 내용을 댓글 스레드로
+ * 우회 열람하게 된다. 목록 조회 전에 가드를 통과해야 한다.
+ */
+@ExtendWith(MockitoExtension.class)
+class CommentUsecaseBlockGuardTest {
+
+    private static final Long POST_ID = 100L;
+    private static final Long VIEWER = 1L;
+    private static final Pageable PAGEABLE = PageRequest.of(0, 10);
+
+    @Mock
+    private CommentService commentService;
+    @Mock
+    private CommentGetService commentGetService;
+    @Mock
+    private CommentMentionGetService commentMentionGetService;
+    @Mock
+    private PostGetService postGetService;
+    @Mock
+    private LogEventEmitter logEventEmitter;
+
+    @InjectMocks
+    private CommentUsecase commentUsecase;
+
+    @Test
+    @DisplayName("게시글이 차단으로 가려지면 댓글 목록도 404이며 댓글 조회를 시도하지 않는다")
+    void 가려진_게시글의_댓글은_조회되지_않는다() {
+        willThrow(new PostNotFoundException())
+                .given(postGetService).validateVisiblePost(POST_ID, VIEWER);
+
+        assertThatThrownBy(() -> commentUsecase.getComments(POST_ID, PAGEABLE, VIEWER))
+                .isInstanceOf(PostNotFoundException.class);
+
+        then(commentGetService).should(never()).getComments(anyLong(), any(), anyLong());
+    }
+}

--- a/src/test/java/com/tavemakers/surf/application/comment/usecase/CommentUsecaseTest.java
+++ b/src/test/java/com/tavemakers/surf/application/comment/usecase/CommentUsecaseTest.java
@@ -2,6 +2,7 @@ package com.tavemakers.surf.application.comment.usecase;
 
 import com.tavemakers.surf.application.comment.query.CommentGetService;
 import com.tavemakers.surf.application.comment.query.CommentMentionGetService;
+import com.tavemakers.surf.application.post.query.PostGetService;
 import com.tavemakers.surf.domain.board.entity.Board;
 import com.tavemakers.surf.domain.board.entity.BoardCategory;
 import com.tavemakers.surf.domain.board.entity.BoardType;
@@ -49,6 +50,8 @@ class CommentUsecaseTest {
     private CommentGetService commentGetService;
     @Mock
     private CommentMentionGetService commentMentionGetService;
+    @Mock
+    private PostGetService postGetService;
     @Mock
     private LogEventEmitter logEventEmitter;
 

--- a/src/test/java/com/tavemakers/surf/application/letter/usecase/LetterUsecaseBlockGuardTest.java
+++ b/src/test/java/com/tavemakers/surf/application/letter/usecase/LetterUsecaseBlockGuardTest.java
@@ -11,6 +11,7 @@ import com.tavemakers.surf.presentation.letter.dto.request.LetterCreateReqDTO;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.InOrder;
 import org.mockito.Mock;
@@ -18,10 +19,13 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.util.Map;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.inOrder;
@@ -83,6 +87,26 @@ class LetterUsecaseBlockGuardTest {
 
         then(letterCreateService).should(never()).save(any());
         then(emailSender).should(never()).sendMail(anyString(), anyString(), anyString());
+
+        assertBlockedFailureLogged(senderId, receiverId);
+    }
+
+    /**
+     * 차단 거부도 메일 실패와 동일한 실패 이벤트를 남긴다.
+     * 남기지 않으면 진입 시 emit 한 letter_send_api_called 만 있고 종결 이벤트가 없어,
+     * 분석 퍼널에서 원인 불명 이탈이 되고 차단 발동 횟수를 측정할 수 없다.
+     */
+    @SuppressWarnings("unchecked")
+    private void assertBlockedFailureLogged(Long senderId, Long receiverId) {
+        ArgumentCaptor<Map<String, Object>> props = ArgumentCaptor.forClass(Map.class);
+        then(logEventEmitter).should()
+                .emitError(eq("letter_send_api_failed"), props.capture(), anyString());
+
+        assertThat(props.getValue())
+                .containsEntry("sender_id", senderId)
+                .containsEntry("receiver_id", receiverId)
+                .containsEntry("status_code", 403)
+                .containsEntry("error_code", "LETTER_BLOCKED");
     }
 
     /** 발신자·수신자를 검증한 다음 차단 관계를 검사하는 순서를 고정한다 */

--- a/src/test/java/com/tavemakers/surf/application/letter/usecase/LetterUsecaseBlockGuardTest.java
+++ b/src/test/java/com/tavemakers/surf/application/letter/usecase/LetterUsecaseBlockGuardTest.java
@@ -1,0 +1,113 @@
+package com.tavemakers.surf.application.letter.usecase;
+
+import com.tavemakers.surf.application.block.query.BlockGetService;
+import com.tavemakers.surf.application.letter.query.LetterGetService;
+import com.tavemakers.surf.application.member.query.MemberGetService;
+import com.tavemakers.surf.domain.letter.exception.LetterBlockedException;
+import com.tavemakers.surf.domain.member.entity.Member;
+import com.tavemakers.surf.global.logging.LogEventEmitter;
+import com.tavemakers.surf.global.util.EmailSender;
+import com.tavemakers.surf.presentation.letter.dto.request.LetterCreateReqDTO;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+
+/** 쪽지 발송 전 양방향 차단 가드 검증 */
+@ExtendWith(MockitoExtension.class)
+class LetterUsecaseBlockGuardTest {
+
+    private static final Long MEMBER_A = 1L;
+    private static final Long MEMBER_B = 2L;
+
+    @Mock
+    private MemberGetService memberGetService;
+    @Mock
+    private BlockGetService blockGetService;
+    @Mock
+    private LetterCreateService letterCreateService;
+    @Mock
+    private EmailSender emailSender;
+    @Mock
+    private LetterGetService letterGetService;
+    @Mock
+    private LogEventEmitter logEventEmitter;
+
+    @InjectMocks
+    private LetterUsecase letterUsecase;
+
+    @Test
+    @DisplayName("A가 B를 차단하면 A에서 B로 쪽지를 보낼 수 없고 부수효과가 없다")
+    void 차단한_상대에게는_쪽지를_보낼_수_없다() {
+        givenMembers();
+        given(blockGetService.existsBetween(MEMBER_A, MEMBER_B)).willReturn(true);
+
+        assertBlocked(MEMBER_A, MEMBER_B);
+
+        assertLookupAndGuardOrder(MEMBER_A, MEMBER_B);
+    }
+
+    @Test
+    @DisplayName("A가 B를 차단하면 B에서 A로 보내는 쪽지도 거부되어 차단 방향이 노출되지 않는다")
+    void 나를_차단한_상대에게도_쪽지를_보낼_수_없다() {
+        givenMembers();
+        given(blockGetService.existsBetween(MEMBER_B, MEMBER_A)).willReturn(true);
+
+        assertBlocked(MEMBER_B, MEMBER_A);
+
+        assertLookupAndGuardOrder(MEMBER_B, MEMBER_A);
+    }
+
+    private void assertBlocked(Long senderId, Long receiverId) {
+        assertThatThrownBy(() -> letterUsecase.createLetter(senderId, request(receiverId)))
+                .isInstanceOf(LetterBlockedException.class)
+                .satisfies(exception -> {
+                    LetterBlockedException blocked = (LetterBlockedException) exception;
+                    assertThat(blocked.getStatus()).isEqualTo(HttpStatus.FORBIDDEN);
+                    assertThat(blocked.getMessage()).isEqualTo("쪽지를 보낼 수 없는 상대입니다.");
+                });
+
+        then(letterCreateService).should(never()).save(any());
+        then(emailSender).should(never()).sendMail(anyString(), anyString(), anyString());
+    }
+
+    /** 발신자·수신자를 검증한 다음 차단 관계를 검사하는 순서를 고정한다 */
+    private void assertLookupAndGuardOrder(Long senderId, Long receiverId) {
+        InOrder order = inOrder(memberGetService, blockGetService);
+        order.verify(memberGetService).getMember(senderId);
+        order.verify(memberGetService).getMember(receiverId);
+        order.verify(blockGetService).existsBetween(senderId, receiverId);
+    }
+
+    private void givenMembers() {
+        given(memberGetService.getMember(MEMBER_A)).willReturn(member(MEMBER_A));
+        given(memberGetService.getMember(MEMBER_B)).willReturn(member(MEMBER_B));
+    }
+
+    private LetterCreateReqDTO request(Long receiverId) {
+        return new LetterCreateReqDTO(receiverId, "제목", "내용", null, "reply@test.com");
+    }
+
+    private Member member(Long memberId) {
+        Member member = Member.builder()
+                .name("회원" + memberId)
+                .email("member" + memberId + "@test.com")
+                .build();
+        ReflectionTestUtils.setField(member, "id", memberId);
+        return member;
+    }
+}

--- a/src/test/java/com/tavemakers/surf/application/letter/usecase/LetterUsecaseCreateLetterTest.java
+++ b/src/test/java/com/tavemakers/surf/application/letter/usecase/LetterUsecaseCreateLetterTest.java
@@ -3,6 +3,8 @@ package com.tavemakers.surf.application.letter.usecase;
 import com.tavemakers.surf.application.block.query.BlockGetService;
 import com.tavemakers.surf.application.letter.query.LetterGetService;
 import com.tavemakers.surf.application.member.query.MemberGetService;
+import com.tavemakers.surf.domain.block.entity.Block;
+import com.tavemakers.surf.domain.block.repository.BlockRepository;
 import com.tavemakers.surf.domain.letter.event.LetterSentEvent;
 import com.tavemakers.surf.domain.letter.exception.LetterBlockedException;
 import com.tavemakers.surf.domain.letter.exception.LetterMailSendFailException;
@@ -56,12 +58,17 @@ import static org.mockito.Mockito.never;
  *
  * <p>usecase 가 더 이상 트랜잭션을 열지 않으므로 테스트 트랜잭션을 NOT_SUPPORTED 로 끄고
  * 픽스처는 TransactionTemplate 으로 명시적 커밋한다 (MemberDismissRollbackTest 패턴).
+ *
+ * <p>차단 가드는 BlockGetService 를 mock 하지 않고 실제 block 레코드로 검증한다. mock 으로
+ * existsBetween 을 stub 하면 "양방향 거부"를 mock 이 대신 주장하게 되어, 구현이
+ * isBlockedByMe(단방향)로 바뀌어도 테스트가 통과한다.
  */
 @DataJpaTest
 @Import({
         LetterUsecase.class,
         LetterCreateService.class,
         LetterGetService.class,
+        BlockGetService.class,
         LetterUsecaseCreateLetterTest.AfterCommitProbe.class,
 })
 @Transactional(propagation = Propagation.NOT_SUPPORTED)
@@ -90,10 +97,11 @@ class LetterUsecaseCreateLetterTest {
     @Autowired
     private AfterCommitProbe afterCommitProbe;
 
+    @Autowired
+    private BlockRepository blockRepository;
+
     @MockBean
     private MemberGetService memberGetService;
-    @MockBean
-    private BlockGetService blockGetService;
     @MockBean
     private EmailSender emailSender;
     @MockBean
@@ -141,16 +149,34 @@ class LetterUsecaseCreateLetterTest {
     }
 
     @Test
-    @DisplayName("차단 관계이면 쪽지·LetterSentEvent·이메일이 모두 생성되지 않는다")
-    void 차단시_저장_이벤트_이메일이_모두_없다() {
-        given(blockGetService.existsBetween(sender.getId(), receiver.getId())).willReturn(true);
+    @DisplayName("내가 차단한 상대에게 보내면 쪽지·LetterSentEvent·이메일이 모두 생성되지 않는다")
+    void 내가_차단한_상대에게는_저장_이벤트_이메일이_모두_없다() {
+        persistBlock(sender.getId(), receiver.getId());
 
+        assertBlockedWithoutSideEffects();
+    }
+
+    @Test
+    @DisplayName("나를 차단한 상대에게 보내도 거부된다 — 실제 레코드는 반대 방향뿐이다")
+    void 나를_차단한_상대에게도_저장_이벤트_이메일이_모두_없다() {
+        persistBlock(receiver.getId(), sender.getId());
+
+        assertBlockedWithoutSideEffects();
+    }
+
+    /** 차단 시 §7의 0회 요건 — 저장·AFTER_COMMIT 이벤트·이메일이 모두 발생하지 않는다 */
+    private void assertBlockedWithoutSideEffects() {
         assertThatThrownBy(() -> letterUsecase.createLetter(sender.getId(), req()))
                 .isInstanceOf(LetterBlockedException.class);
 
         assertThat(countLetters()).as("차단된 쪽지는 DB에 저장되지 않아야 한다").isZero();
         assertThat(afterCommitProbe.fired.get()).as("LetterSentEvent가 발행되지 않아야 한다").isZero();
         then(emailSender).should(never()).sendMail(anyString(), anyString(), anyString());
+    }
+
+    private void persistBlock(Long blockerId, Long blockedId) {
+        TransactionTemplate tx = new TransactionTemplate(transactionManager);
+        tx.executeWithoutResult(status -> blockRepository.save(Block.of(blockerId, blockedId)));
     }
 
     private LetterCreateReqDTO req() {

--- a/src/test/java/com/tavemakers/surf/application/letter/usecase/LetterUsecaseCreateLetterTest.java
+++ b/src/test/java/com/tavemakers/surf/application/letter/usecase/LetterUsecaseCreateLetterTest.java
@@ -1,17 +1,19 @@
 package com.tavemakers.surf.application.letter.usecase;
 
-import com.tavemakers.surf.presentation.letter.dto.request.LetterCreateReqDTO;
-import com.tavemakers.surf.presentation.letter.dto.response.LetterResDTO;
-import com.tavemakers.surf.domain.letter.event.LetterSentEvent;
-import com.tavemakers.surf.domain.letter.exception.LetterMailSendFailException;
+import com.tavemakers.surf.application.block.query.BlockGetService;
 import com.tavemakers.surf.application.letter.query.LetterGetService;
+import com.tavemakers.surf.application.member.query.MemberGetService;
+import com.tavemakers.surf.domain.letter.event.LetterSentEvent;
+import com.tavemakers.surf.domain.letter.exception.LetterBlockedException;
+import com.tavemakers.surf.domain.letter.exception.LetterMailSendFailException;
 import com.tavemakers.surf.domain.member.entity.Member;
 import com.tavemakers.surf.domain.member.entity.enums.MemberRole;
 import com.tavemakers.surf.domain.member.entity.enums.MemberStatus;
 import com.tavemakers.surf.domain.member.entity.enums.MemberType;
-import com.tavemakers.surf.application.member.query.MemberGetService;
 import com.tavemakers.surf.global.logging.LogEventEmitter;
 import com.tavemakers.surf.global.util.EmailSender;
+import com.tavemakers.surf.presentation.letter.dto.request.LetterCreateReqDTO;
+import com.tavemakers.surf.presentation.letter.dto.response.LetterResDTO;
 import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -35,7 +37,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
 import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.never;
 
 /**
  * 쪽지 생성 R5 수정(저장 커밋 후 트랜잭션 밖 메일 발송) 검증.
@@ -89,6 +93,8 @@ class LetterUsecaseCreateLetterTest {
     @MockBean
     private MemberGetService memberGetService;
     @MockBean
+    private BlockGetService blockGetService;
+    @MockBean
     private EmailSender emailSender;
     @MockBean
     private LogEventEmitter logEventEmitter;
@@ -132,6 +138,19 @@ class LetterUsecaseCreateLetterTest {
         assertThat(countLetters())
                 .as("저장이 메일 발송보다 먼저 커밋되어 쪽지 레코드가 남아야 한다")
                 .isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("차단 관계이면 쪽지·LetterSentEvent·이메일이 모두 생성되지 않는다")
+    void 차단시_저장_이벤트_이메일이_모두_없다() {
+        given(blockGetService.existsBetween(sender.getId(), receiver.getId())).willReturn(true);
+
+        assertThatThrownBy(() -> letterUsecase.createLetter(sender.getId(), req()))
+                .isInstanceOf(LetterBlockedException.class);
+
+        assertThat(countLetters()).as("차단된 쪽지는 DB에 저장되지 않아야 한다").isZero();
+        assertThat(afterCommitProbe.fired.get()).as("LetterSentEvent가 발행되지 않아야 한다").isZero();
+        then(emailSender).should(never()).sendMail(anyString(), anyString(), anyString());
     }
 
     private LetterCreateReqDTO req() {

--- a/src/test/java/com/tavemakers/surf/application/notification/event/NotificationBlockGuardIntegrationTest.java
+++ b/src/test/java/com/tavemakers/surf/application/notification/event/NotificationBlockGuardIntegrationTest.java
@@ -1,0 +1,120 @@
+package com.tavemakers.surf.application.notification.event;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tavemakers.surf.application.block.query.BlockGetService;
+import com.tavemakers.surf.application.member.query.MemberGetService;
+import com.tavemakers.surf.application.notification.query.NotificationGetService;
+import com.tavemakers.surf.application.notification.usecase.NotificationUsecase;
+import com.tavemakers.surf.application.post.query.PostGetService;
+import com.tavemakers.surf.domain.block.entity.Block;
+import com.tavemakers.surf.domain.block.repository.BlockRepository;
+import com.tavemakers.surf.domain.comment.event.CommentCreatedEvent;
+import com.tavemakers.surf.domain.member.entity.enums.MemberStatus;
+import com.tavemakers.surf.domain.notification.repository.NotificationRepository;
+import com.tavemakers.surf.domain.notification.service.NotificationCreateService;
+import com.tavemakers.surf.domain.notification.service.NotificationService;
+import com.tavemakers.surf.domain.post.event.PostLikedEvent;
+import com.tavemakers.surf.global.logging.LogEventEmitterImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+/**
+ * 차단 관계에서 개인 알림이 <b>저장 단계부터</b> 발생하지 않는지 실제 block·notification 테이블로 검증한다.
+ *
+ * <p>BlockGetService를 mock하지 않는다. mock으로 existsBetween을 stub하면 "양방향 차단"을 mock이
+ * 대신 주장하게 되어, 구현이 단방향 조회로 바뀌어도 테스트가 통과한다. 실제 block 행을 정방향·역방향으로
+ * 각각 심어 리포지토리 JPQL의 OR 절부터 알림 미저장까지를 한 번에 고정한다.
+ *
+ * <p>리스너 메서드를 직접 호출한다. @Async·AFTER_COMMIT 배선이 아니라 가드가 검증 대상이다.
+ */
+@DataJpaTest
+@Import({
+        NotificationEventListener.class,
+        NotificationUsecase.class,
+        NotificationCreateService.class,
+        BlockGetService.class,
+        ObjectMapper.class,
+})
+class NotificationBlockGuardIntegrationTest {
+
+    private static final Long RECEIVER = 1L;
+    private static final Long ACTOR = 2L;
+    private static final Long BOARD_ID = 10L;
+    private static final Long POST_ID = 20L;
+
+    @Autowired
+    private NotificationEventListener listener;
+
+    @Autowired
+    private BlockRepository blockRepository;
+
+    @Autowired
+    private NotificationRepository notificationRepository;
+
+    @MockBean
+    private MemberGetService memberGetService;
+    @MockBean
+    private NotificationGetService notificationGetService;
+    @MockBean
+    private NotificationService notificationService;
+    @MockBean
+    private PostGetService postGetService;
+    @MockBean
+    private LogEventEmitterImpl logEventEmitter;
+
+    /**
+     * 수신자를 항상 활성 회원으로 둔다.
+     *
+     * <p>createAndSend는 비활성 수신자면 스스로 조기 반환한다. 이 stub이 없으면 mock 기본값(false)
+     * 때문에 <b>가드가 없어도</b> 알림이 저장되지 않아, 차단 테스트가 잘못된 이유로 통과한다.
+     * 저장을 막는 유일한 원인이 차단 가드가 되도록 고정한다.
+     */
+    @BeforeEach
+    void setUp() {
+        given(memberGetService.existsByIdAndStatusNot(RECEIVER, MemberStatus.WITHDRAWN)).willReturn(true);
+    }
+
+    @Test
+    @DisplayName("내가 차단한 상대의 댓글 알림은 Notification이 저장되지 않는다")
+    void 내가_차단한_상대의_알림은_저장되지_않는다() {
+        blockRepository.saveAndFlush(Block.of(RECEIVER, ACTOR));
+
+        listener.handleCommentCreated(commentCreatedEvent());
+
+        assertThat(notificationRepository.count())
+                .as("FCM만 막으면 알림함·미읽음 뱃지에 이름이 쌓이므로 저장 자체가 없어야 한다")
+                .isZero();
+    }
+
+    @Test
+    @DisplayName("나를 차단한 상대의 게시글 좋아요 알림도 저장되지 않는다 — 실제 레코드는 반대 방향뿐이다")
+    void 나를_차단한_상대의_알림도_저장되지_않는다() {
+        blockRepository.saveAndFlush(Block.of(ACTOR, RECEIVER));
+
+        listener.handlePostLiked(new PostLikedEvent(RECEIVER, "좋아요누른사람", ACTOR, BOARD_ID, POST_ID));
+
+        assertThat(notificationRepository.count()).isZero();
+    }
+
+    @Test
+    @DisplayName("차단 관계가 없으면 알림이 정상 저장된다")
+    void 차단이_없으면_알림이_저장된다() {
+        listener.handleCommentCreated(commentCreatedEvent());
+
+        assertThat(notificationRepository.count())
+                .as("가드가 정상 알림까지 막으면 안 된다")
+                .isEqualTo(1);
+    }
+
+    private CommentCreatedEvent commentCreatedEvent() {
+        return new CommentCreatedEvent(RECEIVER, "댓글작성자", ACTOR, BOARD_ID, POST_ID);
+    }
+}

--- a/src/test/java/com/tavemakers/surf/application/notification/event/NotificationEventListenerBlockGuardTest.java
+++ b/src/test/java/com/tavemakers/surf/application/notification/event/NotificationEventListenerBlockGuardTest.java
@@ -1,0 +1,161 @@
+package com.tavemakers.surf.application.notification.event;
+
+import com.tavemakers.surf.application.block.query.BlockGetService;
+import com.tavemakers.surf.application.notification.usecase.NotificationUsecase;
+import com.tavemakers.surf.application.post.query.PostGetService;
+import com.tavemakers.surf.domain.board.entity.Board;
+import com.tavemakers.surf.domain.board.entity.BoardType;
+import com.tavemakers.surf.domain.comment.event.CommentCreatedEvent;
+import com.tavemakers.surf.domain.comment.event.CommentLikedEvent;
+import com.tavemakers.surf.domain.comment.event.CommentReplyEvent;
+import com.tavemakers.surf.domain.letter.event.LetterSentEvent;
+import com.tavemakers.surf.domain.notification.entity.NotificationType;
+import com.tavemakers.surf.domain.post.entity.Post;
+import com.tavemakers.surf.domain.post.event.PostLikedEvent;
+import com.tavemakers.surf.domain.post.event.PostPublishedEvent;
+import com.tavemakers.surf.global.logging.LogEventEmitterImpl;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+/**
+ * 개인 알림 4종 + 쪽지 방어선에 차단 가드가 걸리는지, 공지 알림은 가드에서 제외되는지 검증한다.
+ *
+ * <p>가드가 createAndSend 호출 자체를 건너뛰는지가 핵심이다. Notification을 저장하고 FCM만
+ * 막으면 알림함과 미읽음 뱃지에 차단한 상대의 이름이 계속 쌓인다.
+ */
+@ExtendWith(MockitoExtension.class)
+class NotificationEventListenerBlockGuardTest {
+
+    private static final Long RECEIVER = 1L;
+    private static final Long ACTOR = 2L;
+    private static final Long BOARD_ID = 10L;
+    private static final Long POST_ID = 20L;
+
+    @Mock
+    private PostGetService postGetService;
+    @Mock
+    private NotificationUsecase notificationUsecase;
+    @Mock
+    private BlockGetService blockGetService;
+    @Mock
+    private LogEventEmitterImpl logEventEmitter;
+
+    @InjectMocks
+    private NotificationEventListener listener;
+
+    @Test
+    @DisplayName("차단 관계이면 댓글 생성 알림을 만들지 않는다")
+    void 차단시_댓글_알림이_생성되지_않는다() {
+        givenBlocked();
+
+        listener.handleCommentCreated(commentCreatedEvent());
+
+        thenNoNotificationCreated();
+    }
+
+    @Test
+    @DisplayName("차단 관계이면 대댓글 알림을 만들지 않는다")
+    void 차단시_대댓글_알림이_생성되지_않는다() {
+        givenBlocked();
+
+        listener.handleCommentReply(commentReplyEvent());
+
+        thenNoNotificationCreated();
+    }
+
+    @Test
+    @DisplayName("차단 관계이면 댓글 좋아요 알림을 만들지 않는다")
+    void 차단시_댓글_좋아요_알림이_생성되지_않는다() {
+        givenBlocked();
+
+        listener.handleCommentLiked(commentLikedEvent());
+
+        thenNoNotificationCreated();
+    }
+
+    @Test
+    @DisplayName("차단 관계이면 게시글 좋아요 알림을 만들지 않는다")
+    void 차단시_게시글_좋아요_알림이_생성되지_않는다() {
+        givenBlocked();
+
+        listener.handlePostLiked(postLikedEvent());
+
+        thenNoNotificationCreated();
+    }
+
+    @Test
+    @DisplayName("쪽지 알림은 발송 단계에서 이미 막히지만 방어선으로 한 번 더 검사한다")
+    void 차단시_쪽지_알림이_생성되지_않는다() {
+        givenBlocked();
+
+        listener.handleLetterSent(new LetterSentEvent(RECEIVER, "보낸사람", ACTOR));
+
+        thenNoNotificationCreated();
+        then(logEventEmitter).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("차단 관계가 없으면 기존 알림 흐름이 그대로 유지된다")
+    void 차단이_없으면_알림이_정상_생성된다() {
+        given(blockGetService.existsBetween(RECEIVER, ACTOR)).willReturn(false);
+
+        listener.handleCommentCreated(commentCreatedEvent());
+        listener.handleCommentReply(commentReplyEvent());
+        listener.handleCommentLiked(commentLikedEvent());
+        listener.handlePostLiked(postLikedEvent());
+
+        then(notificationUsecase).should().createAndSend(eq(RECEIVER), eq(NotificationType.POST_COMMENT), any());
+        then(notificationUsecase).should().createAndSend(eq(RECEIVER), eq(NotificationType.COMMENT_REPLY), any());
+        then(notificationUsecase).should().createAndSend(eq(RECEIVER), eq(NotificationType.COMMENT_LIKE), any());
+        then(notificationUsecase).should().createAndSend(eq(RECEIVER), eq(NotificationType.POST_LIKE), any());
+    }
+
+    @Test
+    @DisplayName("공지 알림은 개인 간 상호작용이 아니므로 차단을 조회하지도 않는다")
+    void 공지_알림은_차단_가드를_타지_않는다() {
+        Post notice = Post.builder().board(Board.of("공지사항", BoardType.NOTICE)).build();
+        given(postGetService.readPost(POST_ID)).willReturn(notice);
+
+        listener.handle(new PostPublishedEvent(POST_ID));
+
+        then(notificationUsecase).should().notifyNoticePost(notice);
+        then(blockGetService).shouldHaveNoInteractions();
+    }
+
+    /** 방향 무관 차단 — 어느 쪽이 차단했든 existsBetween은 true다 */
+    private void givenBlocked() {
+        given(blockGetService.existsBetween(RECEIVER, ACTOR)).willReturn(true);
+    }
+
+    /** 저장 이전 단계에서 끊겼는지 — createAndSend가 호출되면 Notification이 남는다 */
+    private void thenNoNotificationCreated() {
+        then(notificationUsecase).should(never()).createAndSend(anyLong(), any(), any());
+    }
+
+    private CommentCreatedEvent commentCreatedEvent() {
+        return new CommentCreatedEvent(RECEIVER, "댓글작성자", ACTOR, BOARD_ID, POST_ID);
+    }
+
+    private CommentReplyEvent commentReplyEvent() {
+        return new CommentReplyEvent(RECEIVER, "대댓글작성자", ACTOR, BOARD_ID, POST_ID);
+    }
+
+    private CommentLikedEvent commentLikedEvent() {
+        return new CommentLikedEvent(RECEIVER, "좋아요누른사람", ACTOR, BOARD_ID, POST_ID);
+    }
+
+    private PostLikedEvent postLikedEvent() {
+        return new PostLikedEvent(RECEIVER, "좋아요누른사람", ACTOR, BOARD_ID, POST_ID);
+    }
+}

--- a/src/test/java/com/tavemakers/surf/application/post/query/PostGetServiceBlockGuardTest.java
+++ b/src/test/java/com/tavemakers/surf/application/post/query/PostGetServiceBlockGuardTest.java
@@ -1,0 +1,144 @@
+package com.tavemakers.surf.application.post.query;
+
+import com.tavemakers.surf.application.block.query.BlockGetService;
+import com.tavemakers.surf.application.reservation.query.ReservationGetService;
+import com.tavemakers.surf.application.scrap.query.ScrapGetService;
+import com.tavemakers.surf.domain.board.entity.Board;
+import com.tavemakers.surf.domain.board.entity.BoardCategory;
+import com.tavemakers.surf.domain.board.entity.BoardType;
+import com.tavemakers.surf.domain.member.entity.Member;
+import com.tavemakers.surf.domain.post.entity.Post;
+import com.tavemakers.surf.domain.post.exception.PostNotFoundException;
+import com.tavemakers.surf.domain.post.repository.PostRepository;
+import com.tavemakers.surf.domain.post.service.like.PostLikeService;
+import com.tavemakers.surf.domain.post.service.support.ViewCountService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+/**
+ * 게시글 상세의 차단 가드 (이슈 #370).
+ *
+ * <p>가드가 조회수 증가·스크랩·좋아요·첨부 조회보다 <b>앞</b>에 있어야 한다. 뒤로 밀리면 숨겨야 할 글의
+ * 조회수가 오르고 부수효과가 남는다 — 응답만 404면 겉으로는 정상으로 보여 놓치기 쉬운 회귀다.
+ *
+ * <p>403이 아니라 404인 이유는 차단 사실을 상대에게 노출하지 않기 위해서다.
+ */
+@ExtendWith(MockitoExtension.class)
+class PostGetServiceBlockGuardTest {
+
+    private static final Long VIEWER = 1L;
+    private static final Long AUTHOR = 2L;
+    private static final Long POST_ID = 100L;
+
+    @Mock
+    private PostRepository postRepository;
+    @Mock
+    private BlockGetService blockGetService;
+    @Mock
+    private ScrapGetService scrapGetService;
+    @Mock
+    private PostLikeService postLikeService;
+    @Mock
+    private PostImageGetService imageGetService;
+    @Mock
+    private PostFileGetService fileGetService;
+    @Mock
+    private ViewCountService viewCountService;
+    @Mock
+    private ReservationGetService reservationGetService;
+
+    @InjectMocks
+    private PostGetService postGetService;
+
+    private Post post;
+
+    @BeforeEach
+    void setUp() {
+        Board board = Board.of("자유게시판", BoardType.GENERAL);
+        BoardCategory category = BoardCategory.of(board, "잡담", "chat");
+        Member author = Member.builder().name("작성자").build();
+        ReflectionTestUtils.setField(author, "id", AUTHOR);
+        post = Post.of("제목", "본문", false, false, false, board, category, author);
+        ReflectionTestUtils.setField(post, "id", POST_ID);
+    }
+
+    @Test
+    @DisplayName("차단한 작성자의 게시글 상세는 404다 — 403이면 차단 사실이 드러난다")
+    void 차단한_작성자의_상세는_404다() {
+        given(postRepository.findById(POST_ID)).willReturn(Optional.of(post));
+        given(blockGetService.isBlockedByMe(VIEWER, AUTHOR)).willReturn(true);
+
+        assertThatThrownBy(() -> postGetService.getPostDetail(POST_ID, VIEWER))
+                .isInstanceOf(PostNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("차단으로 막힌 상세는 조회수를 올리지 않고 스크랩·좋아요도 조회하지 않는다")
+    void 차단시_부수효과가_없다() {
+        given(postRepository.findById(POST_ID)).willReturn(Optional.of(post));
+        given(blockGetService.isBlockedByMe(VIEWER, AUTHOR)).willReturn(true);
+
+        assertThatThrownBy(() -> postGetService.getPostDetail(POST_ID, VIEWER))
+                .isInstanceOf(PostNotFoundException.class);
+
+        then(viewCountService).should(never()).increaseViewCount(any(), anyLong());
+        then(scrapGetService).should(never()).isScrappedByMe(anyLong(), anyLong());
+        then(postLikeService).should(never()).isLikedByMe(anyLong(), anyLong());
+    }
+
+    @Test
+    @DisplayName("차단하지 않은 작성자의 게시글은 그대로 조회된다")
+    void 차단하지_않으면_정상_조회된다() {
+        given(postRepository.findById(POST_ID)).willReturn(Optional.of(post));
+        given(blockGetService.isBlockedByMe(VIEWER, AUTHOR)).willReturn(false);
+
+        assertThatCode(() -> postGetService.getPostDetail(POST_ID, VIEWER)).doesNotThrowAnyException();
+
+        then(viewCountService).should().increaseViewCount(post, VIEWER);
+    }
+
+    @Test
+    @DisplayName("validateVisiblePost — 차단한 작성자의 글이면 404 (댓글 목록의 선행 가드)")
+    void 가드는_차단시_404다() {
+        given(postRepository.findById(POST_ID)).willReturn(Optional.of(post));
+        given(blockGetService.isBlockedByMe(VIEWER, AUTHOR)).willReturn(true);
+
+        assertThatThrownBy(() -> postGetService.validateVisiblePost(POST_ID, VIEWER))
+                .isInstanceOf(PostNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("validateVisiblePost — 없는 게시글도 동일하게 404")
+    void 가드는_없는_게시글도_404다() {
+        given(postRepository.findById(POST_ID)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> postGetService.validateVisiblePost(POST_ID, VIEWER))
+                .isInstanceOf(PostNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("내부 조합용 조회는 차단 필터를 타지 않는다 — scheduler·event 가 깨지면 안 된다")
+    void 내부_조회는_필터링하지_않는다() {
+        given(postRepository.findById(POST_ID)).willReturn(Optional.of(post));
+
+        assertThatCode(() -> postGetService.readPost(POST_ID)).doesNotThrowAnyException();
+
+        then(blockGetService).should(never()).isBlockedByMe(anyLong(), anyLong());
+    }
+}

--- a/src/test/java/com/tavemakers/surf/application/post/query/PostListServiceBlockFilterTest.java
+++ b/src/test/java/com/tavemakers/surf/application/post/query/PostListServiceBlockFilterTest.java
@@ -1,0 +1,147 @@
+package com.tavemakers.surf.application.post.query;
+
+import com.tavemakers.surf.application.block.query.BlockGetService;
+import com.tavemakers.surf.application.board.query.BoardCategoryGetService;
+import com.tavemakers.surf.application.board.query.BoardGetService;
+import com.tavemakers.surf.application.member.query.MemberGetService;
+import com.tavemakers.surf.domain.board.entity.Board;
+import com.tavemakers.surf.domain.board.entity.BoardType;
+import com.tavemakers.surf.domain.member.entity.Member;
+import com.tavemakers.surf.domain.member.entity.enums.MemberRole;
+import com.tavemakers.surf.domain.post.entity.Post;
+import com.tavemakers.surf.domain.post.repository.PostRepository;
+import com.tavemakers.surf.presentation.post.dto.response.PostResDTO;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+/**
+ * 게시글 목록의 차단 필터 배선 (이슈 #370).
+ *
+ * <p>제외 집합이 실제로 쿼리에 전달되는지, 그리고 특정 작성자 목록이 <b>조회 자체를 생략</b>하는지 본다.
+ * 후자는 DB 페이지를 읽고 버리는 방식이면 페이지네이션이 깨지므로 호출 부재까지 검증한다.
+ */
+@ExtendWith(MockitoExtension.class)
+class PostListServiceBlockFilterTest {
+
+    private static final Long VIEWER = 1L;
+    private static final Long BLOCKED_AUTHOR = 2L;
+    private static final Long BOARD_ID = 10L;
+    private static final Pageable PAGEABLE = PageRequest.of(0, 20);
+
+    @Mock
+    private PostRepository postRepository;
+    @Mock
+    private MemberGetService memberGetService;
+    @Mock
+    private BoardGetService boardGetService;
+    @Mock
+    private BoardCategoryGetService boardCategoryGetService;
+    @Mock
+    private BlockGetService blockGetService;
+    @Mock
+    private FlagsMapper flagsMapper;
+
+    @InjectMocks
+    private PostListService postListService;
+
+    @Test
+    @DisplayName("차단한 작성자의 글 목록은 조회 없이 빈 Slice 다 — 읽고 버리면 페이지네이션이 깨진다")
+    void 차단한_작성자_목록은_조회를_생략한다() {
+        given(blockGetService.isBlockedByMe(VIEWER, BLOCKED_AUTHOR)).willReturn(true);
+
+        Slice<PostResDTO> result = postListService.getPostsByMember(BLOCKED_AUTHOR, VIEWER, PAGEABLE);
+
+        assertThat(result.getContent()).isEmpty();
+        assertThat(result.hasNext()).isFalse();
+        then(postRepository).should(never()).findByMemberId(anyLong(), any());
+    }
+
+    @Test
+    @DisplayName("차단하지 않은 작성자의 글 목록은 정상 조회된다")
+    void 차단하지_않은_작성자는_정상_조회된다() {
+        given(blockGetService.isBlockedByMe(VIEWER, BLOCKED_AUTHOR)).willReturn(false);
+        given(postRepository.findByMemberId(BLOCKED_AUTHOR, PAGEABLE))
+                .willReturn(new SliceImpl<>(List.of(), PAGEABLE, false));
+
+        postListService.getPostsByMember(BLOCKED_AUTHOR, VIEWER, PAGEABLE);
+
+        then(postRepository).should().findByMemberId(BLOCKED_AUTHOR, PAGEABLE);
+    }
+
+    @Test
+    @DisplayName("게시판 목록(slug)은 제외 집합을 쿼리에 그대로 넘긴다")
+    void 게시판_목록은_제외_집합을_전달한다() {
+        Set<Long> excluded = Set.of(BLOCKED_AUTHOR);
+        given(boardGetService.getBoard(BOARD_ID)).willReturn(Board.of("자유게시판", BoardType.GENERAL));
+        given(memberGetService.getMember(VIEWER)).willReturn(normalViewer());
+        given(blockGetService.getMyBlockedMemberIds(VIEWER)).willReturn(excluded);
+        given(postRepository.findByBoardIdAndIsReservedFalseExcludingAuthors(BOARD_ID, excluded, PAGEABLE))
+                .willReturn(new SliceImpl<>(List.of(), PAGEABLE, false));
+
+        postListService.getPostsByBoardAndCategory(BOARD_ID, "all", VIEWER, PAGEABLE);
+
+        then(postRepository).should()
+                .findByBoardIdAndIsReservedFalseExcludingAuthors(BOARD_ID, excluded, PAGEABLE);
+        // 필터 없는 기존 쿼리로 회귀하면 차단 글이 그대로 노출된다
+        then(postRepository).should(never()).findByBoardIdAndIsReservedFalse(anyLong(), any());
+    }
+
+    @Test
+    @DisplayName("관리자 뷰(예약글 포함)도 차단 필터를 적용한다")
+    void 관리자_뷰도_필터를_적용한다() {
+        Set<Long> excluded = Set.of(BLOCKED_AUTHOR);
+        given(boardGetService.getBoard(BOARD_ID)).willReturn(Board.of("자유게시판", BoardType.GENERAL));
+        given(memberGetService.getMember(VIEWER)).willReturn(managerViewer());
+        given(blockGetService.getMyBlockedMemberIds(VIEWER)).willReturn(excluded);
+        given(postRepository.findByBoardIdExcludingAuthors(BOARD_ID, excluded, PAGEABLE))
+                .willReturn(new SliceImpl<>(List.of(), PAGEABLE, false));
+
+        postListService.getPostsByBoardAndCategory(BOARD_ID, "all", VIEWER, PAGEABLE);
+
+        then(postRepository).should().findByBoardIdExcludingAuthors(BOARD_ID, excluded, PAGEABLE);
+        then(postRepository).should(never()).findByBoardId(anyLong(), any());
+    }
+
+    @Test
+    @DisplayName("내 글 목록은 차단 필터 대상이 아니다 — 자기 자신은 차단할 수 없다")
+    void 내_글_목록은_필터링하지_않는다() {
+        given(postRepository.findByMemberId(VIEWER, PAGEABLE))
+                .willReturn(new SliceImpl<>(List.<Post>of(), PAGEABLE, false));
+
+        postListService.getMyPosts(VIEWER, PAGEABLE);
+
+        then(blockGetService).should(never()).getMyBlockedMemberIds(anyLong());
+        then(blockGetService).should(never()).isBlockedByMe(anyLong(), anyLong());
+    }
+
+    private Member normalViewer() {
+        Member viewer = Member.builder().name("뷰어").role(MemberRole.MEMBER).build();
+        ReflectionTestUtils.setField(viewer, "id", VIEWER);
+        return viewer;
+    }
+
+    private Member managerViewer() {
+        Member viewer = Member.builder().name("매니저").role(MemberRole.MANAGER).build();
+        ReflectionTestUtils.setField(viewer, "id", VIEWER);
+        return viewer;
+    }
+}

--- a/src/test/java/com/tavemakers/surf/application/post/query/PostSearchServiceBlockFilterTest.java
+++ b/src/test/java/com/tavemakers/surf/application/post/query/PostSearchServiceBlockFilterTest.java
@@ -1,0 +1,80 @@
+package com.tavemakers.surf.application.post.query;
+
+import com.tavemakers.surf.application.block.query.BlockGetService;
+import com.tavemakers.surf.domain.post.entity.Post;
+import com.tavemakers.surf.domain.post.repository.PostRepository;
+import com.tavemakers.surf.domain.post.service.search.RecentSearchService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.SliceImpl;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+/**
+ * 검색의 차단 필터 배선 (이슈 #370).
+ *
+ * <p>목록에서 숨긴 글이 검색으로 다시 드러나면 차단이 무의미해진다.
+ * 통합 검색·게시판 내 검색 두 경로 모두 필터 쿼리를 타야 한다.
+ */
+@ExtendWith(MockitoExtension.class)
+class PostSearchServiceBlockFilterTest {
+
+    private static final Long VIEWER = 1L;
+    private static final Long BOARD_ID = 10L;
+    private static final String KEYWORD = "서핑";
+    private static final Pageable PAGEABLE = PageRequest.of(0, 20);
+    private static final Set<Long> EXCLUDED = Set.of(2L);
+
+    @Mock
+    private PostRepository postRepository;
+    @Mock
+    private RecentSearchService recentSearchService;
+    @Mock
+    private BlockGetService blockGetService;
+    @Mock
+    private FlagsMapper flagsMapper;
+
+    @InjectMocks
+    private PostSearchService postSearchService;
+
+    @Test
+    @DisplayName("통합 검색은 차단 작성자를 제외하는 쿼리를 탄다")
+    void 통합_검색도_제외한다() {
+        given(blockGetService.getMyBlockedMemberIds(VIEWER)).willReturn(EXCLUDED);
+        given(postRepository.searchExcludingAuthors(KEYWORD, EXCLUDED, PAGEABLE))
+                .willReturn(new SliceImpl<>(List.<Post>of(), PAGEABLE, false));
+
+        postSearchService.search(VIEWER, KEYWORD, null, PAGEABLE);
+
+        then(postRepository).should().searchExcludingAuthors(KEYWORD, EXCLUDED, PAGEABLE);
+        then(postRepository).should(never())
+                .findByTitleContainingIgnoreCaseOrContentContainingIgnoreCase(anyString(), anyString(), any());
+    }
+
+    @Test
+    @DisplayName("게시판 내 검색도 차단 작성자를 제외하는 쿼리를 탄다")
+    void 게시판_내_검색도_제외한다() {
+        given(blockGetService.getMyBlockedMemberIds(VIEWER)).willReturn(EXCLUDED);
+        given(postRepository.searchInBoardExcludingAuthors(BOARD_ID, KEYWORD, EXCLUDED, PAGEABLE))
+                .willReturn(new SliceImpl<>(List.<Post>of(), PAGEABLE, false));
+
+        postSearchService.search(VIEWER, KEYWORD, BOARD_ID, PAGEABLE);
+
+        then(postRepository).should().searchInBoardExcludingAuthors(BOARD_ID, KEYWORD, EXCLUDED, PAGEABLE);
+        then(postRepository).should(never()).searchInBoard(anyLong(), anyString(), any());
+    }
+}

--- a/src/test/java/com/tavemakers/surf/application/reservation/task/PostPublishRunnerRaceTest.java
+++ b/src/test/java/com/tavemakers/surf/application/reservation/task/PostPublishRunnerRaceTest.java
@@ -1,5 +1,6 @@
 package com.tavemakers.surf.application.reservation.task;
 
+import com.tavemakers.surf.application.block.query.BlockGetService;
 import com.tavemakers.surf.domain.board.entity.Board;
 import com.tavemakers.surf.domain.board.entity.BoardCategory;
 import com.tavemakers.surf.domain.board.entity.BoardType;
@@ -84,6 +85,8 @@ class PostPublishRunnerRaceTest {
     private PlatformTransactionManager transactionManager;
 
     // PostGetService 의 잠금 조회 외 부가 의존성 — 이 테스트에서는 호출되지 않는다.
+    @MockBean
+    private BlockGetService blockGetService;
     @MockBean
     private ScrapGetService scrapGetService;
     @MockBean

--- a/src/test/java/com/tavemakers/surf/application/reservation/usecase/ReservationUpdateConcurrencyTest.java
+++ b/src/test/java/com/tavemakers/surf/application/reservation/usecase/ReservationUpdateConcurrencyTest.java
@@ -1,5 +1,6 @@
 package com.tavemakers.surf.application.reservation.usecase;
 
+import com.tavemakers.surf.application.block.query.BlockGetService;
 import com.tavemakers.surf.domain.board.entity.Board;
 import com.tavemakers.surf.domain.board.entity.BoardCategory;
 import com.tavemakers.surf.domain.board.entity.BoardType;
@@ -84,6 +85,8 @@ class ReservationUpdateConcurrencyTest {
     private ReservationScheduleService reservationScheduleService;
 
     // PostGetService 의 잠금 조회 외 부가 의존성 — 이 테스트에서는 호출되지 않는다.
+    @MockBean
+    private BlockGetService blockGetService;
     @MockBean
     private ScrapGetService scrapGetService;
     @MockBean

--- a/src/test/java/com/tavemakers/surf/domain/comment/repository/CommentBlockFilterQueryTest.java
+++ b/src/test/java/com/tavemakers/surf/domain/comment/repository/CommentBlockFilterQueryTest.java
@@ -1,0 +1,127 @@
+package com.tavemakers.surf.domain.comment.repository;
+
+import com.tavemakers.surf.domain.board.entity.Board;
+import com.tavemakers.surf.domain.board.entity.BoardCategory;
+import com.tavemakers.surf.domain.board.entity.BoardType;
+import com.tavemakers.surf.domain.comment.entity.Comment;
+import com.tavemakers.surf.domain.member.entity.Member;
+import com.tavemakers.surf.domain.member.entity.enums.MemberRole;
+import com.tavemakers.surf.domain.member.entity.enums.MemberStatus;
+import com.tavemakers.surf.domain.member.entity.enums.MemberType;
+import com.tavemakers.surf.domain.post.entity.Post;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 댓글·대댓글 차단 필터 JPQL 실검증 (이슈 #370).
+ *
+ * <p>핵심은 <b>목록과 totalCount 가 같은 기준으로 줄어드는지</b>다. 한쪽만 필터링하면
+ * "댓글 3개"라고 표시되는데 목록에는 아무것도 없는 화면이 나온다.
+ *
+ * <p>대댓글은 별도 테이블이 아니라 같은 Slice 의 depth>0 행이므로 같은 쿼리로 함께 걸러져야 한다.
+ */
+@DataJpaTest
+class CommentBlockFilterQueryTest {
+
+    /** 차단이 0건일 때 BlockGetService 가 넣어주는 값 */
+    private static final Set<Long> NO_ONE_BLOCKED = Set.of(-1L);
+
+    @Autowired
+    private CommentRepository commentRepository;
+
+    @Autowired
+    private EntityManager em;
+
+    private Post post;
+    private Member blockedAuthor;
+    private Member normalAuthor;
+
+    @BeforeEach
+    void setUp() {
+        Board board = Board.of("자유게시판", BoardType.GENERAL);
+        em.persist(board);
+        BoardCategory category = BoardCategory.of(board, "잡담", "chat-" + System.nanoTime());
+        em.persist(category);
+
+        blockedAuthor = persistMember("blocked");
+        normalAuthor = persistMember("normal");
+
+        post = Post.of("제목", "본문", false, false, false, board, category, normalAuthor);
+        em.persist(post);
+    }
+
+    @Test
+    @DisplayName("차단 작성자의 댓글이 목록과 totalCount 에서 함께 빠진다")
+    void 목록과_카운트가_함께_줄어든다() {
+        em.persist(Comment.root(post, blockedAuthor, "차단 댓글"));
+        em.persist(Comment.root(post, normalAuthor, "정상 댓글"));
+        em.flush();
+
+        Set<Long> excluded = Set.of(blockedAuthor.getId());
+        Slice<Comment> slice = commentRepository.findByPostIdExcludingAuthors(
+                post.getId(), excluded, PageRequest.of(0, 20));
+        long totalCount = commentRepository.countByPostIdExcludingAuthors(post.getId(), excluded);
+
+        assertThat(slice.getContent()).extracting(Comment::getContent).containsExactly("정상 댓글");
+        assertThat(totalCount)
+                .as("목록만 줄고 카운트가 그대로면 '댓글 2개'인데 1개만 보이는 화면이 된다")
+                .isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("차단 작성자의 대댓글도 함께 빠진다 — 같은 Slice 의 depth>0 행이다")
+    void 대댓글도_함께_빠진다() {
+        Comment root = Comment.root(post, normalAuthor, "루트 댓글");
+        em.persist(root);
+        em.persist(Comment.child(post, blockedAuthor, "차단 대댓글", root));
+        em.persist(Comment.child(post, normalAuthor, "정상 대댓글", root));
+        em.flush();
+
+        Set<Long> excluded = Set.of(blockedAuthor.getId());
+        Slice<Comment> slice = commentRepository.findByPostIdExcludingAuthors(
+                post.getId(), excluded, PageRequest.of(0, 20));
+
+        assertThat(slice.getContent()).extracting(Comment::getContent)
+                .containsExactlyInAnyOrder("루트 댓글", "정상 대댓글");
+        assertThat(commentRepository.countByPostIdExcludingAuthors(post.getId(), excluded)).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("차단이 없으면(sentinel) 아무 댓글도 제외되지 않는다")
+    void sentinel이면_아무도_제외되지_않는다() {
+        em.persist(Comment.root(post, blockedAuthor, "댓글1"));
+        em.persist(Comment.root(post, normalAuthor, "댓글2"));
+        em.flush();
+
+        Slice<Comment> slice = commentRepository.findByPostIdExcludingAuthors(
+                post.getId(), NO_ONE_BLOCKED, PageRequest.of(0, 20));
+
+        assertThat(slice.getContent()).hasSize(2);
+        assertThat(commentRepository.countByPostIdExcludingAuthors(post.getId(), NO_ONE_BLOCKED)).isEqualTo(2);
+    }
+
+    private Member persistMember(String prefix) {
+        long seed = System.nanoTime();
+        Member member = Member.builder()
+                .name("회원")
+                .email(prefix + seed + "@test.com")
+                .phoneNumber(String.valueOf(seed))
+                .status(MemberStatus.APPROVED)
+                .role(MemberRole.MEMBER)
+                .memberType(MemberType.YB)
+                .activityStatus(true)
+                .build();
+        em.persist(member);
+        return member;
+    }
+}

--- a/src/test/java/com/tavemakers/surf/domain/post/repository/PostBlockFilterQueryTest.java
+++ b/src/test/java/com/tavemakers/surf/domain/post/repository/PostBlockFilterQueryTest.java
@@ -1,0 +1,197 @@
+package com.tavemakers.surf.domain.post.repository;
+
+import com.tavemakers.surf.domain.board.entity.Board;
+import com.tavemakers.surf.domain.board.entity.BoardCategory;
+import com.tavemakers.surf.domain.board.entity.BoardType;
+import com.tavemakers.surf.domain.member.entity.Member;
+import com.tavemakers.surf.domain.member.entity.enums.MemberRole;
+import com.tavemakers.surf.domain.member.entity.enums.MemberStatus;
+import com.tavemakers.surf.domain.member.entity.enums.MemberType;
+import com.tavemakers.surf.domain.post.entity.Post;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 차단 작성자 제외 JPQL 실검증 (이슈 #370).
+ *
+ * <p>필터를 DTO 생성 후 stream 으로 걸러내면 "페이지 20건을 읽고 3건을 버려 17건만 내려주는" 형태가 되어
+ * 페이지 크기가 들쭉날쭉해지고 무한스크롤이 조기 종료된다. 그래서 쿼리에서 걸러내며, 이 테스트는
+ * <b>제외가 실제로 SQL에서 일어나고 페이지가 요청 크기만큼 채워지는지</b>를 본다.
+ *
+ * <p>제외 집합은 절대 비어 있지 않다는 계약({@code BlockGetService.getMyBlockedMemberIds})에 기대므로,
+ * 차단 0건일 때 쓰는 sentinel 경로도 함께 고정한다.
+ */
+@DataJpaTest
+class PostBlockFilterQueryTest {
+
+    /** 차단이 0건일 때 BlockGetService 가 넣어주는 값 — 어떤 회원과도 일치하지 않는다 */
+    private static final Set<Long> NO_ONE_BLOCKED = Set.of(-1L);
+
+    @Autowired
+    private PostRepository postRepository;
+
+    @Autowired
+    private EntityManager em;
+
+    private Board board;
+    private BoardCategory category;
+    private Member blockedAuthor;
+    private Member normalAuthor;
+
+    @BeforeEach
+    void setUp() {
+        board = persistBoard("자유게시판");
+        category = persistCategory(board);
+        blockedAuthor = persistMember("blocked");
+        normalAuthor = persistMember("normal");
+    }
+
+    @Test
+    @DisplayName("게시판 목록에서 차단 작성자의 글이 빠진다")
+    void 게시판_목록에서_차단_작성자가_빠진다() {
+        persistPost("차단글", blockedAuthor, false);
+        persistPost("정상글", normalAuthor, false);
+        em.flush();
+
+        Slice<Post> result = postRepository.findByBoardIdExcludingAuthors(
+                board.getId(), Set.of(blockedAuthor.getId()), PageRequest.of(0, 20));
+
+        assertThat(result.getContent()).extracting(Post::getTitle).containsExactly("정상글");
+    }
+
+    @Test
+    @DisplayName("차단이 없으면(sentinel) 아무도 제외되지 않는다 — 빈 컬렉션을 not in 에 넘기지 않기 위한 계약")
+    void sentinel이면_아무도_제외되지_않는다() {
+        persistPost("글1", blockedAuthor, false);
+        persistPost("글2", normalAuthor, false);
+        em.flush();
+
+        Slice<Post> result = postRepository.findByBoardIdExcludingAuthors(
+                board.getId(), NO_ONE_BLOCKED, PageRequest.of(0, 20));
+
+        assertThat(result.getContent()).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("차단 작성자를 제외해도 페이지는 요청한 크기만큼 채워진다 — 조회 후 필터링이 아니다")
+    void 페이지_크기가_유지된다() {
+        // 차단 작성자 글 5건이 앞쪽에 섞여 있어도, 정상 글 3건을 요청하면 3건이 와야 한다
+        for (int i = 0; i < 5; i++) {
+            persistPost("차단글" + i, blockedAuthor, false);
+        }
+        for (int i = 0; i < 4; i++) {
+            persistPost("정상글" + i, normalAuthor, false);
+        }
+        em.flush();
+
+        Slice<Post> result = postRepository.findByBoardIdExcludingAuthors(
+                board.getId(), Set.of(blockedAuthor.getId()), PageRequest.of(0, 3));
+
+        assertThat(result.getContent()).hasSize(3);
+        assertThat(result.hasNext()).isTrue();
+        assertThat(result.getContent()).extracting(p -> p.getMember().getId())
+                .containsOnly(normalAuthor.getId());
+    }
+
+    @Test
+    @DisplayName("예약글 제외 변형은 차단과 예약을 함께 걸러낸다")
+    void 예약글_제외_변형도_함께_적용된다() {
+        persistPost("차단-공개", blockedAuthor, false);
+        persistPost("정상-예약", normalAuthor, true);
+        persistPost("정상-공개", normalAuthor, false);
+        em.flush();
+
+        Slice<Post> result = postRepository.findByBoardIdAndIsReservedFalseExcludingAuthors(
+                board.getId(), Set.of(blockedAuthor.getId()), PageRequest.of(0, 20));
+
+        assertThat(result.getContent()).extracting(Post::getTitle).containsExactly("정상-공개");
+    }
+
+    @Test
+    @DisplayName("카테고리 변형도 차단 작성자를 제외한다")
+    void 카테고리_변형도_제외한다() {
+        persistPost("차단글", blockedAuthor, false);
+        persistPost("정상글", normalAuthor, false);
+        em.flush();
+
+        Slice<Post> withReserved = postRepository.findByBoardIdAndCategoryIdExcludingAuthors(
+                board.getId(), category.getId(), Set.of(blockedAuthor.getId()), PageRequest.of(0, 20));
+        Slice<Post> withoutReserved = postRepository.findByBoardIdAndCategoryIdAndIsReservedFalseExcludingAuthors(
+                board.getId(), category.getId(), Set.of(blockedAuthor.getId()), PageRequest.of(0, 20));
+
+        assertThat(withReserved.getContent()).extracting(Post::getTitle).containsExactly("정상글");
+        assertThat(withoutReserved.getContent()).extracting(Post::getTitle).containsExactly("정상글");
+    }
+
+    @Test
+    @DisplayName("통합 검색과 게시판 내 검색 모두 차단 작성자를 제외한다")
+    void 검색도_차단_작성자를_제외한다() {
+        persistPost("서핑 차단글", blockedAuthor, false);
+        persistPost("서핑 정상글", normalAuthor, false);
+        em.flush();
+
+        Slice<Post> all = postRepository.searchExcludingAuthors(
+                "서핑", Set.of(blockedAuthor.getId()), PageRequest.of(0, 20));
+        Slice<Post> inBoard = postRepository.searchInBoardExcludingAuthors(
+                board.getId(), "서핑", Set.of(blockedAuthor.getId()), PageRequest.of(0, 20));
+
+        assertThat(all.getContent()).extracting(Post::getTitle).containsExactly("서핑 정상글");
+        assertThat(inBoard.getContent()).extracting(Post::getTitle).containsExactly("서핑 정상글");
+    }
+
+    @Test
+    @DisplayName("차단은 단방향이다 — 상대 시점에서는 내 글이 그대로 보인다")
+    void 차단은_단방향이다() {
+        persistPost("내글", normalAuthor, false);
+        persistPost("상대글", blockedAuthor, false);
+        em.flush();
+
+        // normalAuthor 가 blockedAuthor 를 차단한 상황에서, blockedAuthor 시점 조회
+        Slice<Post> fromOtherSide = postRepository.findByBoardIdExcludingAuthors(
+                board.getId(), NO_ONE_BLOCKED, PageRequest.of(0, 20));
+
+        assertThat(fromOtherSide.getContent()).extracting(Post::getTitle)
+                .containsExactlyInAnyOrder("내글", "상대글");
+    }
+
+    private Board persistBoard(String name) {
+        Board board = Board.of(name, BoardType.GENERAL);
+        em.persist(board);
+        return board;
+    }
+
+    private BoardCategory persistCategory(Board board) {
+        BoardCategory category = BoardCategory.of(board, "잡담", "chat-" + System.nanoTime());
+        em.persist(category);
+        return category;
+    }
+
+    private void persistPost(String title, Member writer, boolean isReserved) {
+        em.persist(Post.of(title, "본문", false, isReserved, false, board, category, writer));
+    }
+
+    private Member persistMember(String prefix) {
+        long seed = System.nanoTime();
+        Member member = Member.builder()
+                .name("회원")
+                .email(prefix + seed + "@test.com")
+                .phoneNumber(String.valueOf(seed))
+                .status(MemberStatus.APPROVED)
+                .role(MemberRole.MEMBER)
+                .memberType(MemberType.YB)
+                .activityStatus(true)
+                .build();
+        em.persist(member);
+        return member;
+    }
+}


### PR DESCRIPTION
## 📄 작업 내용 요약

사용자 차단(Block) 기능의 **3차 PR — 게시판·댓글 조회 필터** (요구사항 1·2).

1차(#368)·2차(#369)로 차단 관계를 만들고 조회할 수 있게 됐지만, **차단해도 상대의 게시글·댓글이 그대로 보이는 상태**였습니다. 이 PR에서 조회 경로에 필터를 걸어 실제로 숨겨지게 합니다.

> ⚠️ **base가 `dev`가 아니라 PR2 브랜치(`feat/#367/block-사용자-관리자-api-추가`)입니다.** 충돌을 피하려고 PR2에서 분기했습니다. **#368 → #369 → 이 PR 순서로 머지**해 주세요. 앞 PR이 머지되면 base가 자동으로 따라 내려갑니다.

### 적용 범위

| 경로 | 변경 |
|---|---|
| 게시판 목록 | `categorySlug`·`categoryId` **두 오버로드 모두** — 일반/관리자(예약글 포함) 뷰 각각 |
| 검색 | 통합 검색 + 게시판 내 검색 |
| 특정 작성자 목록 | 차단 대상이면 조회 생략, 빈 Slice |
| 게시글 상세 | 차단 작성자면 404 |
| 댓글·대댓글 | 목록 + `totalCount` 동시 필터 |
| 내 글 목록 | **대상 아님** — 자기 자신은 차단할 수 없음 |

### 정책

- 콘텐츠 숨김은 **blocker 기준 단방향**입니다. 내가 차단한 사람의 글은 나에게 안 보이지만, 상대에게는 내 글이 그대로 보입니다(양방향 검사는 쪽지·알림 전용).
- 차단 사실을 상대에게 노출하지 않기 위해 상세는 403이 아니라 **404**입니다.

## 🔍 리뷰 포인트

### 1. 필터는 쿼리에서 겁니다 — DTO 생성 후 stream filter 금지

DTO를 만든 뒤 걸러내면 "20건 읽고 3건 버려 17건 응답"이 되어 **페이지 크기가 들쭉날쭉해지고 무한스크롤이 조기 종료**됩니다. 그래서 기존 파생 메서드는 내부 작업·관리자 흐름용으로 그대로 두고, 사용자 조회용 `...ExcludingAuthors` 변형을 따로 뒀습니다.

`PostBlockFilterQueryTest`가 **차단 글 5건이 앞에 섞여 있어도 3건을 요청하면 3건이 오는지**를 고정합니다.

### 2. 특정 작성자 목록은 조회 자체를 생략합니다

JPQL을 늘리지 않고, 차단 대상이면 `postRepository`를 **아예 호출하지 않고** 빈 `SliceImpl`을 반환합니다. 읽고 버리는 방식이 아니라 안 읽는 방식이라 페이지네이션 문제가 없습니다. 테스트에서 호출 부재(`never()`)까지 검증합니다.

### 3. 상세 가드가 부수효과보다 앞입니다

조회수 증가·스크랩·좋아요·첨부·예약 조회 **이전**에 둡니다. 뒤로 밀리면 응답은 404인데 **숨겨야 할 글의 조회수가 오릅니다** — 겉으로는 정상 동작으로 보여 놓치기 쉬운 회귀라, `PostGetServiceBlockGuardTest`가 `viewCountService`·`scrapGetService`·`postLikeService` 미호출을 따로 검증합니다.

### 4. 내부 조합용 조회는 건드리지 않았습니다

`getPost`·`readPost`·`findPostById`까지 필터링하면 **예약 발행 scheduler와 알림 event가 깨집니다.** 사용자 상세 메서드와 신설한 `validateVisiblePost`에만 적용했고, "내부 조회는 `BlockGetService`를 호출하지 않는다"도 테스트로 박아뒀습니다.

### 5. 댓글은 목록과 totalCount에 같은 집합을 넘깁니다

한쪽만 걸러내면 **"댓글 3개"라고 표시되는데 목록은 비어 보이는 화면**이 나옵니다. 대댓글은 별도 테이블이 아니라 같은 Slice의 `depth>0` 행이라 동일 쿼리로 함께 걸러집니다.

또 댓글 목록 조회 전에 `validateVisiblePost`를 호출합니다 — 상세가 404인데 댓글 목록이 열려 있으면 차단한 상대의 글을 **댓글 스레드로 우회 열람**하게 됩니다.

### 6. 빈 컬렉션을 `not in`에 넘기지 않습니다

제외 집합은 `BlockGetService.getMyBlockedMemberIds`가 보장하는 대로 절대 비어 있지 않습니다(차단 0건이면 음수 sentinel). 빈 컬렉션을 JPQL `not in`에 넘기면 공급자·DB별로 렌더링이 갈려 **목록이 통째로 비거나 문법 오류**가 납니다. sentinel 경로도 테스트로 고정했습니다.

## ✅ 테스트

**25건 추가, 전체 445건 통과** (실패·에러 0). `CleanArchitectureRulesTest` 통과, archunit freeze store 무변동.

| 테스트 | 건수 | 내용 |
|---|---|---|
| `PostBlockFilterQueryTest` | 7 | 제외 동작, **페이지 크기 유지**, 예약글·카테고리·검색 변형, sentinel, 단방향 |
| `PostGetServiceBlockGuardTest` | 6 | 404 응답, **조회수·스크랩·좋아요 부수효과 없음**, 내부 조회 미필터링 |
| `PostListServiceBlockFilterTest` | 5 | 조기 반환 시 repository 미호출, 제외 집합 전달, 관리자 뷰, 내 글 목록 제외 |
| `CommentBlockFilterQueryTest` | 3 | 목록·카운트 동시 감소, 대댓글 포함, sentinel |
| `PostSearchServiceBlockFilterTest` | 2 | 통합·게시판 내 검색이 필터 쿼리를 타는지 |
| `CommentGetServiceBlockFilterTest` | 1 | Slice와 `totalCount`에 같은 제외 집합이 전달되는지 |
| `CommentUsecaseBlockGuardTest` | 1 | 가려진 게시글의 댓글 우회 열람 차단 |

기존 테스트 3건(`CommentUsecaseTest`, `PostPublishRunnerRaceTest`, `ReservationUpdateConcurrencyTest`)은 `PostGetService`·`CommentUsecase`에 협력자 의존이 생겨 mock만 추가했습니다. **로직 변경은 없습니다.**

## 🗄️ 실행할 쿼리

**이 PR에서 추가로 실행할 쿼리는 없습니다.** 엔티티·컬럼·인덱스 변경이 없고, 추가분은 전부 기존 테이블을 읽는 `select` JPQL입니다(`@Modifying` 없음).

다만 **#368의 `block` 테이블 생성 DDL이 이 PR보다 먼저 적용되어 있어야 합니다.** 필터가 `block` 테이블을 읽기 때문에, 테이블이 없으면 게시판·댓글 조회가 통째로 실패합니다. DDL 전문은 #368 본문에 있습니다.

인덱스 추가는 필요 없습니다 — `board_id`/`category_id`/`post_id`로 범위를 좁힌 뒤 `member_id NOT IN (...)`으로 거르는 형태라 부정 조건은 어차피 인덱스를 타지 않고, 차단 목록 자체는 `uk_block_blocker_blocked`의 선두 컬럼으로 조회됩니다.

## 📌 참고

- `PostListService`·`PostSearchService`는 `{Domain}GetService` 네이밍과 다르지만 **기존 클래스명이며 이 PR에서 만든 위반이 아닙니다.** 여기서 개명하면 호출부까지 diff가 번져 정작 봐야 할 필터 로직이 묻히므로 유지했습니다. 정리한다면 `post` 도메인 query 서비스를 한 번에 맞추는 별도 리팩토링이 적절합니다.
- 남은 범위: **PR4** 쪽지 차단 / **PR5** 개인 알림 차단
- **배포 순서 주의** — PR1~PR5를 함께 배포하거나 feature flag로 묶어야 합니다. 이 단계만 선배포하면 게시판·댓글은 숨겨지지만 쪽지·알림은 그대로 도착하는 불완전 상태가 됩니다.

## 📎 Issue 번호

closed #370


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 차단한 회원이 작성한 게시글, 댓글, 대댓글이 목록과 검색 결과에서 제외됩니다.
  * 차단된 게시글은 상세 조회 및 해당 게시글의 댓글 조회를 통해 우회할 수 없습니다.
  * 댓글 수와 댓글 목록에 동일한 차단 필터가 적용됩니다.
* **테스트**
  * 게시글·댓글 목록, 검색, 상세 조회의 차단 사용자 필터 동작을 검증했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->