### PR TITLE
[FEAT] 차단 관계의 개인 알림 차단

### DIFF
--- a/src/main/java/com/tavemakers/surf/application/notification/event/NotificationEventListener.java
+++ b/src/main/java/com/tavemakers/surf/application/notification/event/NotificationEventListener.java
@@ -1,5 +1,6 @@
 package com.tavemakers.surf.application.notification.event;
 
+import com.tavemakers.surf.application.block.query.BlockGetService;
 import com.tavemakers.surf.domain.comment.event.CommentCreatedEvent;
 import com.tavemakers.surf.domain.comment.event.CommentLikedEvent;
 import com.tavemakers.surf.domain.comment.event.CommentReplyEvent;
@@ -30,7 +31,27 @@ public class NotificationEventListener {
 
     private final PostGetService postGetService;
     private final NotificationUsecase notificationUsecase;
+    private final BlockGetService blockGetService;
     private final LogEventEmitterImpl logEventEmitter;
+
+    /**
+     * 차단 관계이면 개인 알림을 만들지 않는다.
+     *
+     * <p>어느 방향이든 차단이 있으면 막는다(쪽지와 동일한 상호작용 정책). 콘텐츠 숨김의
+     * 단방향 필터와 달리, 알림은 직접 접촉이라 한쪽만 차단해도 접촉 경로가 남으면 안 된다.
+     *
+     * <p><b>가드는 반드시 알림 생성 이전에 둔다.</b> Notification을 저장하고 FCM만 막으면
+     * 알림함 목록과 미읽음 뱃지에는 차단한 상대의 이름이 계속 쌓인다.
+     *
+     * <p>공지 알림은 개인 간 상호작용이 아니므로 이 가드를 적용하지 않는다.
+     */
+    private boolean blockedBetween(Long receiverId, Long actorId, NotificationType type) {
+        if (!blockGetService.existsBetween(receiverId, actorId)) {
+            return false;
+        }
+        log.info("[BlockedNotification] skipped type={} receiverId={} actorId={}", type, receiverId, actorId);
+        return true;
+    }
 
     @Async
     @Transactional
@@ -53,6 +74,10 @@ public class NotificationEventListener {
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleCommentCreated(CommentCreatedEvent event) {
+        if (blockedBetween(event.getReceiverId(), event.getActorId(), NotificationType.POST_COMMENT)) {
+            return;
+        }
+
         notificationUsecase.createAndSend(
                 event.getReceiverId(),
                 NotificationType.POST_COMMENT,
@@ -72,6 +97,10 @@ public class NotificationEventListener {
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleCommentReply(CommentReplyEvent event) {
+        if (blockedBetween(event.getReceiverId(), event.getActorId(), NotificationType.COMMENT_REPLY)) {
+            return;
+        }
+
         notificationUsecase.createAndSend(
                 event.getReceiverId(),
                 NotificationType.COMMENT_REPLY,
@@ -91,6 +120,10 @@ public class NotificationEventListener {
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleCommentLiked(CommentLikedEvent event) {
+        if (blockedBetween(event.getReceiverId(), event.getActorId(), NotificationType.COMMENT_LIKE)) {
+            return;
+        }
+
         notificationUsecase.createAndSend(
                 event.getReceiverId(),
                 NotificationType.COMMENT_LIKE,
@@ -110,6 +143,10 @@ public class NotificationEventListener {
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handlePostLiked(PostLikedEvent event) {
+        if (blockedBetween(event.getReceiverId(), event.getActorId(), NotificationType.POST_LIKE)) {
+            return;
+        }
+
         notificationUsecase.createAndSend(
                 event.getReceiverId(),
                 NotificationType.POST_LIKE,
@@ -129,6 +166,14 @@ public class NotificationEventListener {
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleLetterSent(LetterSentEvent event) {
+        // 방어선 — 쪽지는 발송 단계에서 이미 거부되므로 이 이벤트 자체가 발행되지 않아야 한다.
+        // 여기서 걸린다면 LetterUsecase의 차단 가드가 우회된 것이므로 경고로 남긴다.
+        if (blockedBetween(event.getReceiverId(), event.getSenderId(), NotificationType.MESSAGE)) {
+            log.warn("[LetterNotification] 쪽지 발송 가드를 통과한 차단 관계 - receiverId={} senderId={}",
+                    event.getReceiverId(), event.getSenderId());
+            return;
+        }
+
         logEventEmitter.emit("letter_notification_requested", Map.of(
                 "sender_id", event.getSenderId(),
                 "receiver_id", event.getReceiverId(),

--- a/src/test/java/com/tavemakers/surf/application/notification/event/NotificationBlockGuardIntegrationTest.java
+++ b/src/test/java/com/tavemakers/surf/application/notification/event/NotificationBlockGuardIntegrationTest.java
@@ -1,0 +1,120 @@
+package com.tavemakers.surf.application.notification.event;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tavemakers.surf.application.block.query.BlockGetService;
+import com.tavemakers.surf.application.member.query.MemberGetService;
+import com.tavemakers.surf.application.notification.query.NotificationGetService;
+import com.tavemakers.surf.application.notification.usecase.NotificationUsecase;
+import com.tavemakers.surf.application.post.query.PostGetService;
+import com.tavemakers.surf.domain.block.entity.Block;
+import com.tavemakers.surf.domain.block.repository.BlockRepository;
+import com.tavemakers.surf.domain.comment.event.CommentCreatedEvent;
+import com.tavemakers.surf.domain.member.entity.enums.MemberStatus;
+import com.tavemakers.surf.domain.notification.repository.NotificationRepository;
+import com.tavemakers.surf.domain.notification.service.NotificationCreateService;
+import com.tavemakers.surf.domain.notification.service.NotificationService;
+import com.tavemakers.surf.domain.post.event.PostLikedEvent;
+import com.tavemakers.surf.global.logging.LogEventEmitterImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+/**
+ * 차단 관계에서 개인 알림이 <b>저장 단계부터</b> 발생하지 않는지 실제 block·notification 테이블로 검증한다.
+ *
+ * <p>BlockGetService를 mock하지 않는다. mock으로 existsBetween을 stub하면 "양방향 차단"을 mock이
+ * 대신 주장하게 되어, 구현이 단방향 조회로 바뀌어도 테스트가 통과한다. 실제 block 행을 정방향·역방향으로
+ * 각각 심어 리포지토리 JPQL의 OR 절부터 알림 미저장까지를 한 번에 고정한다.
+ *
+ * <p>리스너 메서드를 직접 호출한다. @Async·AFTER_COMMIT 배선이 아니라 가드가 검증 대상이다.
+ */
+@DataJpaTest
+@Import({
+        NotificationEventListener.class,
+        NotificationUsecase.class,
+        NotificationCreateService.class,
+        BlockGetService.class,
+        ObjectMapper.class,
+})
+class NotificationBlockGuardIntegrationTest {
+
+    private static final Long RECEIVER = 1L;
+    private static final Long ACTOR = 2L;
+    private static final Long BOARD_ID = 10L;
+    private static final Long POST_ID = 20L;
+
+    @Autowired
+    private NotificationEventListener listener;
+
+    @Autowired
+    private BlockRepository blockRepository;
+
+    @Autowired
+    private NotificationRepository notificationRepository;
+
+    @MockBean
+    private MemberGetService memberGetService;
+    @MockBean
+    private NotificationGetService notificationGetService;
+    @MockBean
+    private NotificationService notificationService;
+    @MockBean
+    private PostGetService postGetService;
+    @MockBean
+    private LogEventEmitterImpl logEventEmitter;
+
+    /**
+     * 수신자를 항상 활성 회원으로 둔다.
+     *
+     * <p>createAndSend는 비활성 수신자면 스스로 조기 반환한다. 이 stub이 없으면 mock 기본값(false)
+     * 때문에 <b>가드가 없어도</b> 알림이 저장되지 않아, 차단 테스트가 잘못된 이유로 통과한다.
+     * 저장을 막는 유일한 원인이 차단 가드가 되도록 고정한다.
+     */
+    @BeforeEach
+    void setUp() {
+        given(memberGetService.existsByIdAndStatusNot(RECEIVER, MemberStatus.WITHDRAWN)).willReturn(true);
+    }
+
+    @Test
+    @DisplayName("내가 차단한 상대의 댓글 알림은 Notification이 저장되지 않는다")
+    void 내가_차단한_상대의_알림은_저장되지_않는다() {
+        blockRepository.saveAndFlush(Block.of(RECEIVER, ACTOR));
+
+        listener.handleCommentCreated(commentCreatedEvent());
+
+        assertThat(notificationRepository.count())
+                .as("FCM만 막으면 알림함·미읽음 뱃지에 이름이 쌓이므로 저장 자체가 없어야 한다")
+                .isZero();
+    }
+
+    @Test
+    @DisplayName("나를 차단한 상대의 게시글 좋아요 알림도 저장되지 않는다 — 실제 레코드는 반대 방향뿐이다")
+    void 나를_차단한_상대의_알림도_저장되지_않는다() {
+        blockRepository.saveAndFlush(Block.of(ACTOR, RECEIVER));
+
+        listener.handlePostLiked(new PostLikedEvent(RECEIVER, "좋아요누른사람", ACTOR, BOARD_ID, POST_ID));
+
+        assertThat(notificationRepository.count()).isZero();
+    }
+
+    @Test
+    @DisplayName("차단 관계가 없으면 알림이 정상 저장된다")
+    void 차단이_없으면_알림이_저장된다() {
+        listener.handleCommentCreated(commentCreatedEvent());
+
+        assertThat(notificationRepository.count())
+                .as("가드가 정상 알림까지 막으면 안 된다")
+                .isEqualTo(1);
+    }
+
+    private CommentCreatedEvent commentCreatedEvent() {
+        return new CommentCreatedEvent(RECEIVER, "댓글작성자", ACTOR, BOARD_ID, POST_ID);
+    }
+}

--- a/src/test/java/com/tavemakers/surf/application/notification/event/NotificationEventListenerBlockGuardTest.java
+++ b/src/test/java/com/tavemakers/surf/application/notification/event/NotificationEventListenerBlockGuardTest.java
@@ -1,0 +1,161 @@
+package com.tavemakers.surf.application.notification.event;
+
+import com.tavemakers.surf.application.block.query.BlockGetService;
+import com.tavemakers.surf.application.notification.usecase.NotificationUsecase;
+import com.tavemakers.surf.application.post.query.PostGetService;
+import com.tavemakers.surf.domain.board.entity.Board;
+import com.tavemakers.surf.domain.board.entity.BoardType;
+import com.tavemakers.surf.domain.comment.event.CommentCreatedEvent;
+import com.tavemakers.surf.domain.comment.event.CommentLikedEvent;
+import com.tavemakers.surf.domain.comment.event.CommentReplyEvent;
+import com.tavemakers.surf.domain.letter.event.LetterSentEvent;
+import com.tavemakers.surf.domain.notification.entity.NotificationType;
+import com.tavemakers.surf.domain.post.entity.Post;
+import com.tavemakers.surf.domain.post.event.PostLikedEvent;
+import com.tavemakers.surf.domain.post.event.PostPublishedEvent;
+import com.tavemakers.surf.global.logging.LogEventEmitterImpl;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+/**
+ * 개인 알림 4종 + 쪽지 방어선에 차단 가드가 걸리는지, 공지 알림은 가드에서 제외되는지 검증한다.
+ *
+ * <p>가드가 createAndSend 호출 자체를 건너뛰는지가 핵심이다. Notification을 저장하고 FCM만
+ * 막으면 알림함과 미읽음 뱃지에 차단한 상대의 이름이 계속 쌓인다.
+ */
+@ExtendWith(MockitoExtension.class)
+class NotificationEventListenerBlockGuardTest {
+
+    private static final Long RECEIVER = 1L;
+    private static final Long ACTOR = 2L;
+    private static final Long BOARD_ID = 10L;
+    private static final Long POST_ID = 20L;
+
+    @Mock
+    private PostGetService postGetService;
+    @Mock
+    private NotificationUsecase notificationUsecase;
+    @Mock
+    private BlockGetService blockGetService;
+    @Mock
+    private LogEventEmitterImpl logEventEmitter;
+
+    @InjectMocks
+    private NotificationEventListener listener;
+
+    @Test
+    @DisplayName("차단 관계이면 댓글 생성 알림을 만들지 않는다")
+    void 차단시_댓글_알림이_생성되지_않는다() {
+        givenBlocked();
+
+        listener.handleCommentCreated(commentCreatedEvent());
+
+        thenNoNotificationCreated();
+    }
+
+    @Test
+    @DisplayName("차단 관계이면 대댓글 알림을 만들지 않는다")
+    void 차단시_대댓글_알림이_생성되지_않는다() {
+        givenBlocked();
+
+        listener.handleCommentReply(commentReplyEvent());
+
+        thenNoNotificationCreated();
+    }
+
+    @Test
+    @DisplayName("차단 관계이면 댓글 좋아요 알림을 만들지 않는다")
+    void 차단시_댓글_좋아요_알림이_생성되지_않는다() {
+        givenBlocked();
+
+        listener.handleCommentLiked(commentLikedEvent());
+
+        thenNoNotificationCreated();
+    }
+
+    @Test
+    @DisplayName("차단 관계이면 게시글 좋아요 알림을 만들지 않는다")
+    void 차단시_게시글_좋아요_알림이_생성되지_않는다() {
+        givenBlocked();
+
+        listener.handlePostLiked(postLikedEvent());
+
+        thenNoNotificationCreated();
+    }
+
+    @Test
+    @DisplayName("쪽지 알림은 발송 단계에서 이미 막히지만 방어선으로 한 번 더 검사한다")
+    void 차단시_쪽지_알림이_생성되지_않는다() {
+        givenBlocked();
+
+        listener.handleLetterSent(new LetterSentEvent(RECEIVER, "보낸사람", ACTOR));
+
+        thenNoNotificationCreated();
+        then(logEventEmitter).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("차단 관계가 없으면 기존 알림 흐름이 그대로 유지된다")
+    void 차단이_없으면_알림이_정상_생성된다() {
+        given(blockGetService.existsBetween(RECEIVER, ACTOR)).willReturn(false);
+
+        listener.handleCommentCreated(commentCreatedEvent());
+        listener.handleCommentReply(commentReplyEvent());
+        listener.handleCommentLiked(commentLikedEvent());
+        listener.handlePostLiked(postLikedEvent());
+
+        then(notificationUsecase).should().createAndSend(eq(RECEIVER), eq(NotificationType.POST_COMMENT), any());
+        then(notificationUsecase).should().createAndSend(eq(RECEIVER), eq(NotificationType.COMMENT_REPLY), any());
+        then(notificationUsecase).should().createAndSend(eq(RECEIVER), eq(NotificationType.COMMENT_LIKE), any());
+        then(notificationUsecase).should().createAndSend(eq(RECEIVER), eq(NotificationType.POST_LIKE), any());
+    }
+
+    @Test
+    @DisplayName("공지 알림은 개인 간 상호작용이 아니므로 차단을 조회하지도 않는다")
+    void 공지_알림은_차단_가드를_타지_않는다() {
+        Post notice = Post.builder().board(Board.of("공지사항", BoardType.NOTICE)).build();
+        given(postGetService.readPost(POST_ID)).willReturn(notice);
+
+        listener.handle(new PostPublishedEvent(POST_ID));
+
+        then(notificationUsecase).should().notifyNoticePost(notice);
+        then(blockGetService).shouldHaveNoInteractions();
+    }
+
+    /** 방향 무관 차단 — 어느 쪽이 차단했든 existsBetween은 true다 */
+    private void givenBlocked() {
+        given(blockGetService.existsBetween(RECEIVER, ACTOR)).willReturn(true);
+    }
+
+    /** 저장 이전 단계에서 끊겼는지 — createAndSend가 호출되면 Notification이 남는다 */
+    private void thenNoNotificationCreated() {
+        then(notificationUsecase).should(never()).createAndSend(anyLong(), any(), any());
+    }
+
+    private CommentCreatedEvent commentCreatedEvent() {
+        return new CommentCreatedEvent(RECEIVER, "댓글작성자", ACTOR, BOARD_ID, POST_ID);
+    }
+
+    private CommentReplyEvent commentReplyEvent() {
+        return new CommentReplyEvent(RECEIVER, "대댓글작성자", ACTOR, BOARD_ID, POST_ID);
+    }
+
+    private CommentLikedEvent commentLikedEvent() {
+        return new CommentLikedEvent(RECEIVER, "좋아요누른사람", ACTOR, BOARD_ID, POST_ID);
+    }
+
+    private PostLikedEvent postLikedEvent() {
+        return new PostLikedEvent(RECEIVER, "좋아요누른사람", ACTOR, BOARD_ID, POST_ID);
+    }
+}


### PR DESCRIPTION
## 📄 작업 내용 요약

사용자 차단(Block) 기능의 **5차 PR — 개인 알림 차단** (요구사항 5).

PR #371에서 게시글·댓글을, PR #373에서 쪽지를 막았지만 **알림 채널은 아직 열려 있었습니다.** A가 B를 차단해도 B가 A의 글에 댓글·좋아요를 남기면 `B님이 댓글을 남겼습니다` 푸시가 그대로 갔습니다. 푸시 문구에 차단한 사람의 이름이 노출되고, 눌러 들어가면 A 본인 글이라 정상 표시되는데 그 댓글만 안 보여 사용자에게는 버그로 보입니다.

이 PR로 **§13.0에서 확정한 1차 범위(게시판·댓글·쪽지·알림)가 모두 채워집니다.**

> ⚠️ **base가 `dev`가 아니라 PR4 브랜치(`feat/#372/block-쪽지-발송-차단`)입니다.** PR #373의 head에서 분기했습니다. **#368 → #369 → #371 → #373 → 이 PR 순서로 머지**해 주세요. #373이 머지되면 이 PR의 base를 `dev`로 변경합니다.

### 적용 범위

| 이벤트 | 가드 | 근거 |
|---|:---:|---|
| `CommentCreatedEvent` (댓글) | ✅ | 개인 상호작용 |
| `CommentReplyEvent` (대댓글) | ✅ | 개인 상호작용 |
| `CommentLikedEvent` (댓글 좋아요) | ✅ | 개인 상호작용 |
| `PostLikedEvent` (게시글 좋아요) | ✅ | 개인 상호작용 |
| `LetterSentEvent` (쪽지) | ✅ 방어선 | PR #373이 발송 단계에서 이미 차단 |
| `PostPublishedEvent` (공지) | ❌ | 개인 간 상호작용이 아니라 조직 공지 |

변경 파일은 `NotificationEventListener` 하나이며, 공용 가드 `blockedBetween(receiverId, actorId, type)`을 추가해 각 핸들러 첫 줄에서 조기 반환합니다.

## 🔍 리뷰 포인트

### 1. 가드가 `createAndSend` 호출 자체를 건너뜁니다

`Notification`을 저장하고 FCM만 막으면 **알림함 목록과 미읽음 뱃지에는 차단한 상대의 이름이 계속 쌓입니다.** 푸시만 안 올 뿐 앱을 열면 그대로 보이므로 차단이 완성되지 않습니다. 저장 이전 단계에서 끊는 것이 이 PR의 핵심이고, 통합 테스트가 `Notification` row 0건으로 이를 고정합니다.

### 2. 방향이 콘텐츠와 다릅니다 — 양방향입니다

게시글·댓글 숨김은 내가 차단한 회원만 제외하는 단방향(`getMyBlockedMemberIds`)이지만, 알림은 쪽지와 같은 직접 접촉이므로 `existsBetween(receiverId, actorId)`입니다. 한쪽만 차단해도 접촉 경로가 남으면 안 됩니다.

### 3. 공지 알림은 차단을 조회하지도 않습니다

`PostPublishedEvent`는 조직 공지라 차단과 무관합니다. 가드를 넣지 않는 것이 요구사항이며, 불필요한 쿼리도 태우지 않습니다. `공지_알림은_차단_가드를_타지_않는다` 테스트가 `blockGetService`에 **아무 상호작용이 없음**을 검증해 실수로 가드가 추가되는 회귀를 막습니다.

### 4. 스킵 로그에 `LogEventEmitter`를 쓰지 않았습니다

이 리스너들은 `@Async` 스레드에서 돕니다. `LogEventEmitter.emit`은 요청 컨텍스트(ThreadLocal)에 적재했다가 요청 종료 시 flush하는 구조라, 비동기 스레드에서 부르면 수동 `flush()`가 필요합니다(기존 쪽지 핸들러가 `finally`에서 그렇게 하고 있습니다). 스킵 로그 하나 때문에 나머지 4개 핸들러에 flush 책임을 퍼뜨리지 않고 SLF4J만 씁니다.

### 5. 쪽지 방어선이 발화하면 경고입니다

PR #373이 발송 자체를 막으므로 `LetterSentEvent`는 차단 관계에서 아예 발행되지 않아야 합니다. 여기서 걸린다면 `LetterUsecase`의 가드가 우회된 것이므로 `log.warn`으로 남깁니다.

## ✅ 테스트

**10건 추가, 전체 459건 통과** (실패·에러·스킵 0). `CleanArchitectureRulesTest` 통과, archunit freeze store 무변동.

| 테스트 | 건수 | 내용 |
|---|---|---|
| `NotificationEventListenerBlockGuardTest` | 7 | 개인 4종·쪽지 방어선 스킵, 차단 없을 때 정상 발송, 공지는 차단 조회조차 안 함 |
| `NotificationBlockGuardIntegrationTest` | 3 | **실제 `block` 레코드**로 양방향 `Notification` 미저장, 차단 없으면 정상 저장 |

### 헛도는 테스트를 피하기 위해 한 것

**통합 테스트는 `BlockGetService`를 mock하지 않습니다.** mock으로 `existsBetween`을 stub하면 "양방향 차단"을 mock이 대신 주장하게 되어, 구현이 단방향 조회로 바뀌어도 통과합니다(PR #373 리뷰에서 같은 지적을 받아 반영한 방식입니다).

**`existsByIdAndStatusNot`를 `@BeforeEach`에서 true로 고정합니다.** `createAndSend`는 비활성 수신자면 스스로 조기 반환하므로, 이 stub이 없으면 mock 기본값(false) 때문에 **가드가 없어도** 알림이 저장되지 않아 차단 테스트가 잘못된 이유로 통과합니다. 저장을 막는 유일한 원인이 차단 가드가 되도록 고정했습니다.

**가드를 무력화해 검증했습니다.** `blockedBetween`이 항상 false를 반환하도록 바꾸면 10건 중 8건이 실패하는 것을 확인했습니다.

## 🗄️ 실행할 쿼리

**이 PR에서 추가로 실행할 DDL은 없습니다.** 기존 `block` 테이블을 `existsBetween`으로 조회할 뿐 엔티티·컬럼·인덱스 변경이 없습니다.

다만 #368의 `block` 테이블 생성 DDL이 이 PR보다 먼저 적용되어 있어야 합니다.

## 📌 참고

- **이미 쌓인 과거 알림은 소급 삭제하지 않습니다.** 차단은 시점 기준 동작이고 알림함은 지나간 사건의 기록입니다(설계 문서 §2.5).
- 알림 조회 시점이 아니라 **생성 시점** 기준입니다. 차단 이전에 만들어진 알림은 알림함에 남습니다.
- 이 PR로 1차 범위가 완성됩니다. 남은 2차는 PR6(스크랩·회원 탐색), PR7(문서·운영 검증)이며 별도 이슈로 등록할 예정입니다.
- **PR1~PR5를 함께 배포하거나 feature flag로 묶어야 합니다.** 중간 단계만 배포하면 차단 API는 성공하는데 콘텐츠나 알림이 그대로 노출되는 불완전 상태가 됩니다.

## 📎 Issue 번호

closed #374
