### PR TITLE
[FEAT] 로컬 테스트용 토큰 발급 API

### DIFF
--- a/src/main/java/com/tavemakers/surf/global/config/SecurityConfig.java
+++ b/src/main/java/com/tavemakers/surf/global/config/SecurityConfig.java
@@ -4,6 +4,7 @@ import com.tavemakers.surf.domain.member.repository.MemberRepository;
 import com.tavemakers.surf.global.jwt.JwtAuthenticationFilter;
 import com.tavemakers.surf.global.jwt.JwtService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -34,6 +35,13 @@ public class SecurityConfig {
     private final MemberRepository memberRepository;
     private final PermitUrlConfig permitUrlConfig;
 
+    /**
+     * 로컬 테스트 전용 토큰 발급 경로(/test/tokens) 개방 여부 — <b>운영에서는 반드시 false</b>.
+     * true 일 때만 경로가 permitAll 이 되며, 컨트롤러 빈도 동일 프로퍼티로 조건부 생성된다.
+     */
+    @Value("${test-token.enabled:false}")
+    private boolean testTokenEnabled;
+
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
 
@@ -42,7 +50,12 @@ public class SecurityConfig {
 
         http
                 .csrf(csrf -> csrf.disable()) // JWT 사용 시 CSRF 비활성화
-                .authorizeHttpRequests(auth -> auth
+                .authorizeHttpRequests(auth -> {
+                    // 로컬 테스트 전용 토큰 발급 — 프로퍼티가 명시적으로 켜졌을 때만 개방한다
+                    if (testTokenEnabled) {
+                        auth.requestMatchers("/test/tokens").permitAll();
+                    }
+                    auth
                         .requestMatchers("/login/**").permitAll() // 로그인
                         .requestMatchers("/auth/refresh").permitAll()   //
                         .requestMatchers("/auth/logout").permitAll()
@@ -53,8 +66,8 @@ public class SecurityConfig {
                         // 헬스체크는 LB/오케스트레이터가 무토큰으로 호출 (기본 설정이라 UP/DOWN만 노출됨)
                         .requestMatchers("/actuator/health").permitAll()
                         .requestMatchers("/actuator/**").hasAnyRole("ADMIN", "PRESIDENT", "MANAGER")
-                        .anyRequest().authenticated()
-                )
+                        .anyRequest().authenticated();
+                })
                 .formLogin(form -> form.disable()) // 우리는 소셜 로그인 + JWT 사용 → formLogin 비활성화
                 .httpBasic(basic -> basic.disable()) // Basic Auth 비활성화
                 .headers(h -> h.frameOptions(f -> f.sameOrigin())); // 클릭재킹 방지 (X-Frame-Options: SAMEORIGIN)

--- a/src/main/java/com/tavemakers/surf/global/testtoken/controller/TestTokenCreateController.java
+++ b/src/main/java/com/tavemakers/surf/global/testtoken/controller/TestTokenCreateController.java
@@ -1,0 +1,59 @@
+package com.tavemakers.surf.global.testtoken.controller;
+
+import com.tavemakers.surf.application.member.query.MemberGetService;
+import com.tavemakers.surf.domain.member.entity.Member;
+import com.tavemakers.surf.global.common.response.ApiResponse;
+import com.tavemakers.surf.global.jwt.JwtService;
+import com.tavemakers.surf.global.testtoken.dto.TestTokenCreateReqDTO;
+import com.tavemakers.surf.global.testtoken.dto.TestTokenCreateResDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 로컬 수동 테스트 전용 액세스 토큰 발급 API — <b>운영 환경 활성화 금지</b>.
+ *
+ * <p>소셜 로그인(Kakao/Apple)만 있는 구조라 Postman 수동 테스트 시 JWT_SECRET 으로 직접 서명해야 하는
+ * 불편을 없애기 위한 개발 편의 기능이다. 인증 없이 임의 회원의 액세스 토큰을 발급하므로,
+ * 활성화되면 사실상 인증 우회 백도어가 된다.
+ *
+ * <p>따라서 {@code test-token.enabled=true} 를 명시적으로 준 경우에만 빈이 생성된다
+ * (기본값 false — 미설정 시 빈 자체가 없어 엔드포인트가 존재하지 않는다).
+ * SecurityConfig 의 경로 허용도 동일 프로퍼티로 조건화되어 있다.
+ *
+ * <p>발급 대상의 역할은 DB 의 {@code member.role} 을 그대로 사용한다(임의 역할 주입 불가).
+ * 리프레시 토큰·RTR 은 다루지 않는다.
+ */
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+@ConditionalOnProperty(name = "test-token.enabled", havingValue = "true", matchIfMissing = false)
+@Tag(name = "테스트 전용", description = "로컬 수동 테스트 전용 API (운영 비활성)")
+public class TestTokenCreateController {
+
+    private final MemberGetService memberGetService;
+    private final JwtService jwtService;
+
+    /** 실존 회원의 DB 역할 그대로 액세스 토큰을 발급한다 (테스트 전용) */
+    @Operation(
+            summary = "[테스트 전용] 액세스 토큰 발급",
+            description = "test-token.enabled=true 일 때만 노출되는 로컬 테스트 전용 API. "
+                    + "실존 memberId 의 DB 역할로 액세스 토큰을 발급한다. 운영 활성화 금지."
+    )
+    @PostMapping("/test/tokens")
+    public ApiResponse<TestTokenCreateResDTO> createTestToken(@Valid @RequestBody TestTokenCreateReqDTO dto) {
+        Member member = memberGetService.getMember(dto.memberId());
+        String accessToken = jwtService.createAccessToken(member.getId(), member.getRole().name());
+
+        log.warn("[테스트 전용] 액세스 토큰 발급 — memberId={}, role={}", member.getId(), member.getRole());
+        return ApiResponse.response(HttpStatus.OK, "테스트 액세스 토큰 발급 성공", TestTokenCreateResDTO.from(accessToken));
+    }
+
+}

--- a/src/main/java/com/tavemakers/surf/global/testtoken/dto/TestTokenCreateReqDTO.java
+++ b/src/main/java/com/tavemakers/surf/global/testtoken/dto/TestTokenCreateReqDTO.java
@@ -1,0 +1,7 @@
+package com.tavemakers.surf.global.testtoken.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+/** 테스트 전용 토큰 발급 요청 (대상 회원 ID) */
+public record TestTokenCreateReqDTO(@NotNull Long memberId) {
+}

--- a/src/main/java/com/tavemakers/surf/global/testtoken/dto/TestTokenCreateResDTO.java
+++ b/src/main/java/com/tavemakers/surf/global/testtoken/dto/TestTokenCreateResDTO.java
@@ -1,0 +1,9 @@
+package com.tavemakers.surf.global.testtoken.dto;
+
+/** 테스트 전용 토큰 발급 응답 (액세스 토큰) */
+public record TestTokenCreateResDTO(String accessToken) {
+
+    public static TestTokenCreateResDTO from(String accessToken) {
+        return new TestTokenCreateResDTO(accessToken);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -91,6 +91,10 @@ management:
       exposure:
         include: health, metrics
 
+# 로컬 수동 테스트용 액세스 토큰 발급 API (/test/tokens) — 운영에서는 절대 true 로 두지 않는다
+test-token:
+  enabled: ${TEST_TOKEN_ENABLED:false}
+
 logging:
   forwarding:
     enabled: ${LOG_FORWARD_ENABLED:false}

--- a/src/test/java/com/tavemakers/surf/global/testtoken/TestTokenDisabledTest.java
+++ b/src/test/java/com/tavemakers/surf/global/testtoken/TestTokenDisabledTest.java
@@ -1,0 +1,38 @@
+package com.tavemakers.surf.global.testtoken;
+
+import com.tavemakers.surf.e2e.E2ESupport;
+import com.tavemakers.surf.global.testtoken.controller.TestTokenCreateController;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+
+/**
+ * 안전 게이트 검증 — {@code test-token.enabled} 미설정(기본 false)이면 테스트 토큰 발급 기능이 존재하지 않는다.
+ * 운영 기본값과 동일한 상태이므로, 이 테스트가 깨지면 인증 우회 백도어가 열린 것이다.
+ */
+class TestTokenDisabledTest extends E2ESupport {
+
+    @Autowired
+    private ApplicationContext applicationContext;
+
+    @Test
+    @DisplayName("프로퍼티 미설정 시 테스트 토큰 컨트롤러 빈이 컨텍스트에 없다")
+    void controllerBean_isAbsent_whenPropertyMissing() {
+        assertThat(applicationContext.getBeanNamesForType(TestTokenCreateController.class)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("프로퍼티 미설정 시 /test/tokens 호출은 통과하지 못한다(4xx)")
+    void endpoint_isNotReachable_whenPropertyMissing() throws Exception {
+        mockMvc.perform(post("/test/tokens")
+                        .contentType("application/json")
+                        .content("{\"memberId\":1}"))
+                .andExpect(result -> assertThat(result.getResponse().getStatus())
+                        .as("게이트가 닫혔는데 토큰 발급이 성공했다 — 인증 우회 백도어")
+                        .isBetween(400, 499));
+    }
+}

--- a/src/test/java/com/tavemakers/surf/global/testtoken/TestTokenEnabledTest.java
+++ b/src/test/java/com/tavemakers/surf/global/testtoken/TestTokenEnabledTest.java
@@ -1,0 +1,86 @@
+package com.tavemakers.surf.global.testtoken;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.tavemakers.surf.domain.member.entity.Member;
+import com.tavemakers.surf.domain.member.entity.enums.MemberRole;
+import com.tavemakers.surf.e2e.E2ESupport;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.test.context.TestPropertySource;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * 게이트 활성 시 동작 검증 — 실존 회원의 DB 역할로 액세스 토큰이 발급되고,
+ * 그 토큰이 실제 JwtAuthenticationFilter + 인가를 통과하는지까지 관통한다.
+ */
+@TestPropertySource(properties = "test-token.enabled=true")
+class TestTokenEnabledTest extends E2ESupport {
+
+    @Value("${jwt.secret}")
+    private String jwtSecret;
+
+    @Test
+    @DisplayName("실존 회원으로 토큰이 발급되고 sub/role 클레임이 DB 값과 일치한다")
+    void issuesToken_withDbRoleClaims() throws Exception {
+        Member member = persistMember(MemberRole.MANAGER);
+
+        String accessToken = requestTestToken(member.getId());
+
+        Claims claims = parseClaims(accessToken);
+        assertThat(claims.getSubject()).isEqualTo(String.valueOf(member.getId()));
+        assertThat(claims.get("role", String.class)).isEqualTo("ROLE_MANAGER");
+    }
+
+    @Test
+    @DisplayName("발급된 토큰으로 보호 엔드포인트 인증을 통과한다")
+    void issuedToken_passesAuthenticationFilter() throws Exception {
+        Member member = persistMember(MemberRole.MEMBER);
+
+        String accessToken = requestTestToken(member.getId());
+
+        mockMvc.perform(get("/v1/user/home")
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 회원이면 404")
+    void unknownMember_returns404() throws Exception {
+        mockMvc.perform(post("/test/tokens")
+                        .contentType("application/json")
+                        .content("{\"memberId\":99999999}"))
+                .andExpect(status().isNotFound());
+    }
+
+    /** /test/tokens 를 호출해 액세스 토큰 문자열을 꺼낸다. */
+    private String requestTestToken(Long memberId) throws Exception {
+        String body = mockMvc.perform(post("/test/tokens")
+                        .contentType("application/json")
+                        .content("{\"memberId\":" + memberId + "}"))
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        JsonNode json = objectMapper.readTree(body);
+        return json.path("data").path("accessToken").asText();
+    }
+
+    private Claims parseClaims(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(Keys.hmacShaKeyFor(jwtSecret.getBytes(StandardCharsets.UTF_8)))
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+}


### PR DESCRIPTION
Resolves #382

## 📄 작업 내용 요약

소셜 로그인(Kakao/Apple)뿐인 환경에서 Postman 수동 테스트 시 JWT를 얻으려면 시크릿으로 직접 서명해야 하는 불편을 해소하는 **개발 편의 기능**.

### 동작

- `POST /test/tokens` `{"memberId": N}` → 해당 회원의 **DB role 그대로** 액세스 토큰 발급 (임의 역할 지정 불가, 미존재 회원 404)
- 리프레시 토큰·RTR·Redis 무접촉 — 액세스 토큰만

### 보안 게이트 (리뷰 포인트)

- **기본 비활성.** `.env`에 `TEST_TOKEN_ENABLED=true`를 명시해야만 열린다.
- 이중 게이트: ① 컨트롤러 `@ConditionalOnProperty(matchIfMissing=false)` — 꺼져 있으면 빈 자체가 없음 ② SecurityConfig permitAll도 같은 프로퍼티로 조건화 — 꺼져 있으면 403
- 테스트가 "비활성 시 200이면 실패"를 단언하며, 발급 토큰이 실제 인증 필터를 관통하는 통합 테스트 포함
- ⚠️ **운영 환경변수에 `TEST_TOKEN_ENABLED`를 절대 넣지 말 것** — 배포 체크리스트 반영 요청

## 📎 Issue 번호

closed #382

🤖 Generated with [Claude Code](https://claude.com/claude-code)
