### PR TITLE
[FEAT] 스크랩 목록 차단 필터와 회원 검색 차단 표기 적용

### DIFF
--- a/docs/domains.md
+++ b/docs/domains.md
@@ -159,3 +159,52 @@ MemberBadge    ← 회원-배지 매핑 (다대다)
 | `reservation` | 예약 게시글 관리 | `/v1/user/reservations` |
 | `team` | 팀/그룹 관리 | `/v1/user/teams` |
 | `login` | 카카오 OAuth2 로그인 | `/login/` |
+| `block` | 회원 간 차단 등록/해제/목록 (관리자 강제 해제 포함) | `/v1/user/blocks`, `/v1/admin/blocks` |
+
+---
+
+### block
+
+**역할**: 폭언·괴롭힘 사용자로부터 사용자를 보호하는 안전 기능. 차단하면 상대의 게시글·댓글이 조회에서 사라지고 쪽지·개인 알림이 차단된다.
+
+**구조**
+
+```
+Block   ← 단방향 관계 (blocker_id → blocked_id)
+```
+
+A→B와 B→A는 서로 다른 레코드다. 한쪽을 지워도 반대 방향은 남는다. 변경되는 속성이 없어 `BaseEntity`를 상속하지 않고 `createdAt`만 둔다.
+
+**두 정책의 방향이 다르다 — 바꿔 쓰면 동작이 조용히 바뀐다**
+
+| 용도 | 방향 | 조회 메서드 |
+|------|------|------------|
+| 콘텐츠 숨김 (게시글·댓글·스크랩) | **단방향** — 내가 차단한 사람만 안 보인다. 상대 시점에서는 내 글이 그대로 보인다 | `BlockGetService.getMyBlockedMemberIds` |
+| 상호작용 차단 (쪽지·개인 알림) | **양방향** — 어느 한쪽이라도 차단했으면 막는다 | `BlockGetService.existsBetween` |
+| 회원 검색 표기 | 단방향, **제외하지 않고 표기만** | `BlockGetService.getMyBlockedIdsRaw` |
+
+**sentinel 계약**: `getMyBlockedMemberIds`는 절대 빈 컬렉션을 반환하지 않는다. 차단이 0건이면 `-1L`을 넣는다 — 빈 컬렉션을 JPQL `not in`에 넘기면 공급자·DB별로 목록이 통째로 비거나 문법 오류가 난다. Java `contains` 판정에는 sentinel이 없는 `getMyBlockedIdsRaw`를 쓴다.
+
+**적용 지점**
+
+| 화면 | 동작 |
+|------|------|
+| 게시판 목록·카테고리·검색 | 쿼리 `not in`으로 제외 (조회 후 Java 필터링 금지 — 페이지 크기가 깨진다) |
+| 게시글 상세 | 404. 403이면 차단 대상의 글이 존재한다는 사실이 드러난다. **조회수 증가보다 앞**에 둔다 |
+| 댓글 목록·count | 같은 제외 집합을 둘 다에 넘긴다. 다르면 "댓글 3개"인데 목록이 비는 불일치가 생긴다 |
+| 댓글 API 직접 호출 | `PostGetService.validateVisiblePost`로 상세 가드 우회를 막는다 |
+| 스크랩 목록 | 차단 **이전**에 스크랩한 글도 사라진다. 단 스크랩 레코드는 지우지 않아 해제하면 복구된다 |
+| 쪽지 | 저장·이벤트·메일 발송 **이전**에 403 |
+| 개인 알림 | `Notification` 저장 이전에 차단 (FCM만 막으면 알림함에 이름이 쌓인다). 공지 알림은 제외 |
+| 회원 검색 | **제외하지 않는다.** `blockedByMe` 플래그만 내려주고 `totalCount`는 유지 — 검색에서 지우면 차단을 해제할 방법이 없어진다 |
+
+**제명(hard delete) 연동**: `BlockMemberDismissListener`가 같은 트랜잭션에서 양방향 차단 관계를 정리한다. 운영 FK가 RESTRICT라 이 정리가 빠지면 회원 삭제 자체가 실패한다 — 부수효과가 아니라 선행 조건이므로 `@Async`·AFTER_COMMIT을 쓰지 않는다.
+
+**운영 스키마**: `block` 테이블은 `ddl-auto`가 FK를 만들지 못한다(회원을 scalar ID로 보유). 운영 DDL을 수동 적용하며 절차는 `docs/block-feature-plan.md` §13.2 참고.
+
+**관련 코드**
+- `presentation/block/controller/` — `BlockCreateController`, `BlockDeleteController`, `BlockGetController`, `BlockAdminGetController`, `BlockAdminDeleteController`
+- `application/block/usecase/` — `BlockUsecase`, `BlockAdminUsecase`
+- `application/block/query/` — `BlockGetService`(사용자), `BlockAdminGetService`(관리자, 방향 무관)
+- `application/block/event/` — `BlockMemberDismissListener`, `BlockForceReleasedLogListener`
+- `domain/block/` — `Block`, `BlockRepository`, `BlockCreateService`, `BlockDeleteService`

--- a/src/main/java/com/tavemakers/surf/application/member/usecase/MemberUsecase.java
+++ b/src/main/java/com/tavemakers/surf/application/member/usecase/MemberUsecase.java
@@ -1,8 +1,10 @@
 package com.tavemakers.surf.application.member.usecase;
 
-import com.tavemakers.surf.presentation.member.dto.request.MemberSignupReqDTO;
-import com.tavemakers.surf.presentation.member.dto.request.ProfileUpdateReqDTO;
-import com.tavemakers.surf.presentation.member.dto.response.*;
+import com.tavemakers.surf.application.block.query.BlockGetService;
+import com.tavemakers.surf.application.member.query.CareerGetService;
+import com.tavemakers.surf.application.member.query.MemberGetService;
+import com.tavemakers.surf.application.member.query.TrackGetService;
+import com.tavemakers.surf.application.score.query.PersonalScoreGetService;
 import com.tavemakers.surf.domain.member.dto.CareerCreateCommand;
 import com.tavemakers.surf.domain.member.dto.CareerUpdateCommand;
 import com.tavemakers.surf.domain.member.entity.Member;
@@ -14,19 +16,18 @@ import com.tavemakers.surf.domain.member.exception.AccountIntegrationAvailableEx
 import com.tavemakers.surf.domain.member.exception.MemberAlreadyExistsException;
 import com.tavemakers.surf.domain.member.exception.MemberSignupRejectedException;
 import com.tavemakers.surf.domain.member.exception.TrackNotFoundException;
