### PR TITLE
[Fix] 삭제권한 확장 및 활동기수 변경권한 조정

### DIFF
--- a/src/main/java/com/tavemakers/surf/domain/comment/service/CommentService.java
+++ b/src/main/java/com/tavemakers/surf/domain/comment/service/CommentService.java
@@ -134,9 +134,12 @@ public class CommentService {
     ) {
         Comment comment = commentRepository.findById(commentId)
                 .orElseThrow(CommentNotFoundException::new);
+        Member member = memberGetService.getMember(memberId);
 
-        // 본인이 쓴 댓글인지 확인
-        if (!comment.getPost().getId().equals(postId) || !comment.getMember().getId().equals(memberId))
+        // 같은 게시글의 댓글이면서 작성자 본인 또는 삭제 권한이 있는 운영진만 삭제할 수 있다.
+        boolean samePost = comment.getPost().getId().equals(postId);
+        boolean isOwner = comment.getMember().getId().equals(memberId);
+        if (!samePost || (!isOwner && !member.hasDeleteRole()))
             throw new NotMyCommentException();
 
         // 자식 댓글 parent 끊기

--- a/src/main/java/com/tavemakers/surf/global/config/SecurityConfig.java
+++ b/src/main/java/com/tavemakers/surf/global/config/SecurityConfig.java
@@ -82,7 +82,10 @@ public class SecurityConfig {
                             response.setContentType(MediaType.APPLICATION_JSON_VALUE);
                             response.setCharacterEncoding("UTF-8");
 
-                            String message = request.getRequestURI().startsWith("/v1/admin/")
+                            String requestUri = request.getRequestURI();
+                            String message = requestUri.equals("/v1/admin/active-generation")
+                                    ? "[활동기수] 변경은 [President]만 가능합니다."
+                                    : requestUri.startsWith("/v1/admin/")
                                     ? "[관리자] 권한이 필요한 요청입니다."
                                     : "[접근 권한]이 없습니다.";
 

--- a/src/main/java/com/tavemakers/surf/presentation/activity/controller/activeGeneration/ActiveGenerationGetController.java
+++ b/src/main/java/com/tavemakers/surf/presentation/activity/controller/activeGeneration/ActiveGenerationGetController.java
@@ -26,7 +26,6 @@ public class ActiveGenerationGetController {
 
     /** 현재 활동 기수 조회 */
     @Operation(summary = "현재 활동 기수 조회")
-    @PreAuthorize("hasRole('PRESIDENT')")
     @GetMapping("/v1/manager/active-generation")
     public ApiResponse<ActiveGenerationResDTO> getActiveGeneration() {
         Integer generation = activeGenerationUsecase.getActiveGeneration();
@@ -36,7 +35,6 @@ public class ActiveGenerationGetController {
 
     /** 현재 활동 기수에 속한 회원 목록 조회 */
     @Operation(summary = "현재 활동 기수에 속한 회원 조회")
-    @PreAuthorize("hasRole('PRESIDENT')")
     @GetMapping("/v1/manager/active-generation/members")
     public ApiResponse<List<ActiveGenerationMemberResDTO>> getActiveGenerationMembers() {
         List<ActiveGenerationMemberResDTO> response = activeGenerationUsecase.getActiveGenerationMembers();

--- a/src/main/java/com/tavemakers/surf/presentation/activity/controller/activeGeneration/ActiveGenerationGetController.java
+++ b/src/main/java/com/tavemakers/surf/presentation/activity/controller/activeGeneration/ActiveGenerationGetController.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -25,6 +26,7 @@ public class ActiveGenerationGetController {
 
     /** 현재 활동 기수 조회 */
     @Operation(summary = "현재 활동 기수 조회")
+    @PreAuthorize("hasRole('PRESIDENT')")
     @GetMapping("/v1/manager/active-generation")
     public ApiResponse<ActiveGenerationResDTO> getActiveGeneration() {
         Integer generation = activeGenerationUsecase.getActiveGeneration();
@@ -34,6 +36,7 @@ public class ActiveGenerationGetController {
 
     /** 현재 활동 기수에 속한 회원 목록 조회 */
     @Operation(summary = "현재 활동 기수에 속한 회원 조회")
+    @PreAuthorize("hasRole('PRESIDENT')")
     @GetMapping("/v1/manager/active-generation/members")
     public ApiResponse<List<ActiveGenerationMemberResDTO>> getActiveGenerationMembers() {
         List<ActiveGenerationMemberResDTO> response = activeGenerationUsecase.getActiveGenerationMembers();

--- a/src/main/java/com/tavemakers/surf/presentation/activity/controller/activeGeneration/ActiveGenerationPutController.java
+++ b/src/main/java/com/tavemakers/surf/presentation/activity/controller/activeGeneration/ActiveGenerationPutController.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -22,6 +23,7 @@ public class ActiveGenerationPutController {
     private final ActiveGenerationUsecase activeGenerationUsecase;
 
     @Operation(summary = "현재 활동 기수 변경")
+    @PreAuthorize("hasRole('PRESIDENT')")
     @PutMapping("/v1/admin/active-generation")
     public ApiResponse<Void> updateActiveGeneration(
             @RequestBody @Valid ActiveGenerationUpdateReqDTO dto) {

--- a/src/main/java/com/tavemakers/surf/presentation/comment/controller/CommentDeleteController.java
+++ b/src/main/java/com/tavemakers/surf/presentation/comment/controller/CommentDeleteController.java
@@ -19,7 +19,7 @@ public class CommentDeleteController {
 
     private final CommentUsecase commentUsecase;
 
-    @Operation(summary = "댓글 삭제 (내 댓글만)", description = "본인이 작성한 댓글만 삭제 가능, 댓글 및 대댓글 구분없이 hard 삭제 처리")
+    @Operation(summary = "댓글 삭제", description = "본인이 작성한 댓글만 삭제 가능 & 관리자는 임의의 댓글 삭제 가능, 댓글 및 대댓글 구분없이 hard 삭제 처리")
     @DeleteMapping("/v1/user/posts/{postId}/comments/{commentId}")
     public ApiResponse<Void> deleteComment(@PathVariable Long postId,
                                            @PathVariable Long commentId) {

--- a/src/test/java/com/tavemakers/surf/domain/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/tavemakers/surf/domain/comment/service/CommentServiceTest.java
@@ -381,9 +381,41 @@ class CommentServiceTest {
         ReflectionTestUtils.setField(comment, "id", 1L);
 
         given(commentRepository.findById(1L)).willReturn(Optional.of(comment));
+        given(memberGetService.getMember(2L)).willReturn(member(2L, "다른회원"));
 
         assertThatThrownBy(() -> commentService.deleteComment(10L, 1L, 2L))
                 .isInstanceOf(NotMyCommentException.class);
+    }
+
+    @Test
+    @DisplayName("Manager는 본인 댓글이 아니어도 댓글을 삭제할 수 있다")
+    void deleteComment_managerCanDeleteOthersComment() {
+        Board board = board();
+        BoardCategory category = category(board);
+        Member writer = member(1L, "작성자");
+        Member manager = Member.builder()
+                .name("매니저")
+                .status(MemberStatus.APPROVED)
+                .role(MemberRole.MANAGER)
+                .memberType(MemberType.YB)
+                .activityStatus(true)
+                .build();
+        ReflectionTestUtils.setField(manager, "id", 2L);
+
+        Post post = post(10L, writer, board, category);
+        Comment comment = Comment.root(post, writer, "댓글");
+        ReflectionTestUtils.setField(comment, "id", 1L);
+
+        given(commentRepository.findById(1L)).willReturn(Optional.of(comment));
+        given(memberGetService.getMember(2L)).willReturn(manager);
+
+        commentService.deleteComment(10L, 1L, 2L);
+
+        then(commentRepository).should().detachChildren(1L);
+        then(commentLikeRepository).should().deleteAllByComment(comment);
+        then(commentMentionService).should().deleteAllByComment(comment);
+        then(commentRepository).should().delete(comment);
+        then(postCommentCountService).should().decrease(10L);
     }
 
     @Test
@@ -397,6 +429,7 @@ class CommentServiceTest {
         ReflectionTestUtils.setField(comment, "id", 1L);
 
         given(commentRepository.findById(1L)).willReturn(Optional.of(comment));
+        given(memberGetService.getMember(1L)).willReturn(writer);
 
         commentService.deleteComment(10L, 1L, 1L);
 

--- a/src/test/java/com/tavemakers/surf/e2e/SecurityE2ETest.java
+++ b/src/test/java/com/tavemakers/surf/e2e/SecurityE2ETest.java
@@ -58,13 +58,18 @@ class SecurityE2ETest extends E2ESupport {
     }
 
     @Test
-    @DisplayName("ADMIN 권한은 활동기수 조회 엔드포인트에 접근할 수 없다")
-    void adminRole_onActiveGenerationEndpoint_returns403() throws Exception {
+    @DisplayName("ADMIN 권한은 활동기수 조회 엔드포인트 인가를 통과한다")
+    void adminRole_passesActiveGenerationGetAuthorization() throws Exception {
         Member admin = persistMember(MemberRole.ADMIN);
 
         mockMvc.perform(get("/v1/manager/active-generation")
                         .header("Authorization", bearer(admin)))
-                .andExpect(status().isForbidden());
+                .andExpect(result -> {
+                    int s = result.getResponse().getStatus();
+                    if (s == 403) {
+                        throw new AssertionError("ADMIN 인데 403 이 발생했다 — 활동기수 조회 인가 배선 오류");
+                    }
+                });
     }
 
     @Test
@@ -90,6 +95,21 @@ class SecurityE2ETest extends E2ESupport {
                     int s = result.getResponse().getStatus();
                     if (s == 403) {
                         throw new AssertionError("PRESIDENT 인데 403 이 발생했다 — 활동기수 인가 배선 오류");
+                    }
+                });
+    }
+
+    @Test
+    @DisplayName("MANAGER 권한은 활동기수 회원조회 엔드포인트 인가를 통과한다")
+    void managerRole_passesActiveGenerationMembersAuthorization() throws Exception {
+        Member manager = persistMember(MemberRole.MANAGER);
+
+        mockMvc.perform(get("/v1/manager/active-generation/members")
+                        .header("Authorization", bearer(manager)))
+                .andExpect(result -> {
+                    int s = result.getResponse().getStatus();
+                    if (s == 403) {
+                        throw new AssertionError("MANAGER 인데 403 이 발생했다 — 활동기수 회원조회 인가 배선 오류");
                     }
                 });
     }

--- a/src/test/java/com/tavemakers/surf/e2e/SecurityE2ETest.java
+++ b/src/test/java/com/tavemakers/surf/e2e/SecurityE2ETest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 /**
@@ -52,6 +53,43 @@ class SecurityE2ETest extends E2ESupport {
                     int s = result.getResponse().getStatus();
                     if (s == 403) {
                         throw new AssertionError("ADMIN 인데 403 이 발생했다 — 인가 배선 오류");
+                    }
+                });
+    }
+
+    @Test
+    @DisplayName("ADMIN 권한은 활동기수 조회 엔드포인트에 접근할 수 없다")
+    void adminRole_onActiveGenerationEndpoint_returns403() throws Exception {
+        Member admin = persistMember(MemberRole.ADMIN);
+
+        mockMvc.perform(get("/v1/manager/active-generation")
+                        .header("Authorization", bearer(admin)))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("MANAGER 권한은 활동기수 변경 엔드포인트에 접근할 수 없다")
+    void managerRole_onActiveGenerationUpdateEndpoint_returns403() throws Exception {
+        Member manager = persistMember(MemberRole.MANAGER);
+
+        mockMvc.perform(put("/v1/admin/active-generation")
+                        .contentType("application/json")
+                        .content("{\"activeGeneration\":16}")
+                        .header("Authorization", bearer(manager)))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("PRESIDENT 권한은 활동기수 조회 엔드포인트 인가를 통과한다")
+    void presidentRole_passesActiveGenerationAuthorization() throws Exception {
+        Member president = persistMember(MemberRole.PRESIDENT);
+
+        mockMvc.perform(get("/v1/manager/active-generation")
+                        .header("Authorization", bearer(president)))
+                .andExpect(result -> {
+                    int s = result.getResponse().getStatus();
+                    if (s == 403) {
+                        throw new AssertionError("PRESIDENT 인데 403 이 발생했다 — 활동기수 인가 배선 오류");
                     }
                 });
     }


### PR DESCRIPTION
## 📄 작업 내용 요약
> 공지사항, 게시글, 댓글 삭제 권한을 모든 운영진으로 확장 및 활동기수를 변경할 수 있는 권한은 `president`로만 조정

### 1. 공지사항 / 게시글 / 댓글 삭제 권한을 모든 운영진(Manager, President, Admin)으로 확장
- 공지사항 및 게시글은 원래 모든 관리자가 삭제 가능하여서, 댓글 삭제 권한만 모든 운영진으로 확장함

### 2. 활동기수를 변경하는 API는 President 등급만 접근 가능하도록 변경
- 활동기수 변경 API에 대해 President 외 권한 접근 시 전용 에러 메시지 추가
```
{
  "status": 403,
  "message": "[활동기수] 변경은 [President]만 가능합니다.",
  "data": null
}
```

## 📎 Issue 번호
closed #387 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **변경 사항**
  * 댓글 작성자뿐 아니라 삭제 권한이 있는 운영진도 해당 게시글의 댓글을 삭제할 수 있습니다.
  * 활동 기수 변경 기능은 President 권한이 있는 운영진만 이용할 수 있도록 보안이 강화되었습니다.
  * 권한이 없는 관리자 요청에 대해 기능별 안내 메시지가 제공됩니다.

* **테스트**
  * 댓글 삭제 및 활동 기수 관련 권한 검증 시나리오가 보강되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->