### PR TITLE
[Hotfix] 온보딩 전화번호 필수 입력 제거 

### DIFF
--- a/src/main/java/com/tavemakers/surf/presentation/member/dto/request/MemberSignupReqDTO.java
+++ b/src/main/java/com/tavemakers/surf/presentation/member/dto/request/MemberSignupReqDTO.java
@@ -57,9 +57,8 @@ public class MemberSignupReqDTO implements LogPropsProvider {
     @NotBlank(message = "이메일은 필수 입력값입니다.")
     private String email;
 
-    @Schema(description = "전화번호", example = "01012345678")
-    @NotBlank(message = "전화번호는 필수 입력값입니다.")
-    @Pattern(regexp = "^[0-9]{10,11}$", message = "전화번호 형식이 올바르지 않습니다.")
+    @Schema(description = "전화번호 (선택)", example = "01012345678")
+    @Pattern(regexp = "^$|^[0-9]{10,11}$", message = "전화번호 형식이 올바르지 않습니다.")
     private String phoneNumber;
 
     @Override

--- a/src/test/java/com/tavemakers/surf/presentation/member/dto/request/MemberSignupReqDTOTest.java
+++ b/src/test/java/com/tavemakers/surf/presentation/member/dto/request/MemberSignupReqDTOTest.java
@@ -1,0 +1,59 @@
+package com.tavemakers.surf.presentation.member.dto.request;
+
+import com.tavemakers.surf.domain.member.entity.enums.Part;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MemberSignupReqDTOTest {
+
+    private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+    @Test
+    @DisplayName("전화번호가 빈 문자열이면 DTO 검증을 통과한다")
+    void validate_blankPhoneNumber_passes() {
+        MemberSignupReqDTO request = validRequest("");
+
+        Set<ConstraintViolation<MemberSignupReqDTO>> violations = validator.validate(request);
+
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    @DisplayName("전화번호가 숫자 10~11자리가 아니면 DTO 검증에 실패한다")
+    void validate_invalidPhoneNumber_fails() {
+        MemberSignupReqDTO request = validRequest("abc");
+
+        Set<ConstraintViolation<MemberSignupReqDTO>> violations = validator.validate(request);
+
+        assertThat(violations)
+                .extracting(v -> v.getPropertyPath().toString())
+                .containsExactly("phoneNumber");
+        assertThat(violations)
+                .extracting(ConstraintViolation::getMessage)
+                .containsExactly("전화번호 형식이 올바르지 않습니다.");
+    }
+
+    private MemberSignupReqDTO validRequest(String phoneNumber) {
+        MemberSignupReqDTO request = new MemberSignupReqDTO();
+        MemberSignupReqDTO.TrackInfo track = new MemberSignupReqDTO.TrackInfo();
+        track.setGeneration(15);
+        track.setPart(Part.BACKEND);
+
+        ReflectionTestUtils.setField(request, "name", "홍길동");
+        ReflectionTestUtils.setField(request, "tracks", List.of(track));
+        ReflectionTestUtils.setField(request, "university", "서울과학기술대학교");
+        ReflectionTestUtils.setField(request, "graduateSchool", "서울과학기술대학교 대학원");
+        ReflectionTestUtils.setField(request, "email", "honggildong@example.com");
+        ReflectionTestUtils.setField(request, "phoneNumber", phoneNumber);
+        return request;
+    }
+}


### PR DESCRIPTION
## 📄 작업 내용 요약
- 온보딩 회원가입 요청에서 전화번호를 필수값이 아닌 선택값으로 변경
- 전화번호가 비어 있으면 DTO validation을 통과하고, 값이 있을 때만 형식을 검증하도록 수정

## 📎 Issue 번호
closed #390 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 회원가입 시 전화번호를 선택적으로 입력할 수 있습니다.
  * 전화번호를 입력하는 경우 10~11자리 숫자 형식이 적용됩니다.

* **버그 수정**
  * 전화번호를 입력하지 않았을 때 회원가입이 실패하던 문제가 수정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->