### PR TITLE
[FEAT] 차단 관계의 쪽지 발송 차단

### DIFF
--- a/src/main/java/com/tavemakers/surf/application/letter/usecase/LetterUsecase.java
+++ b/src/main/java/com/tavemakers/surf/application/letter/usecase/LetterUsecase.java
@@ -45,7 +45,14 @@ public class LetterUsecase {
         Member receiver = memberGetService.getMember(req.receiverId());
 
         // 3) 어느 방향이든 차단 관계가 있으면 저장·이벤트·메일보다 먼저 거부한다
-        if (blockGetService.existsBetween(senderId, receiver.getId())) {
+        if (blockGetService.existsBetween(senderId, req.receiverId())) {
+            // 차단 방향은 응답과 마찬가지로 로그에도 남기지 않는다
+            Map<String, Object> blockedProps = new HashMap<>();
+            blockedProps.put("sender_id", senderId);
+            blockedProps.put("receiver_id", req.receiverId());
+            blockedProps.put("status_code", 403);
+            blockedProps.put("error_code", "LETTER_BLOCKED");
+            logEventEmitter.emitError("letter_send_api_failed", blockedProps, "쪽지 전송 실패 - 차단 관계");
             throw new LetterBlockedException();
         }
 

--- a/src/main/java/com/tavemakers/surf/application/letter/usecase/LetterUsecase.java
+++ b/src/main/java/com/tavemakers/surf/application/letter/usecase/LetterUsecase.java
@@ -1,14 +1,16 @@
 package com.tavemakers.surf.application.letter.usecase;
 
-import com.tavemakers.surf.presentation.letter.dto.request.LetterCreateReqDTO;
-import com.tavemakers.surf.presentation.letter.dto.response.LetterResDTO;
-import com.tavemakers.surf.domain.letter.entity.Letter;
-import com.tavemakers.surf.domain.letter.exception.LetterMailSendFailException;
+import com.tavemakers.surf.application.block.query.BlockGetService;
 import com.tavemakers.surf.application.letter.query.LetterGetService;
-import com.tavemakers.surf.domain.member.entity.Member;
 import com.tavemakers.surf.application.member.query.MemberGetService;
+import com.tavemakers.surf.domain.letter.entity.Letter;
+import com.tavemakers.surf.domain.letter.exception.LetterBlockedException;
+import com.tavemakers.surf.domain.letter.exception.LetterMailSendFailException;
+import com.tavemakers.surf.domain.member.entity.Member;
 import com.tavemakers.surf.global.logging.LogEventEmitter;
 import com.tavemakers.surf.global.util.EmailSender;
+import com.tavemakers.surf.presentation.letter.dto.request.LetterCreateReqDTO;
+import com.tavemakers.surf.presentation.letter.dto.response.LetterResDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -23,6 +25,7 @@ import java.util.Map;
 public class LetterUsecase {
 
     private final MemberGetService memberGetService;
+    private final BlockGetService blockGetService;
     private final LetterCreateService letterCreateService;
     private final EmailSender emailSender;
     private final LetterGetService letterGetService;
@@ -41,7 +44,12 @@ public class LetterUsecase {
         // 2) 수신자 조회
         Member receiver = memberGetService.getMember(req.receiverId());
 
-        // validation 로그 (@Valid 통과 이후 실행되므로 result=true)
+        // 3) 어느 방향이든 차단 관계가 있으면 저장·이벤트·메일보다 먼저 거부한다
+        if (blockGetService.existsBetween(senderId, receiver.getId())) {
+            throw new LetterBlockedException();
+        }
+
+        // 4) validation 로그 (@Valid 통과 이후 실행되므로 result=true)
         String replyEmail = req.replyEmail();
         String emailDomain = replyEmail.contains("@")
                 ? replyEmail.substring(replyEmail.indexOf('@') + 1) : "";
@@ -61,7 +69,7 @@ public class LetterUsecase {
                 "validation_result", true
         ));
 
-        // 3) 엔티티 생성
+        // 5) 엔티티 생성
         Letter letter = Letter.create(
                 req.title(),
                 req.content(),
@@ -71,10 +79,10 @@ public class LetterUsecase {
                 receiver
         );
 
-        // 4) 저장 + 알림 이벤트 발행 (트랜잭션 커밋 → AFTER_COMMIT 리스너 발화)
+        // 6) 저장 + 알림 이벤트 발행 (트랜잭션 커밋 → AFTER_COMMIT 리스너 발화)
         Letter saved = letterCreateService.save(letter);
 
-        // 5) 이메일 본문 생성
+        // 7) 이메일 본문 생성
         String emailBody = """
         [Surf에서 %s님이 보낸 쪽지입니다.]
 
@@ -90,7 +98,7 @@ public class LetterUsecase {
                         req.sns() != null ? req.sns() : "-"
                 );
 
-        // 6) 이메일 전송 (트랜잭션 밖, 실패 시 예외 — 저장된 쪽지는 유지)
+        // 8) 이메일 전송 (트랜잭션 밖, 실패 시 예외 — 저장된 쪽지는 유지)
         boolean emailSent = false;
         try {
             emailSender.sendMail(receiver.getEmail(), req.title(), emailBody);
@@ -113,7 +121,7 @@ public class LetterUsecase {
                 "email_sent", emailSent
         ));
 
-        // 7) 저장된 엔티티 기반으로 Response 생성
+        // 9) 저장된 엔티티 기반으로 Response 생성
         return LetterResDTO.from(saved);
     }
 

--- a/src/main/java/com/tavemakers/surf/application/notification/event/NotificationEventListener.java
+++ b/src/main/java/com/tavemakers/surf/application/notification/event/NotificationEventListener.java
@@ -1,5 +1,6 @@
 package com.tavemakers.surf.application.notification.event;
 
+import com.tavemakers.surf.application.block.query.BlockGetService;
 import com.tavemakers.surf.domain.comment.event.CommentCreatedEvent;
 import com.tavemakers.surf.domain.comment.event.CommentLikedEvent;
 import com.tavemakers.surf.domain.comment.event.CommentReplyEvent;
@@ -30,7 +31,27 @@ public class NotificationEventListener {
 
     private final PostGetService postGetService;
     private final NotificationUsecase notificationUsecase;
+    private final BlockGetService blockGetService;
     private final LogEventEmitterImpl logEventEmitter;
+
+    /**
+     * 차단 관계이면 개인 알림을 만들지 않는다.
+     *
+     * <p>어느 방향이든 차단이 있으면 막는다(쪽지와 동일한 상호작용 정책). 콘텐츠 숨김의
+     * 단방향 필터와 달리, 알림은 직접 접촉이라 한쪽만 차단해도 접촉 경로가 남으면 안 된다.
+     *
+     * <p><b>가드는 반드시 알림 생성 이전에 둔다.</b> Notification을 저장하고 FCM만 막으면
+     * 알림함 목록과 미읽음 뱃지에는 차단한 상대의 이름이 계속 쌓인다.
+     *
+     * <p>공지 알림은 개인 간 상호작용이 아니므로 이 가드를 적용하지 않는다.
+     */
+    private boolean blockedBetween(Long receiverId, Long actorId, NotificationType type) {
+        if (!blockGetService.existsBetween(receiverId, actorId)) {
+            return false;
+        }
+        log.info("[BlockedNotification] skipped type={} receiverId={} actorId={}", type, receiverId, actorId);
+        return true;
+    }
 
     @Async
     @Transactional
@@ -53,6 +74,10 @@ public class NotificationEventListener {
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleCommentCreated(CommentCreatedEvent event) {
+        if (blockedBetween(event.getReceiverId(), event.getActorId(), NotificationType.POST_COMMENT)) {
+            return;
+        }
+
         notificationUsecase.createAndSend(
                 event.getReceiverId(),
                 NotificationType.POST_COMMENT,
@@ -72,6 +97,10 @@ public class NotificationEventListener {
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleCommentReply(CommentReplyEvent event) {
+        if (blockedBetween(event.getReceiverId(), event.getActorId(), NotificationType.COMMENT_REPLY)) {
+            return;
+        }
+
         notificationUsecase.createAndSend(
                 event.getReceiverId(),
                 NotificationType.COMMENT_REPLY,
@@ -91,6 +120,10 @@ public class NotificationEventListener {
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleCommentLiked(CommentLikedEvent event) {
+        if (blockedBetween(event.getReceiverId(), event.getActorId(), NotificationType.COMMENT_LIKE)) {
+            return;
+        }
+
         notificationUsecase.createAndSend(
                 event.getReceiverId(),
                 NotificationType.COMMENT_LIKE,
@@ -110,6 +143,10 @@ public class NotificationEventListener {
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handlePostLiked(PostLikedEvent event) {
+        if (blockedBetween(event.getReceiverId(), event.getActorId(), NotificationType.POST_LIKE)) {
+            return;
+        }
+
         notificationUsecase.createAndSend(
                 event.getReceiverId(),
                 NotificationType.POST_LIKE,
@@ -129,6 +166,14 @@ public class NotificationEventListener {
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleLetterSent(LetterSentEvent event) {
+        // 방어선 — 쪽지는 발송 단계에서 이미 거부되므로 이 이벤트 자체가 발행되지 않아야 한다.
+        // 여기서 걸린다면 LetterUsecase의 차단 가드가 우회된 것이므로 경고로 남긴다.
+        if (blockedBetween(event.getReceiverId(), event.getSenderId(), NotificationType.MESSAGE)) {
+            log.warn("[LetterNotification] 쪽지 발송 가드를 통과한 차단 관계 - receiverId={} senderId={}",
+                    event.getReceiverId(), event.getSenderId());
+            return;
+        }
+
         logEventEmitter.emit("letter_notification_requested", Map.of(
                 "sender_id", event.getSenderId(),
                 "receiver_id", event.getReceiverId(),

--- a/src/main/java/com/tavemakers/surf/domain/letter/exception/LetterBlockedException.java
+++ b/src/main/java/com/tavemakers/surf/domain/letter/exception/LetterBlockedException.java
@@ -1,0 +1,14 @@
+package com.tavemakers.surf.domain.letter.exception;
+
+import com.tavemakers.surf.global.common.exception.BaseException;
+
+/** 차단 관계로 인해 쪽지를 보낼 수 없을 때 발생하는 예외 */
+public class LetterBlockedException extends BaseException {
+
+    public LetterBlockedException() {
+        super(
+                LetterErrorMessage.LETTER_BLOCKED.getStatus(),
+                LetterErrorMessage.LETTER_BLOCKED.getMessage()
+        );
+    }
+}

--- a/src/main/java/com/tavemakers/surf/domain/letter/exception/LetterErrorMessage.java
+++ b/src/main/java/com/tavemakers/surf/domain/letter/exception/LetterErrorMessage.java
@@ -8,7 +8,8 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum LetterErrorMessage {
 
-    LETTER_MAIL_SEND_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "메일 발송에 실패했습니다.");
+    LETTER_MAIL_SEND_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "메일 발송에 실패했습니다."),
+    LETTER_BLOCKED(HttpStatus.FORBIDDEN, "쪽지를 보낼 수 없는 상대입니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/test/java/com/tavemakers/surf/application/letter/usecase/LetterUsecaseBlockGuardTest.java
+++ b/src/test/java/com/tavemakers/surf/application/letter/usecase/LetterUsecaseBlockGuardTest.java
@@ -11,6 +11,7 @@ import com.tavemakers.surf.presentation.letter.dto.request.LetterCreateReqDTO;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.InOrder;
 import org.mockito.Mock;
@@ -18,10 +19,13 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.util.Map;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.inOrder;
@@ -83,6 +87,26 @@ class LetterUsecaseBlockGuardTest {
 
         then(letterCreateService).should(never()).save(any());
         then(emailSender).should(never()).sendMail(anyString(), anyString(), anyString());
+
+        assertBlockedFailureLogged(senderId, receiverId);
+    }
+
+    /**
+     * 차단 거부도 메일 실패와 동일한 실패 이벤트를 남긴다.
+     * 남기지 않으면 진입 시 emit 한 letter_send_api_called 만 있고 종결 이벤트가 없어,
+     * 분석 퍼널에서 원인 불명 이탈이 되고 차단 발동 횟수를 측정할 수 없다.
+     */
+    @SuppressWarnings("unchecked")
+    private void assertBlockedFailureLogged(Long senderId, Long receiverId) {
+        ArgumentCaptor<Map<String, Object>> props = ArgumentCaptor.forClass(Map.class);
+        then(logEventEmitter).should()
+                .emitError(eq("letter_send_api_failed"), props.capture(), anyString());
+
+        assertThat(props.getValue())
+                .containsEntry("sender_id", senderId)
+                .containsEntry("receiver_id", receiverId)
+                .containsEntry("status_code", 403)
+                .containsEntry("error_code", "LETTER_BLOCKED");
     }
 
     /** 발신자·수신자를 검증한 다음 차단 관계를 검사하는 순서를 고정한다 */

--- a/src/test/java/com/tavemakers/surf/application/letter/usecase/LetterUsecaseBlockGuardTest.java
+++ b/src/test/java/com/tavemakers/surf/application/letter/usecase/LetterUsecaseBlockGuardTest.java
@@ -1,0 +1,113 @@
+package com.tavemakers.surf.application.letter.usecase;
+
+import com.tavemakers.surf.application.block.query.BlockGetService;
+import com.tavemakers.surf.application.letter.query.LetterGetService;
+import com.tavemakers.surf.application.member.query.MemberGetService;
+import com.tavemakers.surf.domain.letter.exception.LetterBlockedException;
+import com.tavemakers.surf.domain.member.entity.Member;
+import com.tavemakers.surf.global.logging.LogEventEmitter;
+import com.tavemakers.surf.global.util.EmailSender;
+import com.tavemakers.surf.presentation.letter.dto.request.LetterCreateReqDTO;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+
+/** 쪽지 발송 전 양방향 차단 가드 검증 */
+@ExtendWith(MockitoExtension.class)
+class LetterUsecaseBlockGuardTest {
+
+    private static final Long MEMBER_A = 1L;
+    private static final Long MEMBER_B = 2L;
+
+    @Mock
+    private MemberGetService memberGetService;
+    @Mock
+    private BlockGetService blockGetService;
+    @Mock
+    private LetterCreateService letterCreateService;
+    @Mock
+    private EmailSender emailSender;
+    @Mock
+    private LetterGetService letterGetService;
+    @Mock
+    private LogEventEmitter logEventEmitter;
+
+    @InjectMocks
+    private LetterUsecase letterUsecase;
+
+    @Test
+    @DisplayName("A가 B를 차단하면 A에서 B로 쪽지를 보낼 수 없고 부수효과가 없다")
+    void 차단한_상대에게는_쪽지를_보낼_수_없다() {
+        givenMembers();
+        given(blockGetService.existsBetween(MEMBER_A, MEMBER_B)).willReturn(true);
+
+        assertBlocked(MEMBER_A, MEMBER_B);
+
+        assertLookupAndGuardOrder(MEMBER_A, MEMBER_B);
+    }
+
+    @Test
+    @DisplayName("A가 B를 차단하면 B에서 A로 보내는 쪽지도 거부되어 차단 방향이 노출되지 않는다")
+    void 나를_차단한_상대에게도_쪽지를_보낼_수_없다() {
+        givenMembers();
+        given(blockGetService.existsBetween(MEMBER_B, MEMBER_A)).willReturn(true);
+
+        assertBlocked(MEMBER_B, MEMBER_A);
+
+        assertLookupAndGuardOrder(MEMBER_B, MEMBER_A);
+    }
+
+    private void assertBlocked(Long senderId, Long receiverId) {
+        assertThatThrownBy(() -> letterUsecase.createLetter(senderId, request(receiverId)))
+                .isInstanceOf(LetterBlockedException.class)
+                .satisfies(exception -> {
+                    LetterBlockedException blocked = (LetterBlockedException) exception;
+                    assertThat(blocked.getStatus()).isEqualTo(HttpStatus.FORBIDDEN);
+                    assertThat(blocked.getMessage()).isEqualTo("쪽지를 보낼 수 없는 상대입니다.");
+                });
+
+        then(letterCreateService).should(never()).save(any());
+        then(emailSender).should(never()).sendMail(anyString(), anyString(), anyString());
+    }
+
+    /** 발신자·수신자를 검증한 다음 차단 관계를 검사하는 순서를 고정한다 */
+    private void assertLookupAndGuardOrder(Long senderId, Long receiverId) {
+        InOrder order = inOrder(memberGetService, blockGetService);
+        order.verify(memberGetService).getMember(senderId);
+        order.verify(memberGetService).getMember(receiverId);
+        order.verify(blockGetService).existsBetween(senderId, receiverId);
+    }
+
+    private void givenMembers() {
+        given(memberGetService.getMember(MEMBER_A)).willReturn(member(MEMBER_A));
+        given(memberGetService.getMember(MEMBER_B)).willReturn(member(MEMBER_B));
+    }
+
+    private LetterCreateReqDTO request(Long receiverId) {
+        return new LetterCreateReqDTO(receiverId, "제목", "내용", null, "reply@test.com");
+    }
+
+    private Member member(Long memberId) {
+        Member member = Member.builder()
+                .name("회원" + memberId)
+                .email("member" + memberId + "@test.com")
+                .build();
+        ReflectionTestUtils.setField(member, "id", memberId);
+        return member;
+    }
+}

--- a/src/test/java/com/tavemakers/surf/application/letter/usecase/LetterUsecaseCreateLetterTest.java
+++ b/src/test/java/com/tavemakers/surf/application/letter/usecase/LetterUsecaseCreateLetterTest.java
@@ -3,6 +3,8 @@ package com.tavemakers.surf.application.letter.usecase;
 import com.tavemakers.surf.application.block.query.BlockGetService;
 import com.tavemakers.surf.application.letter.query.LetterGetService;
 import com.tavemakers.surf.application.member.query.MemberGetService;
+import com.tavemakers.surf.domain.block.entity.Block;
+import com.tavemakers.surf.domain.block.repository.BlockRepository;
 import com.tavemakers.surf.domain.letter.event.LetterSentEvent;
 import com.tavemakers.surf.domain.letter.exception.LetterBlockedException;
 import com.tavemakers.surf.domain.letter.exception.LetterMailSendFailException;
@@ -56,12 +58,17 @@ import static org.mockito.Mockito.never;
  *
  * <p>usecase 가 더 이상 트랜잭션을 열지 않으므로 테스트 트랜잭션을 NOT_SUPPORTED 로 끄고
  * 픽스처는 TransactionTemplate 으로 명시적 커밋한다 (MemberDismissRollbackTest 패턴).
+ *
+ * <p>차단 가드는 BlockGetService 를 mock 하지 않고 실제 block 레코드로 검증한다. mock 으로
+ * existsBetween 을 stub 하면 "양방향 거부"를 mock 이 대신 주장하게 되어, 구현이
+ * isBlockedByMe(단방향)로 바뀌어도 테스트가 통과한다.
  */
 @DataJpaTest
 @Import({
         LetterUsecase.class,
         LetterCreateService.class,
         LetterGetService.class,
+        BlockGetService.class,
         LetterUsecaseCreateLetterTest.AfterCommitProbe.class,
 })
 @Transactional(propagation = Propagation.NOT_SUPPORTED)
@@ -90,10 +97,11 @@ class LetterUsecaseCreateLetterTest {
     @Autowired
     private AfterCommitProbe afterCommitProbe;
 
+    @Autowired
+    private BlockRepository blockRepository;
+
     @MockBean
     private MemberGetService memberGetService;
-    @MockBean
-    private BlockGetService blockGetService;
     @MockBean
     private EmailSender emailSender;
     @MockBean
@@ -141,16 +149,34 @@ class LetterUsecaseCreateLetterTest {
     }
 
     @Test
-    @DisplayName("차단 관계이면 쪽지·LetterSentEvent·이메일이 모두 생성되지 않는다")
-    void 차단시_저장_이벤트_이메일이_모두_없다() {
-        given(blockGetService.existsBetween(sender.getId(), receiver.getId())).willReturn(true);
+    @DisplayName("내가 차단한 상대에게 보내면 쪽지·LetterSentEvent·이메일이 모두 생성되지 않는다")
+    void 내가_차단한_상대에게는_저장_이벤트_이메일이_모두_없다() {
+        persistBlock(sender.getId(), receiver.getId());
 
+        assertBlockedWithoutSideEffects();
+    }
+
+    @Test
+    @DisplayName("나를 차단한 상대에게 보내도 거부된다 — 실제 레코드는 반대 방향뿐이다")
+    void 나를_차단한_상대에게도_저장_이벤트_이메일이_모두_없다() {
+        persistBlock(receiver.getId(), sender.getId());
+
+        assertBlockedWithoutSideEffects();
+    }
+
+    /** 차단 시 §7의 0회 요건 — 저장·AFTER_COMMIT 이벤트·이메일이 모두 발생하지 않는다 */
+    private void assertBlockedWithoutSideEffects() {
         assertThatThrownBy(() -> letterUsecase.createLetter(sender.getId(), req()))
                 .isInstanceOf(LetterBlockedException.class);
 
         assertThat(countLetters()).as("차단된 쪽지는 DB에 저장되지 않아야 한다").isZero();
         assertThat(afterCommitProbe.fired.get()).as("LetterSentEvent가 발행되지 않아야 한다").isZero();
         then(emailSender).should(never()).sendMail(anyString(), anyString(), anyString());
+    }
+
+    private void persistBlock(Long blockerId, Long blockedId) {
+        TransactionTemplate tx = new TransactionTemplate(transactionManager);
+        tx.executeWithoutResult(status -> blockRepository.save(Block.of(blockerId, blockedId)));
     }
 
     private LetterCreateReqDTO req() {

--- a/src/test/java/com/tavemakers/surf/application/letter/usecase/LetterUsecaseCreateLetterTest.java
+++ b/src/test/java/com/tavemakers/surf/application/letter/usecase/LetterUsecaseCreateLetterTest.java
@@ -1,17 +1,19 @@
 package com.tavemakers.surf.application.letter.usecase;
 
-import com.tavemakers.surf.presentation.letter.dto.request.LetterCreateReqDTO;
-import com.tavemakers.surf.presentation.letter.dto.response.LetterResDTO;
-import com.tavemakers.surf.domain.letter.event.LetterSentEvent;
-import com.tavemakers.surf.domain.letter.exception.LetterMailSendFailException;
+import com.tavemakers.surf.application.block.query.BlockGetService;
 import com.tavemakers.surf.application.letter.query.LetterGetService;
+import com.tavemakers.surf.application.member.query.MemberGetService;
+import com.tavemakers.surf.domain.letter.event.LetterSentEvent;
+import com.tavemakers.surf.domain.letter.exception.LetterBlockedException;
+import com.tavemakers.surf.domain.letter.exception.LetterMailSendFailException;
 import com.tavemakers.surf.domain.member.entity.Member;
 import com.tavemakers.surf.domain.member.entity.enums.MemberRole;
 import com.tavemakers.surf.domain.member.entity.enums.MemberStatus;
 import com.tavemakers.surf.domain.member.entity.enums.MemberType;
-import com.tavemakers.surf.application.member.query.MemberGetService;
 import com.tavemakers.surf.global.logging.LogEventEmitter;
 import com.tavemakers.surf.global.util.EmailSender;
+import com.tavemakers.surf.presentation.letter.dto.request.LetterCreateReqDTO;
+import com.tavemakers.surf.presentation.letter.dto.response.LetterResDTO;
 import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -35,7 +37,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
 import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.never;
 
 /**
  * 쪽지 생성 R5 수정(저장 커밋 후 트랜잭션 밖 메일 발송) 검증.
@@ -89,6 +93,8 @@ class LetterUsecaseCreateLetterTest {
     @MockBean
     private MemberGetService memberGetService;
     @MockBean
+    private BlockGetService blockGetService;
+    @MockBean
     private EmailSender emailSender;
     @MockBean
     private LogEventEmitter logEventEmitter;
@@ -132,6 +138,19 @@ class LetterUsecaseCreateLetterTest {
         assertThat(countLetters())
                 .as("저장이 메일 발송보다 먼저 커밋되어 쪽지 레코드가 남아야 한다")
                 .isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("차단 관계이면 쪽지·LetterSentEvent·이메일이 모두 생성되지 않는다")
+    void 차단시_저장_이벤트_이메일이_모두_없다() {
+        given(blockGetService.existsBetween(sender.getId(), receiver.getId())).willReturn(true);
+
+        assertThatThrownBy(() -> letterUsecase.createLetter(sender.getId(), req()))
+                .isInstanceOf(LetterBlockedException.class);
+
+        assertThat(countLetters()).as("차단된 쪽지는 DB에 저장되지 않아야 한다").isZero();
+        assertThat(afterCommitProbe.fired.get()).as("LetterSentEvent가 발행되지 않아야 한다").isZero();
+        then(emailSender).should(never()).sendMail(anyString(), anyString(), anyString());
     }
 
     private LetterCreateReqDTO req() {

--- a/src/test/java/com/tavemakers/surf/application/notification/event/NotificationBlockGuardIntegrationTest.java
+++ b/src/test/java/com/tavemakers/surf/application/notification/event/NotificationBlockGuardIntegrationTest.java
@@ -1,0 +1,120 @@
+package com.tavemakers.surf.application.notification.event;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tavemakers.surf.application.block.query.BlockGetService;
+import com.tavemakers.surf.application.member.query.MemberGetService;
+import com.tavemakers.surf.application.notification.query.NotificationGetService;
+import com.tavemakers.surf.application.notification.usecase.NotificationUsecase;
+import com.tavemakers.surf.application.post.query.PostGetService;
+import com.tavemakers.surf.domain.block.entity.Block;
+import com.tavemakers.surf.domain.block.repository.BlockRepository;
+import com.tavemakers.surf.domain.comment.event.CommentCreatedEvent;
+import com.tavemakers.surf.domain.member.entity.enums.MemberStatus;
+import com.tavemakers.surf.domain.notification.repository.NotificationRepository;
+import com.tavemakers.surf.domain.notification.service.NotificationCreateService;
+import com.tavemakers.surf.domain.notification.service.NotificationService;
+import com.tavemakers.surf.domain.post.event.PostLikedEvent;
+import com.tavemakers.surf.global.logging.LogEventEmitterImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+/**
+ * 차단 관계에서 개인 알림이 <b>저장 단계부터</b> 발생하지 않는지 실제 block·notification 테이블로 검증한다.
+ *
+ * <p>BlockGetService를 mock하지 않는다. mock으로 existsBetween을 stub하면 "양방향 차단"을 mock이
+ * 대신 주장하게 되어, 구현이 단방향 조회로 바뀌어도 테스트가 통과한다. 실제 block 행을 정방향·역방향으로
+ * 각각 심어 리포지토리 JPQL의 OR 절부터 알림 미저장까지를 한 번에 고정한다.
+ *
+ * <p>리스너 메서드를 직접 호출한다. @Async·AFTER_COMMIT 배선이 아니라 가드가 검증 대상이다.
+ */
+@DataJpaTest
+@Import({
+        NotificationEventListener.class,
+        NotificationUsecase.class,
+        NotificationCreateService.class,
+        BlockGetService.class,
+        ObjectMapper.class,
+})
+class NotificationBlockGuardIntegrationTest {
+
+    private static final Long RECEIVER = 1L;
+    private static final Long ACTOR = 2L;
+    private static final Long BOARD_ID = 10L;
+    private static final Long POST_ID = 20L;
+
+    @Autowired
+    private NotificationEventListener listener;
+
+    @Autowired
+    private BlockRepository blockRepository;
+
+    @Autowired
+    private NotificationRepository notificationRepository;
+
+    @MockBean
+    private MemberGetService memberGetService;
+    @MockBean
+    private NotificationGetService notificationGetService;
+    @MockBean
+    private NotificationService notificationService;
+    @MockBean
+    private PostGetService postGetService;
+    @MockBean
+    private LogEventEmitterImpl logEventEmitter;
+
+    /**
+     * 수신자를 항상 활성 회원으로 둔다.
+     *
+     * <p>createAndSend는 비활성 수신자면 스스로 조기 반환한다. 이 stub이 없으면 mock 기본값(false)
+     * 때문에 <b>가드가 없어도</b> 알림이 저장되지 않아, 차단 테스트가 잘못된 이유로 통과한다.
+     * 저장을 막는 유일한 원인이 차단 가드가 되도록 고정한다.
+     */
+    @BeforeEach
+    void setUp() {
+        given(memberGetService.existsByIdAndStatusNot(RECEIVER, MemberStatus.WITHDRAWN)).willReturn(true);
+    }
+
+    @Test
+    @DisplayName("내가 차단한 상대의 댓글 알림은 Notification이 저장되지 않는다")
+    void 내가_차단한_상대의_알림은_저장되지_않는다() {
+        blockRepository.saveAndFlush(Block.of(RECEIVER, ACTOR));
+
+        listener.handleCommentCreated(commentCreatedEvent());
+
+        assertThat(notificationRepository.count())
+                .as("FCM만 막으면 알림함·미읽음 뱃지에 이름이 쌓이므로 저장 자체가 없어야 한다")
+                .isZero();
+    }
+
+    @Test
+    @DisplayName("나를 차단한 상대의 게시글 좋아요 알림도 저장되지 않는다 — 실제 레코드는 반대 방향뿐이다")
+    void 나를_차단한_상대의_알림도_저장되지_않는다() {
+        blockRepository.saveAndFlush(Block.of(ACTOR, RECEIVER));
+
+        listener.handlePostLiked(new PostLikedEvent(RECEIVER, "좋아요누른사람", ACTOR, BOARD_ID, POST_ID));
+
+        assertThat(notificationRepository.count()).isZero();
+    }
+
+    @Test
+    @DisplayName("차단 관계가 없으면 알림이 정상 저장된다")
+    void 차단이_없으면_알림이_저장된다() {
+        listener.handleCommentCreated(commentCreatedEvent());
+
+        assertThat(notificationRepository.count())
+                .as("가드가 정상 알림까지 막으면 안 된다")
+                .isEqualTo(1);
+    }
+
+    private CommentCreatedEvent commentCreatedEvent() {
+        return new CommentCreatedEvent(RECEIVER, "댓글작성자", ACTOR, BOARD_ID, POST_ID);
+    }
+}

--- a/src/test/java/com/tavemakers/surf/application/notification/event/NotificationEventListenerBlockGuardTest.java
+++ b/src/test/java/com/tavemakers/surf/application/notification/event/NotificationEventListenerBlockGuardTest.java
@@ -1,0 +1,161 @@
+package com.tavemakers.surf.application.notification.event;
+
+import com.tavemakers.surf.application.block.query.BlockGetService;
+import com.tavemakers.surf.application.notification.usecase.NotificationUsecase;
+import com.tavemakers.surf.application.post.query.PostGetService;
+import com.tavemakers.surf.domain.board.entity.Board;
+import com.tavemakers.surf.domain.board.entity.BoardType;
+import com.tavemakers.surf.domain.comment.event.CommentCreatedEvent;
+import com.tavemakers.surf.domain.comment.event.CommentLikedEvent;
+import com.tavemakers.surf.domain.comment.event.CommentReplyEvent;
+import com.tavemakers.surf.domain.letter.event.LetterSentEvent;
+import com.tavemakers.surf.domain.notification.entity.NotificationType;
+import com.tavemakers.surf.domain.post.entity.Post;
+import com.tavemakers.surf.domain.post.event.PostLikedEvent;
+import com.tavemakers.surf.domain.post.event.PostPublishedEvent;
+import com.tavemakers.surf.global.logging.LogEventEmitterImpl;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+/**
+ * 개인 알림 4종 + 쪽지 방어선에 차단 가드가 걸리는지, 공지 알림은 가드에서 제외되는지 검증한다.
+ *
+ * <p>가드가 createAndSend 호출 자체를 건너뛰는지가 핵심이다. Notification을 저장하고 FCM만
+ * 막으면 알림함과 미읽음 뱃지에 차단한 상대의 이름이 계속 쌓인다.
+ */
+@ExtendWith(MockitoExtension.class)
+class NotificationEventListenerBlockGuardTest {
+
+    private static final Long RECEIVER = 1L;
+    private static final Long ACTOR = 2L;
+    private static final Long BOARD_ID = 10L;
+    private static final Long POST_ID = 20L;
+
+    @Mock
+    private PostGetService postGetService;
+    @Mock
+    private NotificationUsecase notificationUsecase;
+    @Mock
+    private BlockGetService blockGetService;
+    @Mock
+    private LogEventEmitterImpl logEventEmitter;
+
+    @InjectMocks
+    private NotificationEventListener listener;
+
+    @Test
+    @DisplayName("차단 관계이면 댓글 생성 알림을 만들지 않는다")
+    void 차단시_댓글_알림이_생성되지_않는다() {
+        givenBlocked();
+
+        listener.handleCommentCreated(commentCreatedEvent());
+
+        thenNoNotificationCreated();
+    }
+
+    @Test
+    @DisplayName("차단 관계이면 대댓글 알림을 만들지 않는다")
+    void 차단시_대댓글_알림이_생성되지_않는다() {
+        givenBlocked();
+
+        listener.handleCommentReply(commentReplyEvent());
+
+        thenNoNotificationCreated();
+    }
+
+    @Test
+    @DisplayName("차단 관계이면 댓글 좋아요 알림을 만들지 않는다")
+    void 차단시_댓글_좋아요_알림이_생성되지_않는다() {
+        givenBlocked();
+
+        listener.handleCommentLiked(commentLikedEvent());
+
+        thenNoNotificationCreated();
+    }
+
+    @Test
+    @DisplayName("차단 관계이면 게시글 좋아요 알림을 만들지 않는다")
+    void 차단시_게시글_좋아요_알림이_생성되지_않는다() {
+        givenBlocked();
+
+        listener.handlePostLiked(postLikedEvent());
+
+        thenNoNotificationCreated();
+    }
+
+    @Test
+    @DisplayName("쪽지 알림은 발송 단계에서 이미 막히지만 방어선으로 한 번 더 검사한다")
+    void 차단시_쪽지_알림이_생성되지_않는다() {
+        givenBlocked();
+
+        listener.handleLetterSent(new LetterSentEvent(RECEIVER, "보낸사람", ACTOR));
+
+        thenNoNotificationCreated();
+        then(logEventEmitter).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("차단 관계가 없으면 기존 알림 흐름이 그대로 유지된다")
+    void 차단이_없으면_알림이_정상_생성된다() {
+        given(blockGetService.existsBetween(RECEIVER, ACTOR)).willReturn(false);
+
+        listener.handleCommentCreated(commentCreatedEvent());
+        listener.handleCommentReply(commentReplyEvent());
+        listener.handleCommentLiked(commentLikedEvent());
+        listener.handlePostLiked(postLikedEvent());
+
+        then(notificationUsecase).should().createAndSend(eq(RECEIVER), eq(NotificationType.POST_COMMENT), any());
+        then(notificationUsecase).should().createAndSend(eq(RECEIVER), eq(NotificationType.COMMENT_REPLY), any());
+        then(notificationUsecase).should().createAndSend(eq(RECEIVER), eq(NotificationType.COMMENT_LIKE), any());
+        then(notificationUsecase).should().createAndSend(eq(RECEIVER), eq(NotificationType.POST_LIKE), any());
+    }
+
+    @Test
+    @DisplayName("공지 알림은 개인 간 상호작용이 아니므로 차단을 조회하지도 않는다")
+    void 공지_알림은_차단_가드를_타지_않는다() {
+        Post notice = Post.builder().board(Board.of("공지사항", BoardType.NOTICE)).build();
+        given(postGetService.readPost(POST_ID)).willReturn(notice);
+
+        listener.handle(new PostPublishedEvent(POST_ID));
+
+        then(notificationUsecase).should().notifyNoticePost(notice);
+        then(blockGetService).shouldHaveNoInteractions();
+    }
+
+    /** 방향 무관 차단 — 어느 쪽이 차단했든 existsBetween은 true다 */
+    private void givenBlocked() {
+        given(blockGetService.existsBetween(RECEIVER, ACTOR)).willReturn(true);
+    }
+
+    /** 저장 이전 단계에서 끊겼는지 — createAndSend가 호출되면 Notification이 남는다 */
+    private void thenNoNotificationCreated() {
+        then(notificationUsecase).should(never()).createAndSend(anyLong(), any(), any());
+    }
+
+    private CommentCreatedEvent commentCreatedEvent() {
+        return new CommentCreatedEvent(RECEIVER, "댓글작성자", ACTOR, BOARD_ID, POST_ID);
+    }
+
+    private CommentReplyEvent commentReplyEvent() {
+        return new CommentReplyEvent(RECEIVER, "대댓글작성자", ACTOR, BOARD_ID, POST_ID);
+    }
+
+    private CommentLikedEvent commentLikedEvent() {
+        return new CommentLikedEvent(RECEIVER, "좋아요누른사람", ACTOR, BOARD_ID, POST_ID);
+    }
+
+    private PostLikedEvent postLikedEvent() {
+        return new PostLikedEvent(RECEIVER, "좋아요누른사람", ACTOR, BOARD_ID, POST_ID);
+    }
+}


### PR DESCRIPTION
## 📄 작업 내용 요약

사용자 차단(Block) 기능의 **4차 PR — 쪽지 발송 차단** (요구사항 4).

PR #371에서 차단한 회원의 게시글·댓글 노출을 막았지만, 기존에는 어느 한쪽이 상대를 차단해도 쪽지 저장·알림 이벤트·이메일 발송이 그대로 진행됐습니다. 이 PR은 쪽지 생성 전에 방향 무관 차단 관계를 검사해 직접 접촉을 차단합니다.

> ⚠️ **base가 `dev`가 아니라 PR3 브랜치(`feat/#370/block-게시판-댓글-조회-필터`)입니다.** PR #371의 head에서 분기했습니다. **#368 → #369 → #371 → 이 PR 순서로 머지**해 주세요. #371이 머지되면 이 PR의 base를 `dev`로 변경합니다.

### 적용 범위

| 경로 | 변경 |
|---|---|
| 쪽지 발송 | sender·receiver 조회 직후 `BlockGetService.existsBetween` 검사 |
| 차단 방향 | A→B 또는 B→A 중 하나라도 있으면 양쪽 발송 모두 거부 |
| 오류 응답 | 차단 방향을 노출하지 않는 403 `쪽지를 보낼 수 없는 상대입니다.` |
| 부수효과 | 차단 시 쪽지 저장·`LetterSentEvent`·알림·이메일 모두 미발생 |
| 분석 로그 | 차단 거부 시 `letter_send_api_failed`(`error_code=LETTER_BLOCKED`) 적재 |

## 🔍 리뷰 포인트

### 1. 콘텐츠와 쪽지의 차단 방향이 다릅니다

게시글·댓글 숨김은 내가 차단한 회원만 제외하는 단방향 정책이지만, 쪽지는 직접 접촉이므로 `existsBetween(senderId, receiverId)`을 사용합니다. 어느 한쪽이라도 차단했다면 A→B와 B→A 모두 거부합니다.

### 2. 차단 검사가 모든 부수효과보다 앞에 있습니다

호출 순서는 다음과 같습니다.

1. sender 조회
2. receiver 조회
3. 방향 무관 차단 검사
4. validation 로그
5. `Letter.create`
6. `LetterCreateService.save` — DB 저장 + `LetterSentEvent`
7. 트랜잭션 밖 이메일 발송

차단이면 3번에서 `LetterBlockedException`을 던지므로 `save` 자체가 호출되지 않습니다. 따라서 repository 저장, AFTER_COMMIT 이벤트, 알림 리스너, 이메일이 모두 시작되지 않습니다.

### 3. 차단 방향은 응답에서 드러나지 않습니다

A가 B를 차단했는지, B가 A를 차단했는지 구분하지 않고 동일한 403과 중립 메시지를 반환합니다. 상대가 자신이 차단됐는지 API 응답으로 추론하지 못하게 합니다.

### 4. 기존 저장후-메일 트랜잭션 정책은 유지합니다

차단 관계가 없으면 기존과 동일하게 쪽지를 먼저 저장·커밋하고 `LetterSentEvent`의 AFTER_COMMIT 리스너가 발화한 뒤 트랜잭션 밖에서 이메일을 보냅니다. 이메일 실패 시 이미 저장된 쪽지 row가 유지되는 기존 트레이드오프도 변경하지 않았습니다.

### 5. 차단 거부도 실패 이벤트를 남깁니다

`createLetter`는 진입 시 `letter_send_api_called`를 emit합니다. 차단 거부만 종결 이벤트가 없으면 분석 퍼널에서 원인 불명 이탈이 되고 차단이 실제로 얼마나 발동하는지 측정할 수 없습니다. `GlobalExceptionHandler`는 `BaseException`에 대해 SLF4J 경고만 찍고 `LogEventEmitter`를 호출하지 않아 핸들러가 대신 메워주지도 않습니다.

메일 실패 경로와 같은 형태로 `letter_send_api_failed`(`status_code=403`, `error_code=LETTER_BLOCKED`)를 적재하되, **차단 방향은 응답과 마찬가지로 로그에도 남기지 않습니다.**

### 6. 차단 가드 통합 테스트는 `BlockGetService`를 mock하지 않습니다

mock으로 `existsBetween`을 stub하면 "양방향 거부"를 mock이 대신 주장하게 되어, 구현이 `isBlockedByMe`(단방향)로 바뀌어도 테스트가 통과합니다. 실 DB를 쓰는 `LetterUsecaseCreateLetterTest`는 `BlockGetService`를 실제로 import하고 `block` 행을 정방향·역방향으로 각각 심어, 리포지토리 JPQL의 `OR` 절부터 usecase 거부까지를 한 번에 검증합니다. 방향 대칭성 자체는 `BlockRepositoryTest`가 별도로 고정합니다.

## ✅ 테스트

**5건 추가, 전체 449건 통과** (실패·에러·스킵 0). `CleanArchitectureRulesTest` 통과, archunit freeze store 무변동.

| 테스트 | 건수 | 내용 |
|---|---|---|
| `LetterUsecaseBlockGuardTest` | 2 | 회원 조회 후 차단 검사 순서, 403·중립 메시지, save·email 0회, 실패 이벤트 페이로드 |
| `LetterUsecaseCreateLetterTest` 보강 | 2 | **실제 `block` 레코드**로 양방향 거부 — DB row·AFTER_COMMIT 이벤트·email 0회 |

정상 저장·이벤트 발화와 메일 실패 시 row 유지 테스트도 그대로 통과합니다.

## 🗄️ 실행할 쿼리

**이 PR에서 추가로 실행할 DDL은 없습니다.** 기존 `block` 테이블을 `existsBetween`으로 조회할 뿐 엔티티·컬럼·인덱스 변경이 없습니다.

다만 #368의 `block` 테이블 생성 DDL이 이 PR보다 먼저 적용되어 있어야 합니다.

## 📌 참고

- 즉시성 보장은 차단 API가 커밋되고 성공 응답을 반환한 뒤 시작된 신규 쪽지 요청부터입니다. 이미 차단 검사를 통과한 동시 요청까지 소급 취소하는 강한 직렬화는 이번 범위가 아닙니다.
- 쪽지 알림은 `LetterSentEvent`가 발생하지 않아 함께 차단됩니다. 다른 개인 알림의 차단은 후속 PR5 범위입니다.
- PR1~PR5를 함께 배포하거나 feature flag로 묶어야 합니다. PR4까지만 배포하면 콘텐츠·쪽지는 막히지만 다른 개인 알림으로 차단 상대의 이름이 노출될 수 있습니다.

## 📎 Issue 번호

closed #372


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 차단 관계가 있는 상대에게 쪽지를 보낼 수 없도록 제한했습니다.
  * 양방향 차단 여부를 확인하며, 차단된 경우 403 오류를 제공합니다.

* **버그 수정**
  * 차단된 쪽지의 저장, 이메일 발송 및 관련 이벤트 처리를 방지했습니다.
  * 차단으로 인한 실패 상황을 로그로 기록합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->