-import com.tavemakers.surf.application.member.query.CareerGetService;
-import com.tavemakers.surf.application.member.query.MemberGetService;
-import com.tavemakers.surf.application.member.query.TrackGetService;
 import com.tavemakers.surf.domain.member.service.CareerCreateService;
-import com.tavemakers.surf.domain.member.service.CareerPatchService;
 import com.tavemakers.surf.domain.member.service.CareerDeleteService;
+import com.tavemakers.surf.domain.member.service.CareerPatchService;
 import com.tavemakers.surf.domain.member.service.MemberPatchService;
 import com.tavemakers.surf.domain.member.service.MemberService;
 import com.tavemakers.surf.domain.member.service.MemberWithdrawService;
-import com.tavemakers.surf.application.score.query.PersonalScoreGetService;
 import com.tavemakers.surf.global.logging.LogEvent;
 import com.tavemakers.surf.global.logging.LogEventEmitter;
 import com.tavemakers.surf.global.util.SecurityUtils;
+import com.tavemakers.surf.presentation.member.dto.request.MemberSignupReqDTO;
+import com.tavemakers.surf.presentation.member.dto.request.ProfileUpdateReqDTO;
+import com.tavemakers.surf.presentation.member.dto.response.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationContext;
@@ -47,6 +48,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static com.tavemakers.surf.domain.member.exception.ErrorMessage.ACCOUNT_INTEGRATION_AVAILABLE;
@@ -68,6 +70,7 @@ public class MemberUsecase {
     private final MemberService memberService;
     private final MemberWithdrawService memberWithdrawService;
     private final PendingIntegrationUsecase pendingIntegrationUsecase;
+    private final BlockGetService blockGetService;
     private final ApplicationContext context;
     private final LogEventEmitter logEventEmitter;
     //</editor-fold>
@@ -474,7 +477,8 @@ public class MemberUsecase {
         try {
             Pageable pageable = PageRequest.of(pageNum, pageSize);
             Part memberPart = part == null ? null : Part.valueOf(part);
-            Slice<MemberSearchDetailResDTO> slice = search(generation, memberPart, keyword, pageable);
+            Slice<MemberSearchDetailResDTO> slice =
+                    search(generation, memberPart, keyword, pageable, requesterId);
 
             Long totalCount = null;
             if (pageNum == 0) { // FRONTEND 협의 - 0번째 페이지에서만 검색조건에 따른 전체 회원수 조회.
@@ -535,9 +539,14 @@ public class MemberUsecase {
     }
 
 
-    private Slice<MemberSearchDetailResDTO> search(Integer generation, Part part, String keyword, Pageable pageable) {
+    /** 회원 검색 결과에 단방향 차단 여부를 표기한다 */
+    private Slice<MemberSearchDetailResDTO> search(
+            Integer generation, Part part, String keyword, Pageable pageable, Long requesterId) {
+        Set<Long> blockedIds = blockGetService.getMyBlockedIdsRaw(requesterId);
+
         return memberGetService.searchMembers(generation, part, keyword, pageable)
-                .map(MemberSearchDetailResDTO::from);
+                .map(member -> MemberSearchDetailResDTO.from(
+                        member, blockedIds.contains(member.getId())));
     }
 
 }

--- a/src/main/java/com/tavemakers/surf/application/scrap/query/ScrapGetService.java
+++ b/src/main/java/com/tavemakers/surf/application/scrap/query/ScrapGetService.java
@@ -1,11 +1,12 @@
 package com.tavemakers.surf.application.scrap.query;
 
-import com.tavemakers.surf.presentation.post.dto.response.PostResDTO;
-import com.tavemakers.surf.domain.post.entity.Post;
+import com.tavemakers.surf.application.block.query.BlockGetService;
 import com.tavemakers.surf.application.post.query.PostLikeGetService;
+import com.tavemakers.surf.domain.post.entity.Post;
 import com.tavemakers.surf.domain.scrap.repository.ScrapRepository;
 import com.tavemakers.surf.global.logging.LogEvent;
 import com.tavemakers.surf.global.logging.LogEventContext;
+import com.tavemakers.surf.presentation.post.dto.response.PostResDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -24,6 +25,7 @@ public class ScrapGetService {
 
     private final ScrapRepository scrapRepository;
     private final PostLikeGetService postLikeGetService;
+    private final BlockGetService blockGetService;
 
     /** 게시글의 모든 스크랩 삭제 */
     @Transactional
@@ -41,10 +43,13 @@ public class ScrapGetService {
         return scrapRepository.existsByMemberIdAndPostId(memberId, postId);
     }
 
-    /** 내 스크랩 목록 조회 */
+    /** 차단 작성자의 게시글을 제외한 내 스크랩 목록을 조회한다 */
     @LogEvent(value = "scrap.list.view", message = "스크랩 목록 조회")
     public Slice<PostResDTO> getMyScraps(Long memberId, Pageable pageable) {
-        Slice<Post> slice = scrapRepository.findPostsByMemberId(memberId, pageable);
+        Set<Long> excludedAuthorIds = blockGetService.getMyBlockedMemberIds(memberId);
+
+        Slice<Post> slice =
+                scrapRepository.findPostsByMemberIdExcludingAuthors(memberId, excludedAuthorIds, pageable);
 
         List<Long> postIds = slice.getContent().stream()
                 .map(Post::getId)

--- a/src/main/java/com/tavemakers/surf/domain/scrap/repository/ScrapRepository.java
+++ b/src/main/java/com/tavemakers/surf/domain/scrap/repository/ScrapRepository.java
@@ -24,6 +24,7 @@ public interface ScrapRepository extends JpaRepository<Scrap, Long> {
            """)
     List<Long> findPostIdsByMemberId(Long memberId);
 
+    /** 차단 작성자를 제외하고 스크랩한 순서로 게시글을 조회한다 */
     @Query(
             value = """
             select p
@@ -33,10 +34,13 @@ public interface ScrapRepository extends JpaRepository<Scrap, Long> {
             join fetch p.board
             left join fetch p.category
             where s.member.id = :memberId
+              and p.member.id not in :excludedAuthorIds
             order by s.createdAt desc
             """
     )
-    Slice<Post> findPostsByMemberId(Long memberId, Pageable pageable);
+    Slice<Post> findPostsByMemberIdExcludingAuthors(Long memberId,
+                                                    Set<Long> excludedAuthorIds,
+                                                    Pageable pageable);
 
     @Query("""
            select s.post.id

--- a/src/main/java/com/tavemakers/surf/global/common/advice/GlobalExceptionHandler.java
+++ b/src/main/java/com/tavemakers/surf/global/common/advice/GlobalExceptionHandler.java
@@ -22,6 +22,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 import java.util.HashMap;
@@ -81,6 +82,16 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ApiResponse<Void>> handleMissingServletRequestParameterException(MissingServletRequestParameterException e) {
         ErrorCode errorCode = PARAMETER_NOT_FOUND;
         logWarning(e, HttpStatus.BAD_REQUEST.value());
+        return responseException(errorCode.getStatus(), errorCode.getMessage(), null);
+    }
+
+    /** 요청 파라미터 타입 변환 실패를 400으로 응답한다 */
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ApiResponse<Void>> handleMethodArgumentTypeMismatchException(
+            MethodArgumentTypeMismatchException e
+    ) {
+        ErrorCode errorCode = METHOD_ARGUMENT_NOT_VALID;
+        logWarning(e, errorCode.getStatus().value());
         return responseException(errorCode.getStatus(), errorCode.getMessage(), null);
     }
 

--- a/src/main/java/com/tavemakers/surf/presentation/member/dto/response/MemberSearchDetailResDTO.java
+++ b/src/main/java/com/tavemakers/surf/presentation/member/dto/response/MemberSearchDetailResDTO.java
@@ -2,11 +2,14 @@ package com.tavemakers.surf.presentation.member.dto.response;
 
 import com.tavemakers.surf.domain.member.entity.Member;
 import com.tavemakers.surf.domain.member.entity.Track;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 import java.util.Comparator;
 import java.util.List;
 
+/** 회원 검색 결과 행 */
+@Schema(description = "회원 검색 결과")
 @Builder
 public record MemberSearchDetailResDTO(
         Long memberId,
@@ -15,9 +18,13 @@ public record MemberSearchDetailResDTO(
         String selfIntroduction,
         String profileImageUrl,
         String role,
-        List<TrackResDTO> trackList
+        List<TrackResDTO> trackList,
+
+        @Schema(description = "내가 해당 회원을 차단했는지 여부", example = "false")
+        boolean blockedByMe
 ) {
-    public static MemberSearchDetailResDTO from(Member member) {
+    /** 회원과 차단 여부로 검색 결과 행을 만든다 */
+    public static MemberSearchDetailResDTO from(Member member, boolean blockedByMe) {
         List<TrackResDTO> trackDtoList = member.getTracks()
                 .stream()
                 .sorted(Comparator.comparing(Track::getGeneration).reversed())
@@ -32,6 +39,7 @@ public record MemberSearchDetailResDTO(
                 .profileImageUrl(member.getProfileImageUrl())
                 .role(member.getRole().name())
                 .trackList(trackDtoList)
+                .blockedByMe(blockedByMe)
                 .build();
     }
 }

--- a/src/test/java/com/tavemakers/surf/application/block/query/BlockGetServiceTest.java
+++ b/src/test/java/com/tavemakers/surf/application/block/query/BlockGetServiceTest.java
@@ -95,6 +95,18 @@ class BlockGetServiceTest {
     }
 
     @Test
+    @DisplayName("나를 차단한 상대는 표기용 집합에 담기지 않는다 — 회원 검색에서 상대의 차단 사실이 새면 안 된다")
+    void 표기용_집합에_나를_차단한_회원은_없다() {
+        // 반대 방향: target → viewer. viewer 는 아무도 차단하지 않았다.
+        blockRepository.save(Block.of(target.getId(), viewer.getId()));
+        em.flush();
+
+        assertThat(blockGetService.getMyBlockedIdsRaw(viewer.getId()))
+                .as("양방향으로 구현하면 회원 검색에서 blockedByMe=true 가 되어 상대의 차단이 노출된다")
+                .isEmpty();
+    }
+
+    @Test
     @DisplayName("existsBetween은 양방향, isBlockedByMe는 단방향 — 두 정책이 섞이지 않는다")
     void 상호작용은_양방향_콘텐츠는_단방향이다() {
         blockRepository.save(Block.of(viewer.getId(), target.getId()));

--- a/src/test/java/com/tavemakers/surf/application/member/usecase/MemberUsecaseBlockFlagTest.java
+++ b/src/test/java/com/tavemakers/surf/application/member/usecase/MemberUsecaseBlockFlagTest.java
@@ -1,0 +1,160 @@
+package com.tavemakers.surf.application.member.usecase;
+
+import com.tavemakers.surf.application.block.query.BlockGetService;
+import com.tavemakers.surf.application.member.query.MemberGetService;
+import com.tavemakers.surf.domain.member.entity.CustomUserDetails;
+import com.tavemakers.surf.domain.member.entity.Member;
+import com.tavemakers.surf.domain.member.entity.enums.MemberRole;
+import com.tavemakers.surf.domain.member.entity.enums.MemberStatus;
+import com.tavemakers.surf.domain.member.entity.enums.MemberType;
+import com.tavemakers.surf.global.logging.LogEventEmitter;
+import com.tavemakers.surf.presentation.member.dto.response.MemberSearchDetailResDTO;
+import com.tavemakers.surf.presentation.member.dto.response.MemberSearchSliceResDTO;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+/** 회원 검색의 단방향 차단 표기를 검증한다 */
+@ExtendWith(MockitoExtension.class)
+class MemberUsecaseBlockFlagTest {
+
+    private static final long REQUESTER_ID = 1L;
+    private static final long BLOCKED_ID = 2L;
+    private static final long NORMAL_ID = 3L;
+
+    @Mock
+    private MemberGetService memberGetService;
+
+    @Mock
+    private BlockGetService blockGetService;
+
+    @Mock
+    private LogEventEmitter logEventEmitter;
+
+    @InjectMocks
+    private MemberUsecase memberUsecase;
+
+    @BeforeEach
+    void setUp() {
+        authenticateAs(REQUESTER_ID);
+
+        Slice<Member> slice = new SliceImpl<>(
+                List.of(member(BLOCKED_ID, "차단회원"), member(NORMAL_ID, "정상회원")),
+                PageRequest.of(0, 20), false);
+
+        given(memberGetService.searchMembers(any(), any(), any(), any())).willReturn(slice);
+        given(memberGetService.countSearchingMembers(any(), any(), any())).willReturn(2L);
+    }
+
+    @AfterEach
+    void clearContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    @DisplayName("차단한 회원도 결과에 그대로 포함되고 blockedByMe 로만 구분된다 — 제외가 아니라 표기다")
+    void 차단_회원은_제외되지_않고_표기된다() {
+        given(blockGetService.getMyBlockedIdsRaw(REQUESTER_ID)).willReturn(Set.of(BLOCKED_ID));
+
+        MemberSearchSliceResDTO result = memberUsecase.searchMembers(0, 20, null, null, null);
+
+        assertThat(result.content())
+                .extracting(MemberSearchDetailResDTO::memberId, MemberSearchDetailResDTO::blockedByMe)
+                .as("차단 회원이 결과에서 사라지면 사용자가 차단을 해제할 방법이 없어진다")
+                .containsExactly(
+                        tuple(BLOCKED_ID, true),
+                        tuple(NORMAL_ID, false));
+    }
+
+    @Test
+    @DisplayName("totalCount 는 차단과 무관하게 유지된다 — count 쿼리에 필터를 적용하지 않는다")
+    void totalCount는_유지된다() {
+        given(blockGetService.getMyBlockedIdsRaw(REQUESTER_ID)).willReturn(Set.of(BLOCKED_ID));
+
+        MemberSearchSliceResDTO result = memberUsecase.searchMembers(0, 20, null, null, null);
+
+        assertThat(result.totalCount())
+                .as("차단 1건이 있어도 검색 대상 2명이 그대로 집계되어야 한다")
+                .isEqualTo(2L);
+        assertThat(result.numberOfElements()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("상대가 나를 차단한 경우는 blockedByMe 가 false 다 — 단방향")
+    void 상대가_나를_차단한_것은_표기하지_않는다() {
+        // 내가 차단한 목록이 비어 있다 = 내가 차단한 사람은 없다.
+        // 양방향(existsBetween)으로 구현했다면 여기서 true 가 되어 상대의 차단 사실이 노출된다.
+        given(blockGetService.getMyBlockedIdsRaw(REQUESTER_ID)).willReturn(Set.of());
+
+        MemberSearchSliceResDTO result = memberUsecase.searchMembers(0, 20, null, null, null);
+
+        assertThat(result.content()).extracting(MemberSearchDetailResDTO::blockedByMe)
+                .as("차단은 상대에게 알리지 않는 것이 이 기능의 전제다")
+                .containsOnly(false);
+    }
+
+    @Test
+    @DisplayName("차단이 0건이면 빈 Set 이 그대로 쓰인다 — 여기서는 sentinel 을 쓰지 않는다")
+    void 차단이_없으면_모두_false다() {
+        given(blockGetService.getMyBlockedIdsRaw(REQUESTER_ID)).willReturn(Set.of());
+
+        MemberSearchSliceResDTO result = memberUsecase.searchMembers(0, 20, null, null, null);
+
+        assertThat(result.content()).extracting(MemberSearchDetailResDTO::blockedByMe).containsOnly(false);
+        verify(blockGetService, times(0)).getMyBlockedMemberIds(anyLong());
+    }
+
+    @Test
+    @DisplayName("차단 목록은 페이지당 1회만 조회한다 — 회원마다 조회하면 N+1 이다")
+    void 차단_목록은_한_번만_조회한다() {
+        given(blockGetService.getMyBlockedIdsRaw(REQUESTER_ID)).willReturn(Set.of(BLOCKED_ID));
+
+        memberUsecase.searchMembers(0, 20, null, null, null);
+
+        verify(blockGetService, times(1)).getMyBlockedIdsRaw(REQUESTER_ID);
+        verify(blockGetService, times(0)).isBlockedByMe(anyLong(), anyLong());
+    }
+
+    private void authenticateAs(Long memberId) {
+        Member requester = member(memberId, "요청자");
+        CustomUserDetails principal = new CustomUserDetails(requester);
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(principal, null, principal.getAuthorities()));
+    }
+
+    private Member member(Long id, String name) {
+        Member member = Member.builder()
+                .name(name)
+                .email(id + "@test.com")
+                .phoneNumber(String.valueOf(id))
+                .status(MemberStatus.APPROVED)
+                .role(MemberRole.MEMBER)
+                .memberType(MemberType.YB)
+                .activityStatus(true)
+                .build();
+        ReflectionTestUtils.setField(member, "id", id);
+        return member;
+    }
+}

--- a/src/test/java/com/tavemakers/surf/application/scrap/query/ScrapGetServiceBlockFilterTest.java
+++ b/src/test/java/com/tavemakers/surf/application/scrap/query/ScrapGetServiceBlockFilterTest.java
@@ -1,0 +1,173 @@
+package com.tavemakers.surf.application.scrap.query;
+
+import com.tavemakers.surf.application.block.query.BlockGetService;
+import com.tavemakers.surf.application.post.query.PostLikeGetService;
+import com.tavemakers.surf.domain.block.entity.Block;
+import com.tavemakers.surf.domain.block.repository.BlockRepository;
+import com.tavemakers.surf.domain.board.entity.Board;
+import com.tavemakers.surf.domain.board.entity.BoardCategory;
+import com.tavemakers.surf.domain.board.entity.BoardType;
+import com.tavemakers.surf.domain.member.entity.Member;
+import com.tavemakers.surf.domain.member.entity.enums.MemberRole;
+import com.tavemakers.surf.domain.member.entity.enums.MemberStatus;
+import com.tavemakers.surf.domain.member.entity.enums.MemberType;
+import com.tavemakers.surf.domain.post.entity.Post;
+import com.tavemakers.surf.domain.scrap.entity.Scrap;
+import com.tavemakers.surf.presentation.post.dto.response.PostResDTO;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** 실제 차단 관계로 스크랩 목록의 단방향 필터를 검증한다 */
+@DataJpaTest
+@Import({
+        ScrapGetService.class,
+        PostLikeGetService.class,
+        BlockGetService.class,
+})
+class ScrapGetServiceBlockFilterTest {
+
+    @Autowired
+    private ScrapGetService scrapGetService;
+
+    @Autowired
+    private BlockRepository blockRepository;
+
+    @Autowired
+    private EntityManager em;
+
+    private Board board;
+    private BoardCategory category;
+    private Member viewer;
+    private Member author;
+
+    @BeforeEach
+    void setUp() {
+        board = Board.of("자유게시판", BoardType.GENERAL);
+        em.persist(board);
+        category = BoardCategory.of(board, "잡담", "chat-" + System.nanoTime());
+        em.persist(category);
+
+        viewer = persistMember("viewer");
+        author = persistMember("author");
+    }
+
+    @Test
+    @DisplayName("차단 이전에 스크랩해 둔 상대 게시글도 목록에서 사라진다")
+    void 차단_이전_스크랩분도_사라진다() {
+        // 스크랩이 차단보다 먼저다 — 이 순서가 요구사항의 이유다
+        scrap(persistPost("상대글"));
+        scrap(persistPost("내글", viewer));
+        em.flush();
+
+        blockRepository.save(Block.of(viewer.getId(), author.getId()));
+        em.flush();
+        em.clear();
+
+        Slice<PostResDTO> result = scrapGetService.getMyScraps(viewer.getId(), PageRequest.of(0, 20));
+
+        assertThat(result.getContent()).extracting(PostResDTO::title).containsExactly("내글");
+    }
+
+    @Test
+    @DisplayName("숨기기만 하고 scrap 레코드는 지우지 않는다 — 차단을 해제하면 목록에 그대로 돌아온다")
+    void 차단_해제하면_스크랩이_복구된다() {
+        Post post = persistPost("상대글");
+        scrap(post);
+        em.flush();
+
+        Block block = blockRepository.save(Block.of(viewer.getId(), author.getId()));
+        em.flush();
+        em.clear();
+
+        assertThat(scrapGetService.getMyScraps(viewer.getId(), PageRequest.of(0, 20)).getContent())
+                .as("차단 중에는 보이지 않는다").isEmpty();
+
+        assertThat(countScraps())
+                .as("숨김이지 삭제가 아니다 — 레코드가 사라지면 복구할 수 없다").isEqualTo(1);
+
+        blockRepository.delete(block);
+        em.flush();
+        em.clear();
+
+        assertThat(scrapGetService.getMyScraps(viewer.getId(), PageRequest.of(0, 20)).getContent())
+                .extracting(PostResDTO::title)
+                .as("해제하면 그대로 돌아와야 한다").containsExactly("상대글");
+    }
+
+    @Test
+    @DisplayName("차단은 단방향이다 — 상대가 나를 차단했을 뿐이면 내 스크랩은 그대로 보인다")
+    void 상대가_나를_차단해도_내_스크랩은_그대로다() {
+        scrap(persistPost("상대글"));
+        em.flush();
+
+        // 반대 방향: author → viewer
+        blockRepository.save(Block.of(author.getId(), viewer.getId()));
+        em.flush();
+        em.clear();
+
+        Slice<PostResDTO> result = scrapGetService.getMyScraps(viewer.getId(), PageRequest.of(0, 20));
+
+        assertThat(result.getContent()).extracting(PostResDTO::title)
+                .as("양방향(existsBetween)으로 구현하면 여기서 사라진다")
+                .containsExactly("상대글");
+    }
+
+    @Test
+    @DisplayName("차단이 없으면 스크랩 목록이 그대로 조회된다")
+    void 차단이_없으면_그대로_조회된다() {
+        scrap(persistPost("상대글"));
+        scrap(persistPost("내글", viewer));
+        em.flush();
+        em.clear();
+
+        Slice<PostResDTO> result = scrapGetService.getMyScraps(viewer.getId(), PageRequest.of(0, 20));
+
+        assertThat(result.getContent()).extracting(PostResDTO::title)
+                .containsExactlyInAnyOrder("상대글", "내글");
+    }
+
+    private long countScraps() {
+        return em.createQuery(
+                        "select count(s) from Scrap s where s.member.id = :id", Long.class)
+                .setParameter("id", viewer.getId())
+                .getSingleResult();
+    }
+
+    private Post persistPost(String title) {
+        return persistPost(title, author);
+    }
+
+    private Post persistPost(String title, Member writer) {
+        Post post = Post.of(title, "본문", false, false, false, board, category, writer);
+        em.persist(post);
+        return post;
+    }
+
+    private void scrap(Post post) {
+        em.persist(Scrap.of(viewer, post));
+    }
+
+    private Member persistMember(String prefix) {
+        long seed = System.nanoTime();
+        Member member = Member.builder()
+                .name("회원")
+                .email(prefix + seed + "@test.com")
+                .phoneNumber(String.valueOf(seed))
+                .status(MemberStatus.APPROVED)
+                .role(MemberRole.MEMBER)
+                .memberType(MemberType.YB)
+                .activityStatus(true)
+                .build();
+        em.persist(member);
+        return member;
+    }
+}

--- a/src/test/java/com/tavemakers/surf/domain/scrap/repository/ScrapBlockFilterQueryTest.java
+++ b/src/test/java/com/tavemakers/surf/domain/scrap/repository/ScrapBlockFilterQueryTest.java
@@ -1,0 +1,179 @@
+package com.tavemakers.surf.domain.scrap.repository;
+
+import com.tavemakers.surf.domain.board.entity.Board;
+import com.tavemakers.surf.domain.board.entity.BoardCategory;
+import com.tavemakers.surf.domain.board.entity.BoardType;
+import com.tavemakers.surf.domain.member.entity.Member;
+import com.tavemakers.surf.domain.member.entity.enums.MemberRole;
+import com.tavemakers.surf.domain.member.entity.enums.MemberStatus;
+import com.tavemakers.surf.domain.member.entity.enums.MemberType;
+import com.tavemakers.surf.domain.post.entity.Post;
+import com.tavemakers.surf.domain.scrap.entity.Scrap;
+import jakarta.persistence.EntityManager;
+import org.hibernate.Hibernate;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+
+import java.time.LocalDateTime;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** 스크랩 목록의 작성자 제외·정렬·fetch join 쿼리를 검증한다 */
+@DataJpaTest
+class ScrapBlockFilterQueryTest {
+
+    /** 차단이 0건일 때 BlockGetService 가 넣어주는 값 */
+    private static final Set<Long> NO_ONE_BLOCKED = Set.of(-1L);
+
+    @Autowired
+    private ScrapRepository scrapRepository;
+
+    @Autowired
+    private EntityManager em;
+
+    private Board board;
+    private BoardCategory category;
+    private Member viewer;
+    private Member blockedAuthor;
+    private Member normalAuthor;
+
+    @BeforeEach
+    void setUp() {
+        board = Board.of("자유게시판", BoardType.GENERAL);
+        em.persist(board);
+        category = BoardCategory.of(board, "잡담", "chat-" + System.nanoTime());
+        em.persist(category);
+
+        viewer = persistMember("viewer");
+        blockedAuthor = persistMember("blocked");
+        normalAuthor = persistMember("normal");
+    }
+
+    @Test
+    @DisplayName("차단 작성자의 글이 스크랩 목록에서 빠진다 — 스크랩은 차단보다 먼저 한 행위다")
+    void 차단_작성자의_스크랩이_빠진다() {
+        scrap(persistPost("차단글", blockedAuthor));
+        scrap(persistPost("정상글", normalAuthor));
+        em.flush();
+        em.clear();
+
+        Slice<Post> result = scrapRepository.findPostsByMemberIdExcludingAuthors(
+                viewer.getId(), Set.of(blockedAuthor.getId()), PageRequest.of(0, 20));
+
+        assertThat(result.getContent()).extracting(Post::getTitle).containsExactly("정상글");
+    }
+
+    @Test
+    @DisplayName("차단이 없으면(sentinel) 아무도 제외되지 않는다")
+    void sentinel이면_아무도_제외되지_않는다() {
+        scrap(persistPost("글1", blockedAuthor));
+        scrap(persistPost("글2", normalAuthor));
+        em.flush();
+        em.clear();
+
+        Slice<Post> result = scrapRepository.findPostsByMemberIdExcludingAuthors(
+                viewer.getId(), NO_ONE_BLOCKED, PageRequest.of(0, 20));
+
+        assertThat(result.getContent()).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("정렬은 게시글 작성순이 아니라 내가 스크랩한 순서(최신순)다")
+    void 스크랩한_순서가_유지된다() {
+        Post first = persistPost("먼저 스크랩", normalAuthor);
+        Post second = persistPost("나중에 스크랩", normalAuthor);
+        scrap(first);
+        scrap(second);
+        em.flush();
+
+        // 같은 트랜잭션에서 연속 persist 하면 createdAt 이 동률로 찍힐 수 있어 순서 검증이 흔들린다.
+        // 보조 정렬 컬럼이 없는 쿼리라 시각을 명시적으로 벌려 결정적으로 만든다.
+        setScrapCreatedAt(first, LocalDateTime.of(2026, 1, 1, 0, 0));
+        setScrapCreatedAt(second, LocalDateTime.of(2026, 6, 1, 0, 0));
+        em.clear();
+
+        Slice<Post> result = scrapRepository.findPostsByMemberIdExcludingAuthors(
+                viewer.getId(), NO_ONE_BLOCKED, PageRequest.of(0, 20));
+
+        assertThat(result.getContent()).extracting(Post::getTitle)
+                .as("스크랩한 순서의 역순이어야 한다 — order by s.createdAt desc 가 빠지면 무너진다")
+                .containsExactly("나중에 스크랩", "먼저 스크랩");
+    }
+
+    @Test
+    @DisplayName("작성자·게시판·카테고리가 fetch join 으로 함께 로딩된다 — 목록 변환 시 N+1 방지")
+    void 연관관계가_함께_로딩된다() {
+        scrap(persistPost("정상글", normalAuthor));
+        em.flush();
+        em.clear();
+
+        Slice<Post> result = scrapRepository.findPostsByMemberIdExcludingAuthors(
+                viewer.getId(), NO_ONE_BLOCKED, PageRequest.of(0, 20));
+
+        Post post = result.getContent().get(0);
+        assertThat(Hibernate.isInitialized(post.getMember()))
+                .as("PostResDTO 변환이 작성자를 읽으므로 초기화되어 있어야 한다").isTrue();
+        assertThat(Hibernate.isInitialized(post.getBoard())).isTrue();
+        assertThat(Hibernate.isInitialized(post.getCategory())).isTrue();
+    }
+
+    @Test
+    @DisplayName("차단 작성자를 제외해도 페이지는 요청한 크기만큼 채워진다 — 조회 후 필터링이 아니다")
+    void 페이지_크기가_유지된다() {
+        for (int i = 0; i < 5; i++) {
+            scrap(persistPost("차단글" + i, blockedAuthor));
+        }
+        for (int i = 0; i < 4; i++) {
+            scrap(persistPost("정상글" + i, normalAuthor));
+        }
+        em.flush();
+        em.clear();
+
+        Slice<Post> result = scrapRepository.findPostsByMemberIdExcludingAuthors(
+                viewer.getId(), Set.of(blockedAuthor.getId()), PageRequest.of(0, 3));
+
+        assertThat(result.getContent()).hasSize(3);
+        assertThat(result.hasNext()).isTrue();
+        assertThat(result.getContent()).extracting(p -> p.getMember().getId())
+                .containsOnly(normalAuthor.getId());
+    }
+
+    private Post persistPost(String title, Member author) {
+        Post post = Post.of(title, "본문", false, false, false, board, category, author);
+        em.persist(post);
+        return post;
+    }
+
+    private void scrap(Post post) {
+        em.persist(Scrap.of(viewer, post));
+    }
+
+    /** createdAt 은 감사(@CreatedDate)로 채워지고 updatable=false 라 네이티브로 직접 조정한다 */
+    private void setScrapCreatedAt(Post post, LocalDateTime createdAt) {
+        em.createNativeQuery("update scrap set created_at = :createdAt where post_id = :postId")
+                .setParameter("createdAt", createdAt)
+                .setParameter("postId", post.getId())
+                .executeUpdate();
+    }
+
+    private Member persistMember(String prefix) {
+        long seed = System.nanoTime();
+        Member member = Member.builder()
+                .name("회원")
+                .email(prefix + seed + "@test.com")
+                .phoneNumber(String.valueOf(seed))
+                .status(MemberStatus.APPROVED)
+                .role(MemberRole.MEMBER)
+                .memberType(MemberType.YB)
+                .activityStatus(true)
+                .build();
+        em.persist(member);
+        return member;
+    }
+}

--- a/src/test/java/com/tavemakers/surf/global/common/advice/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/tavemakers/surf/global/common/advice/GlobalExceptionHandlerTest.java
@@ -12,10 +12,12 @@ import org.springframework.mock.http.MockHttpInputMessage;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authorization.AuthorizationDecision;
 import org.springframework.security.authorization.AuthorizationDeniedException;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 import static com.tavemakers.surf.global.common.exception.ErrorCode.ACCESS_DENIED;
 import static com.tavemakers.surf.global.common.exception.ErrorCode.INTERNAL_SERVER_ERROR;
 import static com.tavemakers.surf.global.common.exception.ErrorCode.MESSAGE_NOT_READABLE;
+import static com.tavemakers.surf.global.common.exception.ErrorCode.METHOD_ARGUMENT_NOT_VALID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
@@ -72,5 +74,17 @@ class GlobalExceptionHandlerTest {
         assertThat(res.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
         assertThat(res.getBody().message()).isEqualTo(MESSAGE_NOT_READABLE.getMessage());
         assertThat(res.getBody().message()).doesNotContain("JSON parse error");
+    }
+
+    @Test
+    @DisplayName("요청 파라미터 타입 변환 실패는 400으로 응답한다")
+    void methodArgumentTypeMismatch_returns400() {
+        MethodArgumentTypeMismatchException e = new MethodArgumentTypeMismatchException(
+                "INVALID", String.class, "direction", null, new IllegalArgumentException());
+
+        ResponseEntity<ApiResponse<Void>> res = handler.handleMethodArgumentTypeMismatchException(e);
+
+        assertThat(res.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(res.getBody().message()).isEqualTo(METHOD_ARGUMENT_NOT_VALID.getMessage());
     }
 }


### PR DESCRIPTION
## 📄 작업 내용 요약

사용자 차단(Block) 기능의 **6차 PR — 스크랩 제외 · 회원 검색 표기** (요구사항 6·3).

PR #368·#369로 차단 관계를 만들고, #371로 게시글·댓글을, #373으로 쪽지를, #375로 개인 알림을 막았습니다. 남아 있던 두 항목이 이 PR입니다.

- **스크랩 목록에 필터가 없었습니다.** 게시판에서는 안 보이는 상대의 글이 내 스크랩 목록에는 그대로 남아 있었습니다.
- **회원 검색에 차단 표시가 없었습니다.** 내가 차단한 회원인지 알 방법이 없어 클라이언트가 분기할 수 없었습니다.

이 PR로 **확정 요구사항 6종이 모두 채워집니다.**

> base는 `dev`입니다. 1차 전량이 `dev`에 머지된 뒤 분기했으므로 앞선 PR을 기다릴 필요가 없습니다.

### 적용 범위

| 경로 | 변경 | 방향 |
|---|---|---|
| 스크랩 목록 (`GET /v1/user/scraps`) | 차단 작성자의 게시글을 쿼리에서 **제외** | 단방향 |
| 회원 검색 (`GET /v1/user/members`) | 제외하지 않고 `blockedByMe` 플래그만 **추가**, `totalCount` 유지 | 단방향 |
| 파라미터 타입 변환 실패 | `MethodArgumentTypeMismatchException` 핸들러 추가 (500 → 400) | — |
| `docs/domains.md` | block 도메인 설명 추가 | — |

### ⚠️ 두 기능의 방향이 서로 반대입니다

이 PR의 리뷰에서 가장 헷갈리는 지점입니다. 앞선 PR 4개가 전부 "제외"였기 때문에 회원 검색도 같은 패턴으로 읽기 쉽습니다.

| | 스크랩 (요구 6) | 회원 검색 (요구 3) |
|---|---|---|
| 결과 | 차단 대상 **제외** | 차단 대상 **그대로 노출** |
| 개수 | 제외된 만큼 줄어듦 | **줄지 않음 — 현행 유지** |
| 쿼리 | JPQL `not in` 조건 추가 | **쿼리 변경 없음** |
| 사용 메서드 | `getMyBlockedMemberIds` (sentinel 포함) | `getMyBlockedIdsRaw` (sentinel 없음) |

회원 검색은 "이 사람을 찾아서 무언가 하려는" 화면입니다. 차단한 사람이 결과에서 사라지면 사용자는 그 사람을 찾을 수도, **차단을 해제할 수도** 없게 됩니다. 그래서 `MemberSearchRepository`와 count 쿼리는 건드리지 않았습니다.

### 왜 한 PR에 묶었는지

두 항목은 방향이 반대라 **커밋을 분리**했습니다(`#377` 스크랩 / `#378` 회원 검색). 파일도 전혀 겹치지 않습니다. 다만 둘 다 마지막 남은 요구사항이고 각각 100줄 안팎이라, 나눠 올리면 리뷰 컨텍스트만 두 번 쌓입니다. 커밋 단위로 나눠 보시면 정책이 섞이지 않습니다.

`docs/domains.md`와 예외 핸들러 수정도 커밋을 따로 뒀습니다.

## 🔍 리뷰 포인트

### 1. 스크랩 쿼리는 조건 한 줄만 얹었습니다 — fetch join과 정렬이 회귀 지점입니다

기존 `findPostsByMemberId`는 단순 조회가 아니라 `join fetch p.member`·`p.board`·`left join fetch p.category`와 `order by s.createdAt desc`를 갖고 있습니다. 작성자 제외 조건을 넣으면서 쿼리를 새로 쓰면 두 가지가 조용히 깨집니다.

1. **N+1 재발** — `PostResDTO` 변환이 작성자·게시판·카테고리를 읽으므로 fetch join이 빠지면 행마다 추가 쿼리가 나갑니다.
2. **정렬 유실** — 스크랩 목록의 순서는 게시글 작성순이 아니라 **내가 스크랩한 순서**입니다. `order by s.createdAt desc`가 빠지면 순서가 통째로 바뀝니다.

둘 다 기능 테스트로는 안 잡히는 회귀라 `ScrapBlockFilterQueryTest`에 전용 테스트를 뒀습니다 — `Hibernate.isInitialized`로 fetch join을, 스크랩 시각을 명시적으로 벌려 정렬을 각각 고정합니다.

### 2. 스크랩은 숨기는 것이지 지우는 것이 아닙니다

`scrap` 레코드는 그대로 두고 조회에서만 제외합니다. 차단을 해제하면 목록에 그대로 돌아와야 합니다 — 삭제로 구현하면 되돌릴 수 없는 데이터 손실입니다. `차단_해제하면_스크랩이_복구된다` 테스트가 차단 중 목록 비어 있음 → **`scrap` 행 수는 1건 유지** → 해제 후 복구까지 한 흐름으로 검증합니다.

### 3. 차단 이전에 스크랩한 글도 사라집니다

이 요구사항이 별도로 존재하는 이유입니다. 스크랩은 차단보다 **먼저** 일어난 행위라, "차단 이후 작성분만 막는" 구현으로는 이미 담아둔 글이 남습니다. 필터 기준이 "차단 시점 이후 작성분"이 아니라 **"조회 시점의 작성자"** 여야 합니다. 통합 테스트에서 스크랩 → 차단 순으로 데이터를 만들어 이 순서를 고정했습니다.

### 4. `blockedByMe` — 이름에 방향을 박았습니다

초안 필드명은 `isBlocked`였는데 `blockedByMe`로 바꿨습니다.

- 코드베이스는 조회자 기준 플래그에 `...ByMe`를 씁니다 (`scrappedByMe`, `likedByMe`). 이 플래그는 "이 회원이 차단 상태인가"가 아니라 "**내가** 이 회원을 차단했는가"입니다.
- `isBlocked`는 "이 사람이 (누군가에게) 차단당했다"로도 읽혀 방향이 드러나지 않습니다. **이 기능은 단방향이 정책의 핵심**이라 — 상대가 나를 차단한 사실은 절대 내려가면 안 됩니다 — 이름이 모호하면 클라이언트가 잘못 해석할 여지가 생깁니다.
- 부수 효과로 서버 쪽 안전장치도 됩니다. 나중에 양방향(`existsBetween`)으로 잘못 구현하면 `isBlocked`에서는 어색하지 않지만 `blockedByMe`에서는 이름과 명백히 모순되어 리뷰에서 걸립니다.

Jackson 직렬화 결과가 `blockedByMe`로 나가는 것은 실제 실행으로 확인했습니다. record 컴포넌트명이 그대로 쓰이며, 기존 `MemberSearchSliceResDTO.isLast`와 같은 방식입니다.

**FE와 표기 방식(배지 / 흐리게 / 하단 정렬 / 별도 섹션) 합의가 필요합니다.** 서버는 플래그만 내려줍니다.

### 5. 두 조회 메서드를 용도대로 나눠 씁니다

| 메서드 | 반환 | 이 PR에서의 사용처 |
|---|---|---|
| `getMyBlockedMemberIds` | 비어있지 않음 (`Set.of(-1L)`) | 스크랩 — JPQL `not in` 파라미터 |
| `getMyBlockedIdsRaw` | 비어있을 수 있음 | 회원 검색 — Java `contains` 판정 |

sentinel(`-1L`)은 빈 컬렉션을 JPQL `not in`에 넘기면 공급자·DB별로 목록이 통째로 비거나 문법 오류가 나는 것을 막기 위한 것입니다. 회원 검색은 `not in`을 쓰지 않으므로 sentinel이 필요 없고, 넣으면 `-1L`이 섞인 Set으로 `contains`를 하게 되어 결과는 맞지만 의미가 흐려집니다. 테스트에서 회원 검색이 `getMyBlockedMemberIds`를 **호출하지 않는 것**까지 검증합니다.

### 6. 회원 검색의 차단 조회는 페이지당 1회입니다

회원마다 `isBlockedByMe`를 호출하면 N+1이 됩니다. 페이지 단위로 차단 ID 집합을 한 번 조회한 뒤 `contains`로 판정하며, `getMyBlockedIdsRaw` 1회 호출·`isBlockedByMe` 0회를 테스트로 고정했습니다.

### 7. `MemberSearchDetailResDTO.from(Member)` 단일 인자 버전을 제거했습니다

호출부를 전수 확인한 결과 `MemberUsecase.search(...)` 한 곳뿐이었습니다. 플래그 없이 DTO를 만드는 경로를 남기면 이후에 그 경로로 **표기가 빠진 응답**이 나갈 수 있어 오버로드를 두지 않고 교체했습니다. 같은 이유로 스크랩의 기존 `findPostsByMemberId`도 제거했습니다 — 필터 없는 조회 경로를 남기면 차단이 우회됩니다.

### 8. 파라미터 타입 변환 실패가 500이었습니다

관리자 차단 목록의 `direction`처럼 enum 파라미터에 정의되지 않은 값이 들어오면 `MethodArgumentTypeMismatchException`이 전용 핸들러 없이 마지막 `Exception` 핸들러로 떨어져 **500**이 나갔습니다. 클라이언트 입력 오류가 서버 오류로 보고되던 문제라 400으로 바로잡았습니다.

### 9. 통합 테스트에서 `BlockGetService`를 mock하지 않았습니다

PR #373·#375 리뷰에서 정한 것과 같은 이유입니다. mock으로 stub하면 방향성 주장을 mock이 대신하게 되어, 구현이 반대 방향으로 바뀌어도 테스트가 통과합니다. 스크랩 통합 테스트는 실제 `block` 행을 정방향·역방향으로 심습니다.

회원 검색 테스트는 `MemberUsecase`의 의존성이 많아 mock 기반인데, 그 경우 단방향 주장이 헛돌게 됩니다. 그래서 **방향성 자체는 `BlockGetServiceTest`가 실제 레코드로 고정**하도록 테스트를 하나 추가했습니다 — 역방향 차단(`상대 → 나`)이 표기용 집합에 담기지 않는지 검증합니다.

## ✅ 테스트

**15건 추가, 전체 475건 통과** (실패·에러·스킵 0). `CleanArchitectureRulesTest` 포함, archunit freeze store 무변동.

| 테스트 | 건수 | 내용 |
|---|---|---|
| `ScrapBlockFilterQueryTest` | 5 | 제외, sentinel, **스크랩 순서 유지**, **fetch join 유지**, 페이지 크기 유지 |
| `ScrapGetServiceBlockFilterTest` | 4 | **차단 이전 스크랩분 제외**, **해제 시 복구 + 레코드 미삭제**, 단방향, 차단 없을 때 |
| `MemberUsecaseBlockFlagTest` | 5 | 미제외 + 플래그 정확성, `totalCount` 불변, 단방향, 차단 0건, 조회 1회 |
| `BlockGetServiceTest` (보강) | 1 | 역방향 차단이 표기용 집합에 담기지 않음 |
| `GlobalExceptionHandlerTest` (보강) | 1 | 타입 변환 실패 400 |

필터를 무력화하면 스크랩 2건·회원 검색 1건이 실패하는 것을 확인해 헛도는 테스트가 아님을 검증했습니다.

## 📌 API 영향

`GET /v1/user/members` 응답 `content[]`에 `blockedByMe`가 추가됩니다. **기존 필드는 그대로라 하위 호환입니다.**

```json
{
  "memberId": 12,
  "username": "홍길동",
  "university": "서울대학교",
  "selfIntroduction": "...",
  "profileImageUrl": "https://...",
  "role": "MEMBER",
  "trackList": [],
  "blockedByMe": true
}
```

`GET /v1/user/scraps`는 **응답 스키마 변화 없이 결과 집합만 줄어듭니다.** FE에 공유할 때 이 구분을 함께 전달하면 됩니다.

## 📎 Issue 번호

closed #377
closed #378


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 회원 검색 결과에 내가 차단한 회원인지 표시합니다.
  * 차단한 회원의 게시글이 내 스크랩 목록에서 숨겨집니다.
  * 차단 관계와 게시글·댓글·스크랩·쪽지·알림·검색 적용 규칙을 문서화했습니다.

* **버그 수정**
  * 잘못된 요청 파라미터 형식에 대해 일관된 400 오류를 반환합니다.

* **테스트**
  * 차단 방향, 차단 해제, 스크랩 필터링 및 오류 응답 동작을 검증했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->